### PR TITLE
feat: agent skills, code quality fixes, e2e tests, and blueprint gallery

### DIFF
--- a/.agents/skills/blueprint-provisioning/SKILL.md
+++ b/.agents/skills/blueprint-provisioning/SKILL.md
@@ -1,0 +1,350 @@
+---
+name: blueprint-provisioning
+description: Blueprint provisioning system expert. Use when working with blueprint JSON files, step handlers, the executor engine, resource resolution, PHP code generation for Moodle provisioning, or adding new blueprint step types. Covers the full pipeline from blueprint parsing through validation, constant substitution, resource loading, step execution, and progress reporting.
+metadata:
+  author: moodle-playground
+  version: "1.0"
+---
+
+# Blueprint Provisioning System Expert
+
+## Role
+
+You are an expert in the Moodle Playground blueprint system — a declarative, step-based
+JSON format for describing the desired state of a playground instance. You understand
+the full pipeline from blueprint parsing through execution, and you know how to write
+PHP code generators that use Moodle's APIs correctly in CLI mode.
+
+## When to activate
+
+- Adding new blueprint step types
+- Modifying existing step handlers (`src/blueprint/steps/`)
+- Working with the blueprint schema or validation (`src/blueprint/schema.js`)
+- Generating PHP code for Moodle provisioning (`src/blueprint/php/helpers.js`)
+- Debugging blueprint execution failures
+- Working with resource resolution (URL, base64, bundled, VFS, literal)
+- Modifying the blueprint executor or progress reporting
+- Writing or updating blueprint examples
+
+## Architecture overview
+
+```
+Blueprint JSON
+  → parser.js (parse JSON / base64 / data-URL / object)
+  → schema.js (validate structure, steps, resources)
+  → constants.js (substitute {{KEY}} placeholders)
+  → resources.js (resolve resource references)
+  → executor.js (run steps sequentially with progress)
+    → steps/*.js (individual step handlers)
+      → php/helpers.js (generate PHP code)
+        → php.run() (execute in WASM PHP)
+```
+
+### Key files
+
+| File | LOC | Responsibility |
+|------|-----|----------------|
+| `src/blueprint/parser.js` | 87 | Parse JSON, base64, data-URL, object inputs |
+| `src/blueprint/schema.js` | 149 | Hand-written validator (no library dependencies) |
+| `src/blueprint/constants.js` | 32 | `{{KEY}}` substitution in string values |
+| `src/blueprint/resources.js` | 155 | `ResourceRegistry` for multi-format resources |
+| `src/blueprint/resolver.js` | 127 | Blueprint source resolution (URL, inline, sessionStorage) |
+| `src/blueprint/executor.js` | 88 | Sequential step runner with error handling |
+| `src/blueprint/storage.js` | 34 | sessionStorage persistence |
+| `src/blueprint/index.js` | 57 | Public API re-exports |
+| `src/blueprint/php/helpers.js` | 397 | PHP code generation for Moodle API calls |
+| `src/blueprint/steps/` | ~1700 | 20 handler files for 30+ step types |
+
+## Blueprint JSON format
+
+### Top-level structure
+
+```json
+{
+    "$schema": "./assets/blueprints/blueprint-schema.json",
+    "landingPage": "/course/view.php?id=2",
+    "runtime": {
+        "debug": 0,
+        "debugdisplay": 0,
+        "timezone": "Europe/Madrid"
+    },
+    "constants": {
+        "COURSE_NAME": "My Course",
+        "TEACHER_EMAIL": "teacher@example.com"
+    },
+    "resources": {
+        "syllabus": {
+            "type": "url",
+            "url": "https://example.com/syllabus.pdf"
+        }
+    },
+    "steps": [
+        { "step": "installMoodle" },
+        { "step": "createUser", "username": "teacher1", "email": "{{TEACHER_EMAIL}}" },
+        { "step": "createCourse", "fullname": "{{COURSE_NAME}}", "shortname": "C1" },
+        { "step": "enrolUser", "username": "teacher1", "course": "C1", "role": "editingteacher" }
+    ]
+}
+```
+
+### Step types (30+)
+
+#### Installation and config
+| Step | Description |
+|------|-------------|
+| `installMoodle` | Declarative marker — actual install runs in bootstrap.js |
+| `setAdminAccount` | Set admin username, password, email |
+| `login` | Authenticate a user via HTTP (creates session cookie) |
+| `setConfig` | Set a single `$CFG` or admin setting |
+| `setConfigs` | Set multiple settings in one step |
+| `setLandingPage` | Override the default landing page URL |
+
+#### Users and enrollment
+| Step | Description |
+|------|-------------|
+| `createUser` | Create a single user |
+| `createUsers` | Create multiple users in one PHP execution |
+| `enrolUser` | Enrol a user in a course with a role |
+| `enrolUsers` | Bulk enrollment |
+
+#### Course structure
+| Step | Description |
+|------|-------------|
+| `createCategory` | Create a course category |
+| `createCategories` | Create multiple categories |
+| `createCourse` | Create a single course |
+| `createCourses` | Create multiple courses |
+| `createSection` | Add a section to a course |
+| `createSections` | Add multiple sections |
+
+#### Activities and modules
+| Step | Description |
+|------|-------------|
+| `addModule` | Add an activity module (label, assign, folder, forum, page, url, etc.) |
+
+Supported module types via `addModule`:
+- `label` — Text/HTML label in a section
+- `assign` — Assignment activity
+- `folder` — Folder resource (with file upload support)
+- `page` — Page resource
+- `url` — URL resource
+- `forum` — Forum activity
+- `choice` — Choice activity
+- `quiz` — Quiz activity (structure only, no questions)
+- `glossary` — Glossary activity
+- `wiki` — Wiki activity
+- `feedback` — Feedback activity
+- `lesson` — Lesson activity
+- `workshop` — Workshop activity
+- `data` — Database activity
+- `lti` — External tool (LTI)
+- `scorm` — SCORM package (requires resource)
+- `h5pactivity` — H5P activity
+
+#### Plugins and themes
+| Step | Description |
+|------|-------------|
+| `installMoodlePlugin` | Download and install a Moodle plugin from ZIP URL |
+| `installTheme` | Download and install a theme (alias with theme-specific defaults) |
+
+#### Filesystem and code execution
+| Step | Description |
+|------|-------------|
+| `mkdir` | Create a directory in MEMFS |
+| `rmdir` | Remove a directory |
+| `writeFile` | Write content to a file |
+| `writeFiles` | Write multiple files |
+| `copyFile` | Copy a file within MEMFS |
+| `moveFile` | Move/rename a file |
+| `unzip` | Extract a ZIP archive |
+| `request` | Make an HTTP request through the PHP runtime |
+| `runPhpCode` | Execute arbitrary PHP code |
+| `runPhpScript` | Execute a PHP script file |
+
+## PHP code generation (`php/helpers.js`)
+
+### Design principles
+
+1. **CLI_SCRIPT mode**: All provisioning PHP runs with `define('CLI_SCRIPT', true)`
+2. **Single-script batch**: Plural steps (e.g., `createUsers`) generate ONE PHP script
+   that processes all entities — avoids per-entity `php.run()` overhead
+3. **Moodle API calls**: Use official APIs (`user_create_user()`, `create_course()`, etc.)
+   where possible; fall back to direct `$DB->insert_record()` where WASM SQLite compat
+   requires it (see ADR-0003 for course modules)
+4. **Error reporting**: PHP scripts should `echo json_encode(['success' => true, ...])` or
+   throw/die with descriptive error messages
+5. **Escaping**: All user-provided strings are escaped with `escapePHPString()` before
+   embedding in generated PHP code
+
+### Key helper functions
+
+```javascript
+// Generate CLI header (require config.php, set up globals)
+buildCliHeader()
+
+// Escape a string for embedding in PHP single-quoted strings
+escapePHPString(str)
+
+// Generate user creation PHP code
+buildCreateUserPhp(userData)
+
+// Generate course creation PHP code
+buildCreateCoursePhp(courseData)
+
+// Generate enrollment PHP code
+buildEnrolUserPhp(enrolData)
+
+// Generate module addition PHP code (delegates to type-specific generators)
+buildAddModulePhp(moduleData)
+```
+
+### Direct DB insert pattern (ADR-0003)
+
+For course modules, Moodle's `add_moduleinfo()` API calls functions that are incompatible
+with SQLite in WASM. The blueprint system uses direct DB inserts instead:
+
+```php
+// Instead of: add_moduleinfo($moduleinfo)
+// We do:
+$module = $DB->get_record('modules', ['name' => 'label']);
+$instance = $DB->insert_record('label', ['course' => $courseid, 'name' => $name, ...]);
+$cmid = $DB->insert_record('course_modules', [
+    'course' => $courseid,
+    'module' => $module->id,
+    'instance' => $instance,
+    'section' => $sectionid,
+    // ...
+]);
+// Update section sequence
+$section = $DB->get_record('course_sections', ['id' => $sectionid]);
+$section->sequence = trim($section->sequence . ',' . $cmid, ',');
+$DB->update_record('course_sections', $section);
+// Create context
+context_module::instance($cmid);
+```
+
+## Resource system
+
+Resources are named, typed data sources that steps can reference:
+
+```json
+{
+    "resources": {
+        "my-scorm": {
+            "type": "url",
+            "url": "https://example.com/package.zip"
+        },
+        "readme": {
+            "type": "literal",
+            "contents": "# Welcome\nThis is the course readme."
+        },
+        "logo": {
+            "type": "base64",
+            "data": "iVBORw0KGgo...",
+            "mimeType": "image/png"
+        }
+    }
+}
+```
+
+Resource types:
+
+| Type | Source | Resolution |
+|------|--------|-----------|
+| `url` | HTTP URL | Fetched at execution time |
+| `base64` | Base64-encoded string | Decoded in-memory |
+| `literal` | Plain text string | Used directly |
+| `bundled` | Path relative to assets/ | Loaded from app assets |
+| `vfs` | Path in MEMFS | Read from virtual filesystem |
+
+Steps reference resources by name with `@` prefix: `"resource": "@my-scorm"`.
+
+## Plugin installation flow
+
+`installMoodlePlugin` and `installTheme` follow this pipeline:
+
+1. **Parse URL**: Extract plugin type and name from GitHub URL or explicit fields
+2. **Auto-detect** (ADR-0002): If type/name not specified, infer from GitHub repo URL
+   and `version.php` contents
+3. **Download ZIP**: Fetch from URL (GitHub releases via jsDelivr CDN for CORS)
+4. **Extract**: Unzip into the correct Moodle plugin directory
+5. **Register**: Update `alternative_component_cache` so Moodle discovers the plugin
+6. **Upgrade**: Run `upgrade_noncore()` to trigger the plugin's install/upgrade scripts
+
+### GitHub URL auto-detection
+
+```
+https://github.com/owner/moodle-mod_customcert
+  → type: mod, name: customcert
+
+https://github.com/owner/moodle-block_xp
+  → type: block, name: xp
+
+https://github.com/owner/moodle-theme_moove
+  → type: theme, name: moove
+```
+
+Pattern: `moodle-{type}_{name}` in the repo name. Falls back to reading `version.php`
+from the extracted ZIP.
+
+## Executor behavior
+
+### Step execution
+
+Steps run **sequentially** in array order. Each step:
+1. Receives the step config object and execution context
+2. Performs its operation (usually via `php.run()`)
+3. Returns success/failure
+4. Reports progress to the main thread
+
+### Error handling (ADR-0005)
+
+By default, step failures are **non-fatal** — the executor logs the error and continues
+with the next step. This prevents a single bad step from breaking the entire blueprint.
+
+Steps can be marked as critical:
+```json
+{ "step": "installMoodle", "critical": true }
+```
+
+Critical step failure halts execution.
+
+### Constant substitution
+
+`{{KEY}}` patterns in string values are replaced with values from the `constants` object.
+Substitution is recursive (works in nested objects and arrays) but not in keys.
+
+```json
+{
+    "constants": { "SITE": "My School" },
+    "steps": [
+        { "step": "setConfig", "name": "fullname", "value": "{{SITE}} Moodle" }
+    ]
+}
+```
+
+## Testing
+
+Blueprint tests live in `tests/blueprint/` and cover:
+- Parsing (JSON, base64, data-URL, raw objects)
+- Schema validation (required fields, step types, resource types)
+- Constant substitution (strings, nested objects, arrays)
+- Resource resolution (all 5 types)
+- Executor behavior (ordering, failures, progress, critical steps)
+- PHP code generation (escaping, CLI header, all Moodle API generators)
+- Plugin installation (URL parsing, auto-detection, ZIP extraction)
+
+Run with: `npm run test:blueprint`
+
+## Checklist for blueprint changes
+
+- [ ] Is the new step type registered in `src/blueprint/steps/index.js`?
+- [ ] Is the step documented in `docs/blueprint-json.md`?
+- [ ] Is the step added to `assets/blueprints/blueprint-schema.json`?
+- [ ] Does the PHP code use `CLI_SCRIPT` mode?
+- [ ] Are all user strings escaped with `escapePHPString()`?
+- [ ] Does the step work with SQLite (no MySQL-only syntax)?
+- [ ] Are there unit tests in `tests/blueprint/`?
+- [ ] Does batch mode generate a single PHP script, not per-entity calls?
+- [ ] Is error handling graceful (non-fatal by default)?
+- [ ] Does the step report meaningful progress messages?

--- a/.agents/skills/e2e-playwright/SKILL.md
+++ b/.agents/skills/e2e-playwright/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: e2e-playwright
+description: End-to-end testing expert with Playwright. Use when writing, debugging, or reviewing browser-based tests that verify the full Moodle Playground flow — shell boot, Moodle runtime loading, blueprint execution, iframe navigation, service worker routing, and UI interactions. Covers Playwright API, iframe handling, waiting strategies for WASM boot, and test patterns specific to this project.
+metadata:
+  author: moodle-playground
+  version: "1.0"
+---
+
+# E2E Testing Expert (Playwright)
+
+## Role
+
+You are an expert in end-to-end browser testing with Playwright, specifically
+for this project's unique architecture: a shell page hosting an iframe that
+loads a service worker, which boots a PHP WASM runtime running Moodle. You
+understand the timing complexities of waiting for WASM boot, how to interact
+with content inside nested iframes, and how to write reliable tests for a
+runtime that takes 10-30 seconds to fully initialize.
+
+## When to activate
+
+- Writing or debugging Playwright e2e tests in `tests/e2e/`
+- Testing full user flows (boot → navigate → interact)
+- Verifying blueprint execution results in the browser
+- Testing service worker routing and HTML rewriting
+- Debugging test flakiness related to WASM boot timing
+- Adding e2e coverage for new features
+
+## Infrastructure
+
+### Configuration
+
+**File:** `playwright.config.mjs`
+
+```javascript
+{
+  testDir: "./tests/e2e",
+  timeout: 180_000,       // 3 minutes per test (WASM boot is slow)
+  expect: { timeout: 30_000 },
+  webServer: {
+    command: "PORT=8085 make serve",  // or "make up" if no bundle exists
+    url: "http://127.0.0.1:8085",
+    timeout: 300_000,     // 5 minutes for server start (includes bundling)
+  },
+}
+```
+
+### Run commands
+
+```bash
+make test-e2e                        # Run all e2e tests
+npm run test:e2e                     # Same via npm
+npx playwright test --headed         # Watch mode with browser visible
+npx playwright test shell.spec.mjs   # Run specific spec file
+npx playwright show-report           # View HTML report after run
+
+# First time setup
+npm run test:e2e:install             # Install Chromium browser
+```
+
+### Environment variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `PLAYWRIGHT_BASE_URL` | `http://127.0.0.1:8085` | Override the dev server URL |
+| `PLAYWRIGHT_EXTERNAL_SERVER` | `0` | Set to `1` to skip auto-starting the server |
+| `CI` | unset | Set in CI to use `line` reporter |
+
+### Test file conventions
+
+| File | What it covers |
+|------|---------------|
+| `shell.spec.mjs` | Shell UI: toolbar, panels, tabs, settings, blueprint loading |
+| `moodle-boot.spec.mjs` | Moodle runtime: boot lifecycle, PHP info capture |
+| `blueprint-courses.spec.mjs` | Blueprint execution: courses, users, modules, enrollment |
+
+File naming: `{feature}.spec.mjs`
+
+## Architecture awareness
+
+### The boot timeline
+
+```
+t=0s    page.goto("/")
+t=0.1s  Shell UI renders (toolbar, panels, iframe placeholder)
+t=0.5s  Service worker registers
+t=1s    PHP worker starts
+t=2-5s  ZIP bundle downloads and extracts
+t=5-15s Moodle install snapshot loads
+t=15-20s Blueprint steps execute
+t=20-30s Landing page renders in iframe
+```
+
+**Key insight**: Most of the wait time is WASM boot, not DOM rendering. Tests
+must use long timeouts (120s+) for the initial boot but can use normal timeouts
+(5-30s) for subsequent interactions.
+
+### DOM structure
+
+```
+index.html (shell)
+├── #address-input          — URL bar
+├── #site-frame            — iframe hosting Moodle
+├── #panel-toggle-button   — Open/close side panel
+├── #side-panel            — Side panel container
+│   ├── #info-tab / #info-panel     — Version info
+│   ├── #logs-tab / #log-panel      — Runtime logs
+│   ├── #phpinfo-tab / #phpinfo-frame — PHP info
+│   └── #blueprint-tab / #blueprint-textarea — Blueprint JSON
+├── #settings-button       — Open settings
+├── #settings-popover      — Settings dialog
+│   ├── #settings-moodle-version   — Moodle version select
+│   └── #settings-php-version      — PHP version select
+└── #reset-button          — Reset playground
+```
+
+### The iframe challenge
+
+Moodle runs inside `#site-frame`, which loads `remote.html`, which creates
+another nested iframe for the scoped runtime. Content inside Moodle is
+**two iframes deep** from the test's page context.
+
+Accessing Moodle content:
+
+```javascript
+// Get the first-level iframe (remote.html)
+const remoteFrame = page.frame({ url: /playground\// })
+  || await page.locator("#site-frame").contentFrame();
+
+// Moodle content is inside remoteFrame or a nested iframe within it
+```
+
+**Warning**: Cross-origin restrictions may prevent direct frame access in some
+configurations. For most tests, verify behavior through the shell UI (address
+bar, logs, blueprint tab) rather than inspecting iframe content directly.
+
+## Waiting strategies
+
+### Wait for runtime ready
+
+The most critical wait — the runtime has fully booted and Moodle is usable:
+
+```javascript
+async function waitForRuntimeReady(page) {
+  // Address bar is enabled = UI is unlocked = boot complete
+  await expect(page.locator("#address-input")).toBeEnabled({ timeout: 120_000 });
+  // Frame has a src = runtime is mounted
+  await expect(page.locator("#site-frame")).toHaveAttribute(
+    "src", /scope=|playground\//
+  );
+}
+```
+
+### Wait for specific log entry
+
+```javascript
+async function waitForLogEntry(page, pattern, timeout = 30_000) {
+  await page.locator("#panel-toggle-button").click();
+  await page.locator("#logs-tab").click();
+  await expect(page.locator("#log-panel")).toContainText(pattern, { timeout });
+}
+```
+
+### Wait for address bar change
+
+```javascript
+async function waitForNavigation(page, pathPattern) {
+  await expect(page.locator("#address-input")).toHaveValue(pathPattern, {
+    timeout: 30_000,
+  });
+}
+```
+
+## Blueprint test pattern
+
+The standard pattern for testing blueprint execution:
+
+```javascript
+function buildBlueprintParam(payload) {
+  return Buffer.from(JSON.stringify(payload)).toString("base64url");
+}
+
+test("blueprint does X", async ({ page }) => {
+  const bp = buildBlueprintParam({
+    landingPage: "/course/view.php?id=2",
+    steps: [
+      { step: "installMoodle", options: { siteName: "Test" } },
+      { step: "login", username: "admin" },
+      // ... your steps ...
+      { step: "setLandingPage", path: "/course/view.php?id=2" },
+    ],
+  });
+
+  await page.goto(`/?blueprint=${bp}`);
+  await waitForRuntimeReady(page);
+
+  // Verify through shell UI, not iframe content
+  const address = await page.locator("#address-input").inputValue();
+  expect(address).toContain("/course/view.php");
+});
+```
+
+## Anti-patterns
+
+### Don't wait with fixed timeouts
+
+```javascript
+// BAD — fragile, slow on CI
+await page.waitForTimeout(30_000);
+
+// GOOD — condition-based, fast when possible
+await expect(page.locator("#address-input")).toBeEnabled({ timeout: 120_000 });
+```
+
+### Don't access Moodle content directly
+
+```javascript
+// BAD — two iframe levels, cross-origin issues
+const moodleBody = await page.frameLocator("#site-frame")
+  .frameLocator("iframe").locator("body").textContent();
+
+// GOOD — verify through shell UI
+await expect(page.locator("#address-input")).toHaveValue(/\/course\/view\.php/);
+```
+
+### Don't assume boot order
+
+```javascript
+// BAD — may not exist yet during boot
+await page.locator("#reset-button").click();
+
+// GOOD — ensure boot is complete first
+await waitForRuntimeReady(page);
+await page.locator("#panel-toggle-button").click();
+await page.locator("#reset-button").click();
+```
+
+### Don't run tests in parallel
+
+Tests share the browser and the dev server. The Moodle runtime is
+single-threaded. Use `fullyParallel: false` in the config.
+
+## Debugging tips
+
+1. **Run headed**: `npx playwright test --headed` to watch the browser
+2. **Trace viewer**: `npx playwright show-trace trace.zip` after failure
+3. **Slow motion**: Add `use: { launchOptions: { slowMo: 500 } }` to config
+4. **Screenshots**: `await page.screenshot({ path: "debug.png" })` mid-test
+5. **Check logs**: Open the Logs tab in the side panel — bootstrap errors show there
+6. **Console**: `page.on("console", msg => console.log(msg.text()))` to capture browser console
+
+## Checklist for e2e test changes
+
+- [ ] Does the test wait for `waitForRuntimeReady()` before interacting?
+- [ ] Are timeouts appropriate? (120s+ for boot, 30s for interactions)
+- [ ] Does the test verify through shell UI, not deep iframe content?
+- [ ] Is `fullyParallel: false` maintained in the config?
+- [ ] Does `make test-e2e` pass locally?
+- [ ] Is the blueprint minimal? (fewer steps = faster boot)
+- [ ] Does the test clean up any state it creates? (usually not needed — ephemeral runtime)

--- a/.agents/skills/moodle-internals/SKILL.md
+++ b/.agents/skills/moodle-internals/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: moodle-internals
+description: Moodle LMS domain expert. Use when working with Moodle APIs, plugin system, database schema, install/upgrade lifecycle, config settings, course structure, user management, enrollment, caching (MUC), or any PHP code that interacts with Moodle core. Covers Moodle 4.4 through 5.1+ branch conventions.
+metadata:
+  author: moodle-playground
+  version: "1.0"
+---
+
+# Moodle Internals Expert
+
+## Role
+
+You are a senior Moodle core developer with deep knowledge of Moodle's internal
+architecture, API conventions, database schema, plugin system, and install/upgrade
+lifecycle. You understand how Moodle works from `lib/setup.php` through to the
+admin tree, and you know where Moodle's assumptions break in non-standard
+environments (like WebAssembly with SQLite).
+
+## When to activate
+
+- Writing or reviewing PHP code that calls Moodle APIs (`$DB`, `$CFG`, `$PAGE`, etc.)
+- Generating PHP snippets for blueprint steps (user creation, course setup, enrollment)
+- Debugging Moodle-specific errors (redirect loops, missing capabilities, upgrade failures)
+- Working with the plugin type system (mod, block, theme, local, format, etc.)
+- Modifying install/upgrade flow or post-install defaults
+- Touching `config.php` generation or `$CFG` settings
+- Working with Moodle's caching framework (MUC)
+
+## Moodle API Conventions
+
+### Database layer (`$DB`)
+
+- All tables prefixed with `$CFG->prefix` (default `mdl_`)
+- Use DML functions: `$DB->insert_record()`, `$DB->get_record()`, `$DB->execute()`
+- DDL via `$DB->get_manager()` — but in this project we use direct SQL for WASM compat
+- SQLite has no `RANDOM()` — use `ABS(RANDOM())` or avoid; no `CONCAT()` — use `||`
+- No `AUTO_INCREMENT` keyword — SQLite uses `INTEGER PRIMARY KEY AUTOINCREMENT`
+- Moodle's deprecated SQLite PDO driver (`sqlite3_pdo_moodle_database.php`) is patched
+  in `patches/shared/lib/dml/`
+
+### Plugin system
+
+Moodle plugin types and their directory conventions:
+
+| Type prefix | Directory | Example |
+|-------------|-----------|---------|
+| `mod_` | `mod/{name}` | `mod/assign` |
+| `block_` | `blocks/{name}` | `blocks/html` |
+| `theme_` | `theme/{name}` | `theme/boost` |
+| `local_` | `local/{name}` | `local/myplugin` |
+| `format_` | `course/format/{name}` | `course/format/topics` |
+| `enrol_` | `enrol/{name}` | `enrol/manual` |
+| `auth_` | `auth/{name}` | `auth/manual` |
+| `report_` | `report/{name}` | `report/log` |
+| `tool_` | `admin/tool/{name}` | `admin/tool/uploaduser` |
+| `qtype_` | `question/type/{name}` | `question/type/multichoice` |
+| `atto_` | `lib/editor/atto/plugins/{name}` | `lib/editor/atto/plugins/bold` |
+| `tiny_` | `lib/editor/tiny/plugins/{name}` | `lib/editor/tiny/plugins/media` |
+| `availability_` | `availability/condition/{name}` | `availability/condition/date` |
+| `filter_` | `filter/{name}` | `filter/tex` |
+
+Every plugin requires `version.php` with `$plugin->component`, `$plugin->version`,
+and `$plugin->requires`. The component name must match the directory path.
+
+### Install and upgrade lifecycle
+
+1. `admin/index.php` checks `moodle_needs_upgrading()` (compares DB version to disk)
+2. Core upgrade: `lib/db/upgrade.php` functions run sequentially
+3. Plugin upgrade: `upgrade_noncore()` iterates all plugin types
+4. Component cache: `core_component::get_component_list()` discovers plugins from disk
+5. `alternative_component_cache` file can override discovery (used in crash recovery)
+6. After install, `any_new_admin_settings()` checks for unset admin settings — if any
+   exist, Moodle redirects to `admin/upgradesettings.php` (causes redirect loops in WASM)
+
+### Config settings
+
+- `$CFG` properties set in `config.php` are immutable at runtime
+- Admin settings stored in `mdl_config` table (key-value pairs)
+- Plugin settings stored in `mdl_config_plugins` table
+- `set_config($name, $value)` for core, `set_config($name, $value, $plugin)` for plugins
+- Some settings have dynamic defaults computed from `$CFG->wwwroot` — these must be
+  seeded explicitly in the install snapshot to prevent `any_new_admin_settings()` loops
+
+### Caching (MUC)
+
+- Moodle Universal Cache has stores, definitions, and mappings
+- Default store: `cachestore_file` (writes to `$CFG->dataroot/cache/`)
+- `CACHE_DISABLE_ALL` must be `false` — disabling MUC breaks admin pages
+- Cache store plugin defaults must be seeded in the install snapshot
+- `cache/classes/config.php` is patched at runtime to ensure cache config exists
+
+### Course and module structure
+
+- Courses live in `mdl_course`, sections in `mdl_course_sections`
+- Course modules registered in `mdl_course_modules` + `mdl_course_modules_completion`
+- Each activity type has its own table (e.g., `mdl_assign`, `mdl_label`, `mdl_folder`)
+- `mdl_course_modules.instance` links to the activity-specific table
+- Section sequence (`mdl_course_sections.sequence`) is a comma-separated list of
+  `course_modules.id` values — must be updated when adding modules
+
+### User and enrollment
+
+- Users in `mdl_user`, roles in `mdl_role`, assignments in `mdl_role_assignments`
+- Enrollment plugins in `mdl_enrol`, user enrollments in `mdl_user_enrolments`
+- Context system: `mdl_context` with contextlevels (SYSTEM=10, COURSE=50, MODULE=70)
+- `enrol_get_plugin('manual')` → `$plugin->enrol_user($instance, $userid, $roleid)`
+- Role IDs: manager=1, coursecreator=2, editingteacher=3, teacher=4, student=5
+
+## Branch conventions
+
+| Branch | Moodle version | Webroot | PHP requirement |
+|--------|---------------|---------|-----------------|
+| `MOODLE_404_STABLE` | 4.4 | `/` (legacy) | PHP 8.1+ |
+| `MOODLE_405_STABLE` | 4.5 | `/` (legacy) | PHP 8.1+ |
+| `MOODLE_500_STABLE` | 5.0 | `/` (legacy) | PHP 8.2+ |
+| `MOODLE_501_STABLE` | 5.1 | `/public/` | PHP 8.2+ |
+| `main` | dev | `/public/` | PHP 8.3+ |
+
+The `public/` webroot convention means `lib/` becomes `public/lib/` in the source tree.
+Patches must account for this — `patches/shared/` uses bare `lib/` paths and the build
+script adds the `public/` prefix automatically for 5.1+ branches.
+
+## SQLite-specific gotchas in Moodle
+
+- No `FOR UPDATE` — remove or ignore locking hints
+- No `REPLACE()` in some contexts — use PHP-side string manipulation
+- `GROUP_CONCAT` works but `LISTAGG` does not
+- Boolean columns store 0/1 as integers
+- `CAST(x AS SIGNED)` fails — use `CAST(x AS INTEGER)`
+- Transactions are serialized (single-writer) — fine for single-user WASM
+- `LIKE` is case-insensitive by default in SQLite (unlike MySQL/PostgreSQL)
+
+## Checklist for Moodle-touching changes
+
+- [ ] Does the SQL work on SQLite? (no MySQL-only syntax)
+- [ ] Are plugin component names consistent with directory paths?
+- [ ] Will `any_new_admin_settings()` trigger a redirect? (seed defaults if so)
+- [ ] Does the change work across all supported branches (4.4–5.1+)?
+- [ ] Is the `mdl_` prefix used consistently?
+- [ ] Are context levels correct for role assignments?
+- [ ] Does `$CFG->wwwroot` stay based on the real app URL, not the scoped path?

--- a/.agents/skills/unit-testing/SKILL.md
+++ b/.agents/skills/unit-testing/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: unit-testing
+description: Unit testing expert for Node.js built-in test runner (node:test). Use when writing, debugging, or reviewing unit tests, designing test strategies for blueprint steps, PHP code generators, service worker helpers, or runtime utilities. Covers mocking patterns for php.run() and MEMFS, assertion strategies, and test organization conventions.
+metadata:
+  author: moodle-playground
+  version: "1.0"
+---
+
+# Unit Testing Expert
+
+## Role
+
+You are an expert in writing and maintaining unit tests for this project using
+Node.js built-in `node:test` and `node:assert/strict`. You know how to test
+code that generates PHP strings, mock the PHP WASM runtime for step handlers,
+and structure tests for maximum coverage with minimal coupling.
+
+## When to activate
+
+- Writing or reviewing unit tests in `tests/`
+- Adding a new blueprint step and need to test it
+- Testing PHP code generation output (helpers.js)
+- Testing service worker helpers or runtime utilities
+- Debugging flaky or failing tests
+- Improving test coverage
+
+## Test infrastructure
+
+### Runner and assertions
+
+```javascript
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+```
+
+No external framework — only Node.js builtins. No Jest, Mocha, Vitest, etc.
+
+### Run commands
+
+```bash
+make test                           # All 286+ tests
+npm run test:blueprint              # Blueprint tests only
+node --test tests/blueprint/*.test.js  # Specific suite
+node --test --test-name-pattern="escaping" tests/blueprint/php-helpers.test.js  # Pattern filter
+```
+
+### Test file conventions
+
+| Pattern | Location |
+|---------|----------|
+| Blueprint tests | `tests/blueprint/*.test.js` |
+| Runtime tests | `tests/runtime/*.test.js` |
+| Shared tests | `tests/shared/*.test.js` |
+| Service worker tests | `tests/sw/*.test.js` |
+| E2E tests | `tests/e2e/*.spec.mjs` (Playwright, separate runner) |
+
+File naming: `{module-name}.test.js` mirroring the source file name.
+
+### Test structure
+
+```javascript
+describe("functionOrModuleName", () => {
+  it("does X when given Y", () => {
+    const result = functionUnderTest(input);
+    assert.strictEqual(result, expected);
+  });
+
+  it("throws on invalid input", () => {
+    assert.throws(() => functionUnderTest(null), /expected error message/);
+  });
+});
+```
+
+## Mocking patterns
+
+### Mocking php.run() for step handlers
+
+Step handlers receive a `{ php, publish, resources, webRoot }` context.
+Create a minimal mock:
+
+```javascript
+function createMockPhp(responses = {}) {
+  const calls = [];
+  return {
+    calls,
+    run: async (code) => {
+      calls.push(code);
+      return {
+        text: responses.text || '{"ok":true}',
+        errors: responses.errors || "",
+        exitCode: responses.exitCode || 0,
+      };
+    },
+    writeFile: async (path, data) => {
+      calls.push({ writeFile: path, size: data.length });
+    },
+    request: async (req) => {
+      calls.push({ request: req.url });
+      return new Response(responses.text || '{"ok":true}', {
+        status: responses.status || 200,
+      });
+    },
+  };
+}
+```
+
+### Mocking ResourceRegistry
+
+```javascript
+const mockResources = {
+  resolve: async (ref) => new TextEncoder().encode("mock data"),
+  resolveText: async (ref) => "mock data",
+};
+```
+
+### Testing PHP code generation
+
+For `src/blueprint/php/helpers.js` functions, test the **generated PHP string**
+content — not execution. Verify:
+
+```javascript
+it("escapes single quotes in user values", () => {
+  const code = phpCreateUser({ username: "it's" });
+  assert.ok(code.includes("it\\'s"), "single quote should be escaped");
+});
+
+it("uses CLI_SCRIPT mode", () => {
+  const code = phpSetConfig("key", "value");
+  assert.ok(code.includes("define('CLI_SCRIPT', true)"));
+});
+
+it("uses absolute config.php path", () => {
+  const code = phpCreateCourse({ fullname: "Test", shortname: "T1" });
+  assert.ok(code.includes("require('/www/moodle/config.php')"));
+});
+```
+
+### Testing checkPhpResult
+
+The shared `checkPhpResult` in `src/blueprint/steps/check-result.js`:
+
+```javascript
+it("throws on PHP failure response", () => {
+  assert.throws(
+    () => checkPhpResult({ text: '{"ok":false,"error":"boom"}' }, "test"),
+    /test: PHP returned failure/,
+  );
+});
+
+it("passes on success response", () => {
+  assert.doesNotThrow(() =>
+    checkPhpResult({ text: '{"ok":true}' }, "test"),
+  );
+});
+```
+
+## Testing service worker helpers
+
+SW helpers are pure functions extracted for testability:
+
+```javascript
+// tests/sw/sw-helpers.test.js
+import { decodeHtmlAttributeEntities, extractScopedRuntime } from "../../sw.js";
+
+it("decodes &amp;", () => {
+  assert.strictEqual(decodeHtmlAttributeEntities("a&amp;b"), "a&b");
+});
+```
+
+Import the functions directly — no browser environment needed for pure helpers.
+
+## Testing runtime utilities
+
+For `crash-recovery.js`, `config-template.js`, `version-resolver.js`:
+
+```javascript
+// Test error classification
+it("detects WebAssembly.RuntimeError instances", () => {
+  const error = new WebAssembly.RuntimeError("test");
+  assert.strictEqual(isFatalWasmError(error), true);
+});
+
+// Test config generation
+it("sets correct wwwroot", () => {
+  const config = createMoodleConfigPhp({ wwwroot: "http://localhost:8080" });
+  assert.ok(config.includes("$CFG->wwwroot = 'http://localhost:8080'"));
+});
+```
+
+## What to test and what not to test
+
+### Always test
+
+- PHP code generation output (string content, escaping, SQL safety)
+- Pure utility functions (path helpers, entity decoding, version resolution)
+- Schema validation (valid/invalid blueprint inputs)
+- Error classification (isFatalWasmError, checkPhpResult)
+- Step handler input validation (required fields, type checks)
+
+### Don't test in unit tests
+
+- Actual PHP execution (that's what e2e tests are for)
+- Service worker fetch interception (requires browser environment)
+- WASM binary loading (requires @php-wasm runtime)
+- DOM manipulation (shell/main.js — use e2e tests)
+
+## Checklist for test changes
+
+- [ ] Does the test use `node:test` and `node:assert/strict`?
+- [ ] Is the test file named `{module}.test.js` in the correct directory?
+- [ ] Does `make test` still pass with all tests?
+- [ ] Are mocks minimal — only mock what's necessary?
+- [ ] Does the test verify behavior, not implementation?
+- [ ] Are edge cases covered (null, empty, special characters)?
+- [ ] Does `make lint` pass? (Biome checks test files too)

--- a/.agents/skills/wasm-browser-runtime/SKILL.md
+++ b/.agents/skills/wasm-browser-runtime/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: wasm-browser-runtime
+description: WebAssembly and browser runtime expert. Use when debugging WASM crashes (OOM, unreachable traps, memory access out of bounds), optimizing Emscripten MEMFS performance, working with service worker request routing, understanding browser memory constraints, handling Web Worker communication, or investigating issues at the WASM/JS boundary. Also covers crash recovery, resource exhaustion detection, and runtime restart strategies.
+metadata:
+  author: moodle-playground
+  version: "1.0"
+---
+
+# WebAssembly & Browser Runtime Expert
+
+## Role
+
+You are an expert in WebAssembly runtime behavior in browsers, Emscripten's virtual
+filesystem (MEMFS), Web Worker architecture, Service Worker request interception, and
+the constraints of running server-side software (PHP/Moodle) inside a browser sandbox.
+You understand failure modes that are unique to this environment — WASM memory limits,
+file descriptor exhaustion, single-threaded execution, and the ephemeral nature of
+in-memory state.
+
+## When to activate
+
+- Investigating WASM runtime crashes (`RuntimeError: unreachable`, `memory access out of bounds`)
+- Working on crash recovery logic (`src/runtime/crash-recovery.js`)
+- Optimizing memory usage or startup performance
+- Working with the service worker (`sw.js`) — request routing, caching, HTML rewriting
+- Debugging Web Worker communication (`php-worker.js` ↔ main thread)
+- Understanding browser-imposed limits (memory, file descriptors, storage quotas)
+- Working with Emscripten MEMFS filesystem behavior
+- Investigating subpath deployment issues on GitHub Pages
+
+## WebAssembly runtime constraints
+
+### Memory model
+
+- WASM linear memory starts at ~256 MB and can grow up to ~2-4 GB (browser-dependent)
+- Memory can only **grow**, never shrink — once allocated, it's committed for the session
+- OOM manifests as `RuntimeError: memory access out of bounds` or `unreachable`
+- No garbage collection of WASM memory — PHP's internal allocator reuses within the
+  linear memory, but freed memory is not returned to the browser
+- Total memory pressure = WASM linear memory + JS heap (MEMFS file contents) + DOM
+
+### File descriptors
+
+- Emscripten provides a virtual file descriptor table (~1024 entries by default)
+- PHP opens file descriptors for: SQLite DB, session files, temp files, log files
+- Each `php.run()` should close all handles, but some may leak
+- Exhaustion manifests as `RuntimeError: unreachable` with no clear error message
+- Our crash recovery detects this pattern after `MIN_REQUESTS_BEFORE_RESTART` (10)
+
+### Single-threaded execution
+
+- The PHP Web Worker runs on a single thread
+- Each HTTP request is processed sequentially — no concurrency
+- Long-running requests block all other requests
+- The service worker queues requests and sends them one at a time
+- `max_execution_time` should be 0 (unlimited) to prevent timeouts on slow operations
+
+### Browser storage limits
+
+- **MEMFS**: Limited only by available JS heap (~1-4 GB depending on browser/device)
+- **OPFS**: Not used in this project (ephemeral design)
+- **IndexedDB**: Not used in this project
+- **Cache API**: Used by service worker for static asset caching
+- **sessionStorage**: Used for blueprint persistence (5-10 MB limit)
+
+## Emscripten MEMFS deep dive
+
+### How it works
+
+MEMFS stores file contents as JavaScript `Uint8Array` objects on the JS heap (NOT in
+WASM linear memory). The directory tree is a JavaScript object graph.
+
+```
+JS Heap:
+  ├── MEMFS directory tree (JS objects)
+  │   ├── /www/moodle/... (file nodes → Uint8Array contents)
+  │   ├── /persist/moodledata/... (file nodes → Uint8Array contents)
+  │   └── /tmp/... (file nodes → Uint8Array contents)
+  │
+  └── WASM linear memory (ArrayBuffer)
+      └── PHP runtime (stack, heap, globals)
+```
+
+When PHP reads a file, Emscripten copies data from the JS `Uint8Array` into WASM linear
+memory. When PHP writes, data flows the other direction. This means:
+
+- File I/O involves copying between JS heap and WASM memory
+- Large files temporarily consume memory in BOTH locations during I/O
+- The Moodle ZIP extraction (~100-200 MB) is a peak memory moment
+
+### MEMFS operations characteristics
+
+| Operation | Speed | Notes |
+|-----------|-------|-------|
+| Read small file | ~microseconds | Direct JS object access |
+| Read large file | ~milliseconds | Copy to WASM memory |
+| Write file | ~microseconds | JS Uint8Array allocation |
+| Create directory | ~microseconds | JS object creation |
+| List directory | ~microseconds | JS object traversal |
+| Delete file | ~microseconds | JS garbage collection handles cleanup |
+| Check existence | ~microseconds | `FS.analyzePath()` |
+
+### Surviving MEMFS after WASM crash
+
+**Key insight**: When WASM crashes (linear memory corrupted), MEMFS data is still
+accessible because it lives in the JS heap, not in WASM memory. This is why crash
+recovery works — we can snapshot the SQLite database file and plugin directories from
+the dying runtime before creating a fresh one.
+
+## Service Worker architecture
+
+### Request flow
+
+```
+Browser tab
+  → Service Worker (sw.js)
+    → Classify request:
+       ├── Static asset? → Cache API or network fetch
+       ├── Scoped runtime request? → Forward to PHP Worker
+       └── Other? → Network fetch
+
+PHP Worker (php-worker.js)
+  → php.run({ scriptPath, method, headers, url, body })
+    → PHP executes in WASM
+    → Response returned to Service Worker
+  → Service Worker rewrites HTML responses (links, forms, redirects)
+    → Final Response returned to browser tab
+```
+
+### Scoped runtime paths
+
+Requests are scoped under `/playground/<scope>/<runtime>/`:
+- `scope` — identifies the playground instance (default: `main`)
+- `runtime` — identifies the PHP version (e.g., `php83-cgi`)
+- The remaining path maps to the Moodle file structure
+
+Example: `/moodle-playground/playground/main/php83-cgi/admin/index.php`
+- Base path: `/moodle-playground`
+- Scope: `main`
+- Runtime: `php83-cgi`
+- Moodle path: `/admin/index.php`
+
+### HTML rewriting
+
+The service worker rewrites HTML responses to ensure Moodle-generated links stay within
+the scoped runtime path. This includes:
+- `href` and `src` attributes
+- `action` attributes on forms
+- `Location` headers on redirects
+- HTML-escaped entities (`&amp;`, `&#x2F;`, `&colon;`)
+
+### Static asset caching (ADR-0001)
+
+Scoped static assets (CSS, JS, images) are cached in the Cache API:
+- Cache key includes scope and runtime for isolation
+- Assets are served from cache on subsequent requests
+- Cache is invalidated on service worker update
+
+## Crash recovery system
+
+### Detection (`src/runtime/crash-recovery.js`)
+
+Fatal WASM errors are detected by pattern matching on error messages:
+
+```javascript
+function isFatalWasmError(error) {
+    // Patterns: 'unreachable', 'memory access out of bounds',
+    // 'table index is out of bounds', 'null function or function signature mismatch'
+}
+```
+
+### Recovery flow
+
+1. **Detect**: `isFatalWasmError()` returns true
+2. **Snapshot**: `createSnapshotManager()` saves DB file, plugin dirs, filedir from MEMFS
+3. **Destroy**: Old PHP instance is discarded
+4. **Create**: Fresh PHP instance via `loadWebRuntime()`
+5. **Bootstrap**: Full Moodle bootstrap (ZIP extraction → snapshot → config)
+6. **Restore**: Overwrite fresh DB with crash snapshot, copy plugin files back
+7. **Re-register**: Update `alternative_component_cache`, run `upgrade_noncore()`
+8. **Session**: Create new admin session (old one invalidated by DB restore)
+9. **Replay**: Re-execute original request if idempotent (GET/HEAD only)
+
+### Anti-loop guards
+
+- `MAX_REACTIVE_RESTARTS = 20` — maximum restarts per session
+- `MIN_REQUESTS_BEFORE_RESTART = 10` — don't restart if barely started
+- POST/PUT/DELETE requests are never replayed after recovery
+
+## Web Worker communication
+
+### Message protocol
+
+`php-worker.js` communicates with the main thread via `postMessage`:
+
+```javascript
+// Main thread → Worker
+{ type: 'request', id: 123, request: { method, url, headers, body } }
+{ type: 'boot', config: { scope, runtime, blueprint, ... } }
+
+// Worker → Main thread
+{ type: 'response', id: 123, response: { status, headers, body } }
+{ type: 'progress', phase: 'bootstrap', progress: 0.5, message: '...' }
+{ type: 'error', id: 123, error: { message, stack } }
+```
+
+### Progress reporting
+
+Bootstrap reports progress through phases:
+- 0.0–0.1: Runtime initialization
+- 0.1–0.3: ZIP bundle download and extraction
+- 0.3–0.5: Install snapshot loading or CLI install
+- 0.5–0.9: Config normalization and blueprint steps
+- 0.9–1.0: Final setup and auto-login
+
+## Performance optimization strategies
+
+### Startup time
+
+1. **Pre-built install snapshot**: Skip 3-8s CLI install by loading `install.sq3`
+2. **ZIP bundle caching**: Cache API stores the Moodle bundle between page loads
+3. **Lazy extraction**: Only extract files needed for initial boot (not implemented yet)
+4. **OPcache warming**: PHP OPcache compiles scripts on first access, subsequent requests faster
+
+### Runtime performance
+
+1. **MUC enabled**: Moodle caching framework reduces DB queries after first page load
+2. **SQLite pragmas**: `journal_mode=MEMORY`, `synchronous=OFF`, `cache_size=-8000`
+3. **Session files in MEMFS**: No I/O latency for session reads/writes
+4. **Service worker caching**: Static assets served from Cache API, not re-processed by PHP
+
+### Memory management
+
+1. **Avoid large file operations**: SCORM packages, backups can exhaust memory
+2. **Monitor JS heap**: MEMFS file contents + WASM memory should stay under ~2 GB
+3. **Restart as recovery**: When memory is exhausted, the only option is a fresh runtime
+
+## Checklist for runtime-touching changes
+
+- [ ] Could this increase peak memory usage during bootstrap?
+- [ ] Does this handle WASM crash scenarios gracefully?
+- [ ] Are service worker cache keys properly scoped?
+- [ ] Does HTML rewriting preserve query strings and fragments?
+- [ ] Is the base path correctly propagated through all layers?
+- [ ] Does this work on GitHub Pages subpath deployment?
+- [ ] Are Web Worker messages properly serialized (no non-transferable objects)?
+- [ ] Is the anti-loop guard still effective after this change?

--- a/.agents/skills/wp-playground-php-wasm/SKILL.md
+++ b/.agents/skills/wp-playground-php-wasm/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: wp-playground-php-wasm
+description: WordPress Playground and @php-wasm runtime expert. Use when working with the PHP WebAssembly runtime, PHP instance lifecycle, php.run() execution model, file system operations (writeFile, readFileAsBuffer, mkdir, isDir), php.ini configuration via setPhpIniEntries(), request/response conversion, or debugging issues that originate in the upstream @php-wasm/web and @php-wasm/universal packages.
+metadata:
+  author: moodle-playground
+  version: "1.0"
+---
+
+# WordPress Playground & @php-wasm Runtime Expert
+
+## Role
+
+You are an expert in WordPress Playground's PHP WebAssembly runtime — the `@php-wasm/web`
+and `@php-wasm/universal` packages that power the PHP execution layer. You understand the
+PHP instance lifecycle, the Emscripten virtual filesystem, and the bridge between JavaScript
+and PHP execution. You know where the upstream APIs behave unexpectedly and where our
+compatibility layer (`php-compat.js`) adapts the WP Playground API for Moodle's needs.
+
+## When to activate
+
+- Working with `src/runtime/php-loader.js` (PHP instance creation)
+- Working with `src/runtime/php-compat.js` (API adapter layer)
+- Debugging PHP execution issues (`php.run()` behavior, exit codes, output capture)
+- Investigating WASM-level crashes or memory issues
+- Configuring PHP settings (`setPhpIniEntries()`)
+- Working with the Emscripten MEMFS filesystem
+- Debugging file I/O operations in the PHP runtime
+- Investigating upstream issues in WordPress Playground
+
+## Upstream repository
+
+**Source**: https://github.com/WordPress/wordpress-playground
+
+Key packages we depend on:
+- `@php-wasm/web` (v3.1.12+) — Browser-specific PHP runtime, WASM binary loading
+- `@php-wasm/universal` (v3.1.12+) — Platform-agnostic PHP API, filesystem, ini config
+
+## PHP instance lifecycle
+
+### Creation
+
+```javascript
+import { loadWebRuntime } from '@php-wasm/web';
+
+const php = await loadWebRuntime('8.3', {
+    // Options passed to Emscripten module
+});
+```
+
+In our project, `src/runtime/php-loader.js` wraps this:
+
+```javascript
+const rawPhp = await loadWebRuntime(phpVersion, emscriptenOptions);
+setPhpIniEntries(rawPhp, iniEntries);  // from @php-wasm/universal
+```
+
+The raw `PHP` instance is then wrapped by `php-compat.js` into a compatibility layer
+that maps WP Playground's API to the interface expected by `bootstrap.js` and `php-worker.js`.
+
+### Execution model
+
+Each `php.run()` call is a **complete PHP lifecycle**:
+
+1. PHP globals are initialized fresh
+2. `$_SERVER`, `$_GET`, `$_POST`, etc. are populated from the request object
+3. The PHP script executes to completion (or fatal error)
+4. All PHP state is destroyed (variables, open handles, PDO connections)
+5. Output (stdout) and headers are captured and returned
+
+**Critical implication**: PHP state does NOT persist between `php.run()` calls. This is
+why the SQLite database must be a file in MEMFS, not `:memory:` — a `:memory:` DB would
+be empty on the next request because the PDO connection is closed and reopened.
+
+### Request format
+
+```javascript
+const response = await php.run({
+    scriptPath: '/www/moodle/admin/index.php',
+    method: 'GET',
+    headers: { 'Host': 'localhost', 'Cookie': 'MoodleSession=abc123' },
+    url: '/admin/index.php?redirect=0',
+    body: '',  // For POST requests
+});
+```
+
+The response object:
+```javascript
+{
+    httpStatusCode: 200,
+    headers: { 'content-type': ['text/html; charset=utf-8'], ... },
+    text: '<html>...',        // Output as string
+    bytes: Uint8Array,        // Output as bytes
+    errors: '',               // stderr output
+    exitCode: 0,              // 0 = success
+}
+```
+
+### CLI mode execution
+
+For provisioning (blueprint steps), we use CLI mode:
+
+```javascript
+const response = await php.run({
+    scriptPath: '/tmp/script.php',
+    // No method, url, or headers — runs as CLI
+});
+```
+
+The PHP script should define `CLI_SCRIPT` before requiring Moodle's `config.php`:
+
+```php
+define('CLI_SCRIPT', true);
+require('/www/moodle/config.php');
+// ... Moodle API calls
+```
+
+## Filesystem API
+
+The PHP instance exposes Emscripten's MEMFS through these methods:
+
+| Method | Description |
+|--------|-------------|
+| `php.writeFile(path, data)` | Write string or Uint8Array to path |
+| `php.readFileAsText(path)` | Read file as UTF-8 string |
+| `php.readFileAsBuffer(path)` | Read file as Uint8Array |
+| `php.mkdir(path)` | Create directory (parent must exist) |
+| `php.mkdirTree(path)` | Create directory and all parents |
+| `php.isDir(path)` | Check if path is a directory |
+| `php.fileExists(path)` | Check if path exists (file or directory) |
+| `php.unlink(path)` | Delete a file |
+| `php.listFiles(path)` | List directory contents |
+| `php.analyzePath(path)` | Emscripten `FS.analyzePath()` — returns `{ exists, object }` |
+
+**Important**: These operate on the raw `PHP` instance (`php._php` in our compat layer),
+not on the compatibility wrapper. The compat wrapper (`php-compat.js`) exposes a subset
+and adds error handling.
+
+**MEMFS characteristics**:
+- All data lives in JavaScript heap memory (RAM)
+- No durability — tab close = data loss
+- No size limits beyond available heap memory
+- File operations are synchronous and fast (no I/O wait)
+- Permissions are emulated but not enforced
+- Symlinks are supported but rarely used
+
+## php.ini configuration
+
+**Critical**: WP Playground hardcodes the ini path to `/internal/shared/php.ini`. Writing
+a separate `php.ini` file anywhere else has NO effect. All settings must go through:
+
+```javascript
+import { setPhpIniEntries } from '@php-wasm/universal';
+
+setPhpIniEntries(php, {
+    'date.timezone': 'UTC',
+    'memory_limit': '512M',
+    'max_execution_time': '0',
+    'display_errors': 'Off',
+    'session.save_path': '/tmp/moodle/sessions',
+    'upload_tmp_dir': '/tmp',
+    // ... etc
+});
+```
+
+This must be called **before** any `php.run()` — settings applied after execution has
+started may not take effect for all directives.
+
+Our project applies ini settings in `src/runtime/php-loader.js` during runtime creation,
+with timezone overrides applied later in `src/runtime/bootstrap.js` after blueprint parsing.
+
+## The compatibility layer (php-compat.js)
+
+Our `src/runtime/php-compat.js` wraps the raw WP Playground `PHP` instance to provide:
+
+1. **Request conversion**: Browser `Request` → PHP request object format
+2. **Response conversion**: PHP response → browser `Response`
+3. **`$_SERVER` population**: `SCRIPT_NAME`, `PHP_SELF`, `REQUEST_URI`, `PATH_INFO`,
+   `SCRIPT_FILENAME`, `DOCUMENT_ROOT`, `HTTP_*` headers
+4. **Base path injection**: Prepends URL base path (e.g., `/moodle-playground`) to
+   `SCRIPT_NAME` and `PHP_SELF` for correct Moodle URL construction
+5. **PATH_INFO resolution**: Splits URLs like `/theme/styles.php/boost/123/all` into
+   script path (`/theme/styles.php`) and PATH_INFO (`/boost/123/all`)
+6. **MIME type detection**: Returns correct Content-Type for static files
+7. **`analyzePath` emulation**: Wraps Emscripten's `FS.analyzePath()` for path checking
+
+### PATH_INFO handling (critical)
+
+Moodle uses PATH_INFO extensively for resource URLs:
+- `/theme/styles.php/boost/1234567890/all` — CSS delivery
+- `/theme/javascript.php/1234567890/boost/head` — JS delivery
+- `/pluginfile.php/1/mod_resource/content/0/file.pdf` — File serving
+
+`resolveScriptPath()` in `php-compat.js` must:
+1. Walk the URL path segments
+2. Find the first segment ending in `.php`
+3. Split into script path (before and including `.php`) and PATH_INFO (after)
+
+Without this, `isPhpScript()` returns false (URL doesn't end in `.php`) → 404.
+
+## Known issues and upstream bugs
+
+### File descriptor exhaustion
+- PHP WASM has a limited number of file descriptors (~1024)
+- Long sessions with many requests can exhaust them
+- Manifests as `RuntimeError: unreachable` or WASM traps
+- Our crash recovery system detects and handles this
+- See: https://github.com/WordPress/wordpress-playground/issues/1137
+
+### Memory limits
+- WASM linear memory has a growth limit (~2-4 GB depending on browser)
+- Large Moodle operations (file uploads, backup/restore) can hit this
+- OOM manifests as `RuntimeError: memory access out of bounds`
+- No way to free WASM memory — must restart the runtime
+
+### Extension availability
+Available in PHP 8.3 WASM: `sqlite3`, `pdo_sqlite`, `dom`, `simplexml`, `xml`,
+`mbstring`, `openssl`, `intl`, `iconv`, `zlib`, `zip`, `phar`, `curl`, `gd`,
+`fileinfo`, `xmlreader`, `xmlwriter`.
+
+**NOT available**: `sodium` (despite being listed in some docs). The OpenSSL fallback
+patch in `patches/shared/lib/classes/encryption.php` handles encryption needs.
+
+### Session handling
+- Sessions use file-based storage in MEMFS (`/tmp/moodle/sessions/`)
+- Session data persists across `php.run()` calls (files survive in MEMFS)
+- Session IDs are generated by PHP and tracked via `MoodleSession` cookie
+- After crash recovery, sessions are invalidated — a new admin session must be created
+
+## Debugging tips
+
+1. **Check `response.errors`** — stderr output often contains PHP warnings/notices
+2. **Check `response.exitCode`** — non-zero means PHP script failed
+3. **Enable PHP display_errors** — set `display_errors=On` in ini entries for debugging
+4. **Use `?debug=true`** — forces `DEBUG_DEVELOPER` and `display_errors=1` at boot
+5. **Read upstream source** — when `php-compat.js` behavior is unclear, check the
+   `@php-wasm/universal` source at `node_modules/@php-wasm/universal/`
+6. **MEMFS inspection** — use `php.listFiles()` and `php.readFileAsText()` to inspect
+   the virtual filesystem during debugging
+
+## Checklist for php-wasm-touching changes
+
+- [ ] Does the change work with the stateless `php.run()` model? (no PHP state persists)
+- [ ] Are ini settings applied via `setPhpIniEntries()`, not a php.ini file?
+- [ ] Does PATH_INFO resolution handle the URL pattern correctly?
+- [ ] Are `$_SERVER` variables correct, including base path prefix?
+- [ ] Does the change account for `sodium` not being available?
+- [ ] Could this hit file descriptor limits in long sessions?
+- [ ] Is the raw PHP instance (`php._php`) used for filesystem ops, not the wrapper?

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,14 @@ jobs:
 
       - name: Lint
         run: make lint
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Build worker bundle
+        run: npm run build:worker
+
+      - name: Run Playwright e2e tests
+        run: npm run test:e2e
+        env:
+          CI: "true"

--- a/.templates/adr-template.md
+++ b/.templates/adr-template.md
@@ -1,0 +1,34 @@
+# ADR-[NNNN] Short descriptive title
+
+* Status: [Proposed | Accepted | Rejected | Obsolete | Superseded by ADR-NNNN]
+* Date: YYYY-MM-DD
+
+## Context and Problem
+
+[Brief description of the problem to solve. Technical or business context that motivates this decision.]
+
+## Options Considered
+
+* [Option 1]
+* [Option 2]
+* [Option 3]
+
+## Decision
+
+[The chosen option and main justification.]
+
+## Consequences
+
+### Positive
+* [What we gain from this decision]
+
+### Negative / Risks
+* [What we lose, maintenance cost, or technical debt we take on]
+
+## Implementation Notes
+
+[How to proceed. Next steps, impact on other layers, files to modify.]
+
+## Review Criteria
+
+[Under what circumstances should this decision be revisited. Concrete triggers for re-evaluation.]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,8 @@ known pitfalls, and conventions that are not repeated elsewhere in this document
 | **WP Playground & php-wasm** | `@.agents/skills/wp-playground-php-wasm/SKILL.md` | `@php-wasm/web` and `@php-wasm/universal` APIs, PHP instance lifecycle, `php.run()` execution model, filesystem operations, `setPhpIniEntries()`, request/response conversion, `php-compat.js` adapter |
 | **WASM & Browser Runtime** | `@.agents/skills/wasm-browser-runtime/SKILL.md` | WASM crashes and memory limits, Emscripten MEMFS, service worker routing and caching, Web Worker communication, crash recovery, GitHub Pages subpath deployment, browser storage constraints |
 | **Blueprint Provisioning** | `@.agents/skills/blueprint-provisioning/SKILL.md` | Blueprint JSON format, step handlers, executor engine, resource resolution, PHP code generation, plugin/theme installation, constant substitution, adding new step types |
+| **Unit Testing** | `@.agents/skills/unit-testing/SKILL.md` | Writing and reviewing unit tests with `node:test`, mocking `php.run()` and MEMFS, testing PHP code generators, service worker helpers, runtime utilities, test organization conventions |
+| **E2E Testing (Playwright)** | `@.agents/skills/e2e-playwright/SKILL.md` | Browser-based end-to-end tests with Playwright, WASM boot waiting strategies, iframe navigation, blueprint execution verification, shell UI interaction, debugging flaky tests |
 
 ### Skill activation guidelines
 
@@ -539,7 +541,8 @@ When changing blueprint semantics, update the schema, step handlers, docs, and t
 ### Quick reference
 
 ```bash
-make test      # Run all unit tests (186 tests across 45 suites)
+make test      # Run all unit tests (286+ tests across 63 suites)
+make test-e2e  # Run Playwright browser tests (shell, boot, blueprints)
 make lint      # Run Biome linter on src/, tests/, scripts/
 make format    # Auto-fix lint and formatting issues
 ```
@@ -547,8 +550,10 @@ make format    # Auto-fix lint and formatting issues
 These are also available as npm scripts:
 
 ```bash
-npm test                  # All tests
+npm test                  # All unit tests
 npm run test:blueprint    # Blueprint tests only
+npm run test:e2e          # Playwright e2e tests
+npm run test:e2e:install  # Install Chromium for Playwright (first time)
 ```
 
 ### Test suites
@@ -591,6 +596,20 @@ Tests live in `tests/` and run with Node.js built-in `node:test` (no framework).
 | File | What it tests |
 |------|---------------|
 | `sw-helpers.test.js` | HTML entity decoding (`&amp;`, `&#x2F;`, `&colon;`, Moodle URLs), scoped runtime path extraction (scope/runtime/path parsing, subpath deployments) |
+
+#### End-to-End (`tests/e2e/`)
+
+E2E tests use [Playwright](https://playwright.dev/) and run against a real browser (Chromium).
+They verify the full playground flow: shell boot → WASM PHP runtime → Moodle loading → blueprint execution.
+
+| File | What it tests |
+|------|---------------|
+| `shell.spec.mjs` | Shell UI: boot, side panel tabs, logs, blueprint display, settings popover, `?blueprint=` param |
+| `moodle-boot.spec.mjs` | Runtime boot lifecycle, PHP Info capture |
+| `blueprint-courses.spec.mjs` | Blueprint execution: course creation, user creation, enrollment, module addition |
+
+Run with `make test-e2e` (requires `npm run test:e2e:install` for first-time Chromium setup).
+Configuration in `playwright.config.mjs`. The dev server auto-starts on port 8085.
 
 ### Linting and formatting
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,8 @@ MAINTENANCE: Update this file when:
 - Modifying the Moodle bundle format, manifest schema, or storage model
 - Changing deployment assumptions for GitHub Pages or other static hosting
 - Adding new conventions for blueprints, extensions, or persistent state
+- Updating upstream project references (WordPress Playground, Omeka S Playground)
+- Adding or removing agent skills under .agents/skills/
 -->
 
 # AGENTS.md
@@ -24,6 +26,84 @@ It follows the same product shape as `omeka-s-playground`:
 The Moodle core is extracted from a prebuilt ZIP bundle into Emscripten MEMFS (in-memory)
 at boot. All files — core and mutable state — live in writable MEMFS. The runtime is fully
 ephemeral — all state is lost when the browser tab closes or the page is reloaded.
+
+## Related Projects and Upstream References
+
+This project builds on top of two key upstream projects. Agents should consult them
+when investigating bugs, understanding API surfaces, or looking for implementation patterns:
+
+### WordPress Playground (`@php-wasm/*`)
+
+- **Repository**: https://github.com/WordPress/wordpress-playground
+- **What it provides**: The PHP WebAssembly runtime (`@php-wasm/web`, `@php-wasm/universal`)
+  that powers the PHP execution layer. This includes the WASM-compiled PHP 8.3 binary,
+  the `PHP` class API (`php.run()`, `php.writeFile()`, `php.readFileAsBuffer()`,
+  `php.mkdir()`, `php.isDir()`, `setPhpIniEntries()`, etc.), and the web worker
+  infrastructure for running PHP in the browser.
+- **When to look there**:
+  - Understanding PHP instance lifecycle, request execution, and `PHPRequestHandler`
+  - Debugging WASM-level crashes, memory limits, or file descriptor exhaustion
+  - Checking available PHP extensions in the WASM build
+  - Understanding `php.ini` handling (hardcoded path `/internal/shared/php.ini`)
+  - Investigating Emscripten MEMFS behavior and filesystem APIs
+  - Looking for known issues with the PHP WASM runtime (e.g., [#1137](https://github.com/WordPress/wordpress-playground/issues/1137))
+- **Key difference**: WordPress Playground runs WordPress; we adapted the same PHP runtime
+  to run Moodle and Omeka S. The `php-compat.js` layer in this repo bridges the WP
+  Playground PHP API to our request/response model.
+
+### Omeka S Playground
+
+- **Repository**: https://github.com/ateeducacion/omeka-s-playground
+- **What it is**: The first playground we built using this architecture. Moodle Playground
+  follows the same product shape and many of the same patterns. Omeka S Playground was the
+  proving ground where the shell/remote/sw/worker architecture was designed.
+- **When to look there**:
+  - Understanding the original design intent behind the shell → remote → sw → worker flow
+  - Comparing how a simpler PHP application (Omeka S) handles the same challenges
+    (service worker routing, subpath deployment, ZIP extraction, config generation)
+  - Finding patterns that were proven in Omeka S before being adapted for Moodle
+  - Debugging service worker or iframe communication issues — the pattern originated there
+- **Key differences from Moodle Playground**:
+  - Omeka S uses MySQL via PGlite; Moodle uses SQLite (deprecated PDO driver)
+  - Omeka S has a simpler install flow; Moodle requires a pre-built install snapshot
+  - Moodle Playground adds blueprints, crash recovery, and plugin installation support
+  - Moodle's codebase is significantly larger, requiring more aggressive caching and
+    memory management strategies
+
+### How to use these references
+
+1. **Before inventing a solution**, check if WordPress Playground or Omeka S Playground
+   already solved the same problem — especially for WASM runtime issues, service worker
+   routing, and PHP-in-browser quirks.
+2. **When debugging `@php-wasm/*` APIs**, read the WordPress Playground source code for
+   the authoritative behavior — our `php-compat.js` is a thin adapter, not a replacement.
+3. **When adding new architecture**, check if Omeka S Playground established a pattern
+   first. Consistency across playgrounds reduces maintenance burden.
+
+## Specialist Agent Skills
+
+This project includes domain-expert agent skills under `.agents/skills/`. Each skill
+provides deep context for a specific area of the codebase. Activate the appropriate
+skill when working in its domain — the skill file contains API references, checklists,
+known pitfalls, and conventions that are not repeated elsewhere in this document.
+
+| Skill | Directory | When to use |
+|-------|-----------|-------------|
+| **Moodle Internals** | `@.agents/skills/moodle-internals/SKILL.md` | Moodle APIs, plugin system, database schema, install/upgrade lifecycle, config settings, course structure, user management, enrollment, MUC caching, SQLite compatibility |
+| **WP Playground & php-wasm** | `@.agents/skills/wp-playground-php-wasm/SKILL.md` | `@php-wasm/web` and `@php-wasm/universal` APIs, PHP instance lifecycle, `php.run()` execution model, filesystem operations, `setPhpIniEntries()`, request/response conversion, `php-compat.js` adapter |
+| **WASM & Browser Runtime** | `@.agents/skills/wasm-browser-runtime/SKILL.md` | WASM crashes and memory limits, Emscripten MEMFS, service worker routing and caching, Web Worker communication, crash recovery, GitHub Pages subpath deployment, browser storage constraints |
+| **Blueprint Provisioning** | `@.agents/skills/blueprint-provisioning/SKILL.md` | Blueprint JSON format, step handlers, executor engine, resource resolution, PHP code generation, plugin/theme installation, constant substitution, adding new step types |
+
+### Skill activation guidelines
+
+1. **Read the skill file** when entering its domain — it contains the authoritative
+   reference for conventions and known issues in that area.
+2. **Cross-reference skills** when a change spans domains. For example, adding a new
+   blueprint step that installs a plugin touches both `blueprint-provisioning` and
+   `moodle-internals` (plugin type system, upgrade lifecycle).
+3. **Follow the checklists** at the end of each skill file before submitting changes.
+4. **Do not duplicate** skill content in this file — AGENTS.md provides the architectural
+   overview; skills provide the deep domain knowledge.
 
 ## Build System
 
@@ -555,3 +635,32 @@ The `.github/workflows/ci.yml` workflow runs on push to `main` and on pull reque
 - Cache file creation in `/persist/moodledata/cache` (verify Moodle cache system initializes)
 
 If a change touches routing or HTML rewriting, prefer checking real browser behavior, not only syntax.
+
+## Architecture Decision Records (ADRs)
+
+Every significant technical decision must be documented as an Architecture Decision Record.
+ADRs capture the context, options considered, rationale, consequences, and review criteria
+so that future contributors (human or AI) understand **why** a choice was made — not just what.
+
+### Rules
+
+1. **When to write an ADR**: Any change that introduces a new pattern, modifies the request
+   pipeline, changes the storage model, adds a dependency, or alters build/deployment behavior.
+   When in doubt, write one — a short ADR is better than no ADR.
+2. **Template**: Always start from `.templates/adr-template.md`. Do not invent a new format.
+3. **Location**: `docs/decisions/NNNN-kebab-case-title.md`, numbered sequentially.
+4. **Language**: English.
+5. **Status values**: `Proposed`, `Accepted`, `Rejected`, `Obsolete`, `Superseded by ADR-NNNN`.
+6. **Cross-reference**: When an ADR supersedes another, update the old ADR's status.
+7. **Link from code**: When code implements an ADR, add a brief comment referencing it
+   (e.g., `// See docs/decisions/0001-sw-level-scoped-static-asset-caching.md`).
+
+### Current ADRs
+
+| ADR | Topic | Status |
+|-----|-------|--------|
+| [0001](docs/decisions/0001-sw-level-scoped-static-asset-caching.md) | SW-level caching for scoped static assets | Accepted |
+| [0002](docs/decisions/0002-plugin-auto-detection-from-github-urls.md) | Plugin type & name auto-detection from GitHub URLs | Accepted |
+| [0003](docs/decisions/0003-direct-db-inserts-for-course-modules.md) | Direct DB inserts for course modules (WASM SQLite compat) | Accepted |
+| [0004](docs/decisions/0004-opcache-tuning-and-runtime-ux-defaults.md) | OPcache tuning and runtime UX defaults | Accepted |
+| [0005](docs/decisions/0005-resilient-blueprint-step-execution.md) | Resilient blueprint step execution with graceful errors | Accepted |

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ check-php:
 	fi
 	@echo "Using PHP 8.3: $(PHP_BIN)"
 
-.PHONY: deps build-version build-worker bundle bundle-all bundle-all-pretty bundle-legacy prepare prepare-dev prepare-dev-pretty prepare-all serve up up-local clean reset check-php test lint format
+.PHONY: deps build-version build-worker bundle bundle-all bundle-all-pretty bundle-legacy prepare prepare-dev prepare-dev-pretty prepare-all serve up up-local clean reset check-php test test-e2e lint format
 .PHONY: bundle-MOODLE_404_STABLE bundle-MOODLE_405_STABLE bundle-MOODLE_500_STABLE bundle-MOODLE_501_STABLE bundle-main
 
 deps:
@@ -96,6 +96,9 @@ up-local: deps build-version bundle
 
 test:
 	node --test tests/**/*.test.js
+
+test-e2e:
+	npm run test:e2e
 
 lint:
 	npx @biomejs/biome check

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ index.html          Shell UI (toolbar, address bar, log panel)
 4. Moodle runs against an in-memory SQLite database — fully ephemeral, no persistence.
 5. If the PHP runtime crashes (WASM OOM / file descriptor exhaustion), the worker snapshots the DB and user files, boots a fresh runtime, and restores state automatically.
 
+**Default credentials:** username `admin`, password `password`.
+
 ### No persistence by design
 
 All state lives in memory (Emscripten MEMFS). Closing the tab destroys everything. This is intentional — the playground is meant for exploration, demos, and testing, not for storing data.
@@ -61,12 +63,13 @@ Blueprints are step-based JSON files that configure and provision a playground i
 
 ```json
 {
-  "landingPage": "/my/",
+  "landingPage": "/course/view.php?id=2",
   "steps": [
     { "step": "installMoodle", "options": { "siteName": "My Moodle" } },
     { "step": "login", "username": "admin" },
-    { "step": "createCategory", "name": "Science" },
-    { "step": "createCourse", "fullname": "Physics 101", "shortname": "PHYS101", "category": "Science" }
+    { "step": "installMoodlePlugin", "url": "https://github.com/moodlehq/moodle-block_participants/archive/refs/heads/master.zip" },
+    { "step": "createCourse", "fullname": "Physics 101", "shortname": "PHYS101" },
+    { "step": "addModule", "module": "label", "course": "PHYS101", "name": "Welcome", "intro": "<p>Hello World!</p>" }
   ]
 }
 ```

--- a/assets/blueprints/default.blueprint.json
+++ b/assets/blueprints/default.blueprint.json
@@ -8,7 +8,7 @@
     "debug": 0,
     "debugdisplay": 0
   },
-  "landingPage": "/my/",
+  "landingPage": "/?redirect=0",
   "constants": {
     "ADMIN_USER": "admin",
     "ADMIN_PASS": "password",
@@ -49,7 +49,7 @@
     },
     {
       "step": "setLandingPage",
-      "path": "/my/"
+      "path": "/?redirect=0"
     }
   ]
 }

--- a/assets/blueprints/examples/classroom-ready.blueprint.json
+++ b/assets/blueprints/examples/classroom-ready.blueprint.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "../blueprint-schema.json",
+  "landingPage": "/course/view.php?id=2",
+  "preferredVersions": { "php": "8.3", "moodle": "5.0" },
+  "constants": {
+    "ADMIN_USER": "admin",
+    "ADMIN_PASS": "password",
+    "ADMIN_EMAIL": "admin@example.com",
+    "TEACHER_USER": "teacher1",
+    "TEACHER_PASS": "Teacher1!",
+    "TEACHER_EMAIL": "teacher1@example.com"
+  },
+  "steps": [
+    {
+      "step": "installMoodle",
+      "options": {
+        "adminUser": "{{ADMIN_USER}}",
+        "adminPass": "{{ADMIN_PASS}}",
+        "adminEmail": "{{ADMIN_EMAIL}}",
+        "siteName": "Classroom Ready Demo"
+      }
+    },
+    {
+      "step": "login",
+      "username": "{{ADMIN_USER}}"
+    },
+    {
+      "step": "createUsers",
+      "users": [
+        {
+          "username": "{{TEACHER_USER}}",
+          "password": "{{TEACHER_PASS}}",
+          "email": "{{TEACHER_EMAIL}}",
+          "firstname": "Jane",
+          "lastname": "Smith"
+        },
+        {
+          "username": "student1",
+          "password": "Student1!",
+          "email": "student1@example.com",
+          "firstname": "Alice",
+          "lastname": "Johnson"
+        },
+        {
+          "username": "student2",
+          "password": "Student2!",
+          "email": "student2@example.com",
+          "firstname": "Bob",
+          "lastname": "Williams"
+        },
+        {
+          "username": "student3",
+          "password": "Student3!",
+          "email": "student3@example.com",
+          "firstname": "Carlos",
+          "lastname": "Garcia"
+        }
+      ]
+    },
+    {
+      "step": "createCategory",
+      "name": "Languages"
+    },
+    {
+      "step": "createCourse",
+      "fullname": "English for Beginners",
+      "shortname": "ENG101",
+      "category": "Languages",
+      "numsections": 4,
+      "summary": "A beginner's course in English language with assignments, forums, and quizzes."
+    },
+    {
+      "step": "enrolUsers",
+      "enrolments": [
+        { "username": "{{TEACHER_USER}}", "course": "ENG101", "role": "editingteacher" },
+        { "username": "student1", "course": "ENG101", "role": "student" },
+        { "username": "student2", "course": "ENG101", "role": "student" },
+        { "username": "student3", "course": "ENG101", "role": "student" }
+      ]
+    },
+    {
+      "step": "addModule",
+      "module": "label",
+      "course": "ENG101",
+      "section": 1,
+      "name": "Unit 1 Introduction",
+      "intro": "<h3>Unit 1: Greetings and Introductions</h3><p>Learn how to introduce yourself and greet others in English.</p>"
+    },
+    {
+      "step": "addModule",
+      "module": "assign",
+      "course": "ENG101",
+      "section": 1,
+      "name": "Self-Introduction Essay",
+      "intro": "Write a short paragraph introducing yourself in English (100-200 words)."
+    },
+    {
+      "step": "addModule",
+      "module": "label",
+      "course": "ENG101",
+      "section": 2,
+      "name": "Unit 2 Introduction",
+      "intro": "<h3>Unit 2: Daily Routines</h3><p>Describe your daily activities using present tense verbs.</p>"
+    },
+    {
+      "step": "addModule",
+      "module": "url",
+      "course": "ENG101",
+      "section": 2,
+      "name": "English Grammar Reference",
+      "intro": "Present tense verb conjugation guide."
+    },
+    {
+      "step": "addModule",
+      "module": "assign",
+      "course": "ENG101",
+      "section": 2,
+      "name": "My Daily Routine",
+      "intro": "Describe your typical day using at least 10 present tense verbs."
+    },
+    {
+      "step": "addModule",
+      "module": "label",
+      "course": "ENG101",
+      "section": 3,
+      "name": "Unit 3 Introduction",
+      "intro": "<h3>Unit 3: Food and Shopping</h3><p>Learn vocabulary for food, shopping, and ordering at a restaurant.</p>"
+    },
+    {
+      "step": "addModule",
+      "module": "label",
+      "course": "ENG101",
+      "section": 4,
+      "name": "Final Project",
+      "intro": "<h3>Final Project</h3><p>Create a short video introducing yourself, your daily routine, and your favorite food.</p>"
+    },
+    {
+      "step": "addModule",
+      "module": "assign",
+      "course": "ENG101",
+      "section": 4,
+      "name": "Final Video Project",
+      "intro": "Record a 2-minute video in English covering all topics from the course."
+    },
+    {
+      "step": "setLandingPage",
+      "path": "/course/view.php?id=2"
+    }
+  ]
+}

--- a/assets/blueprints/examples/plugin-exeweb.blueprint.json
+++ b/assets/blueprints/examples/plugin-exeweb.blueprint.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "../blueprint-schema.json",
+  "landingPage": "/course/view.php?id=2",
+  "preferredVersions": { "php": "8.3", "moodle": "5.0" },
+  "constants": {
+    "ADMIN_USER": "admin",
+    "ADMIN_PASS": "password",
+    "ADMIN_EMAIL": "admin@example.com"
+  },
+  "steps": [
+    {
+      "step": "installMoodle",
+      "options": {
+        "adminUser": "{{ADMIN_USER}}",
+        "adminPass": "{{ADMIN_PASS}}",
+        "adminEmail": "{{ADMIN_EMAIL}}",
+        "siteName": "Moodle + eXeLearning"
+      }
+    },
+    {
+      "step": "login",
+      "username": "{{ADMIN_USER}}"
+    },
+    {
+      "step": "installMoodlePlugin",
+      "url": "https://github.com/exelearning/mod_exeweb/archive/refs/heads/main.zip",
+      "pluginType": "mod",
+      "pluginName": "exeweb"
+    },
+    {
+      "step": "createCategory",
+      "name": "Interactive Content"
+    },
+    {
+      "step": "createCourse",
+      "fullname": "eXeLearning Demo Course",
+      "shortname": "EXEDEMO",
+      "category": "Interactive Content",
+      "summary": "Demonstrates the exeweb activity module for embedding eXeLearning content in Moodle."
+    },
+    {
+      "step": "addModule",
+      "module": "label",
+      "course": "EXEDEMO",
+      "section": 1,
+      "name": "About this course",
+      "intro": "<h3>eXeLearning + Moodle</h3><p>This course demonstrates the <strong>exeweb</strong> activity module, which allows embedding eXeLearning interactive content directly into Moodle courses.</p>"
+    },
+    {
+      "step": "setLandingPage",
+      "path": "/course/view.php?id=2"
+    }
+  ]
+}

--- a/assets/blueprints/examples/plugin-showcase.blueprint.json
+++ b/assets/blueprints/examples/plugin-showcase.blueprint.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "../blueprint-schema.json",
+  "landingPage": "/my/",
+  "preferredVersions": { "php": "8.3", "moodle": "5.0" },
+  "constants": {
+    "ADMIN_USER": "admin",
+    "ADMIN_PASS": "password",
+    "ADMIN_EMAIL": "admin@example.com"
+  },
+  "steps": [
+    {
+      "step": "installMoodle",
+      "options": {
+        "adminUser": "{{ADMIN_USER}}",
+        "adminPass": "{{ADMIN_PASS}}",
+        "adminEmail": "{{ADMIN_EMAIL}}",
+        "siteName": "Plugin Showcase"
+      }
+    },
+    {
+      "step": "login",
+      "username": "{{ADMIN_USER}}"
+    },
+    {
+      "step": "installMoodlePlugin",
+      "url": "https://github.com/bynfrancesco/moodle-mod_board/archive/refs/heads/main.zip",
+      "pluginType": "mod",
+      "pluginName": "board"
+    },
+    {
+      "step": "createCourse",
+      "fullname": "Plugin Showcase Course",
+      "shortname": "PLUGINS",
+      "summary": "A course that demonstrates third-party Moodle plugins."
+    },
+    {
+      "step": "addModule",
+      "module": "label",
+      "course": "PLUGINS",
+      "section": 1,
+      "name": "Board Plugin",
+      "intro": "<h3>Board Activity</h3><p>The Board plugin provides a Kanban-style collaborative board within Moodle courses.</p>"
+    },
+    {
+      "step": "setLandingPage",
+      "path": "/my/"
+    }
+  ]
+}

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.7/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
   "linter": {
     "enabled": true,
     "rules": {

--- a/blueprint-sample.json
+++ b/blueprint-sample.json
@@ -4,7 +4,7 @@
     "php": "8.3",
     "moodle": "5.0"
   },
-  "landingPage": "/my/",
+  "landingPage": "/course/view.php?id=2",
   "constants": {
     "ADMIN_USER": "admin",
     "ADMIN_PASS": "password",
@@ -29,14 +29,14 @@
     },
     {
       "step": "installMoodlePlugin",
-      "pluginType": "block",
-      "pluginName": "participants",
+      "url": "https://github.com/ateeducacion/moodle-mod_simplemod/archive/refs/heads/main.zip"
+    },
+    {
+      "step": "installMoodlePlugin",
       "url": "https://github.com/moodlehq/moodle-block_participants/archive/refs/heads/master.zip"
     },
     {
       "step": "installMoodlePlugin",
-      "pluginType": "local",
-      "pluginName": "staticpage",
       "url": "https://github.com/moodle-an-hochschulen/moodle-local_staticpage/archive/refs/heads/MOODLE_404_STABLE.zip"
     },
     {
@@ -79,6 +79,14 @@
     },
     {
       "step": "addModule",
+      "module": "simplemod",
+      "course": "INTRO101",
+      "section": 1,
+      "name": "My Simple Activity",
+      "intro": "A simple activity module installed via blueprint."
+    },
+    {
+      "step": "addModule",
       "module": "label",
       "course": "INTRO101",
       "section": 1,
@@ -95,7 +103,7 @@
     },
     {
       "step": "setLandingPage",
-      "path": "/my/"
+      "path": "/course/view.php?id=2"
     }
   ]
 }

--- a/docs/blueprint-gallery.md
+++ b/docs/blueprint-gallery.md
@@ -1,0 +1,176 @@
+# Blueprint Gallery
+
+Ready-to-use blueprint examples for common Moodle Playground scenarios.
+Each blueprint can be loaded via the `?blueprint-url=` query parameter or
+pasted into the Blueprint panel in the playground UI.
+
+All examples live in
+[`assets/blueprints/examples/`](https://github.com/ateeducacion/moodle-playground/tree/main/assets/blueprints/examples).
+
+---
+
+## Minimal
+
+**File:** `minimal.blueprint.json`
+
+The smallest possible blueprint — installs Moodle, logs in as admin, and
+redirects to the dashboard. Use this as a starting point for custom blueprints.
+
+```
+?blueprint-url=assets/blueprints/examples/minimal.blueprint.json
+```
+
+**What it does:**
+
+- Installs Moodle with default admin credentials
+- Logs in as admin
+- Lands on `/my/` (dashboard)
+
+---
+
+## Course with Content
+
+**File:** `course-with-content.blueprint.json`
+
+Creates a single course with a category, a label module, and an assignment.
+Good for demonstrating the course creation and module addition flow.
+
+```
+?blueprint-url=assets/blueprints/examples/course-with-content.blueprint.json
+```
+
+**What it does:**
+
+- Creates a "Science" category
+- Creates "Introduction to Physics" course (PHYS101)
+- Adds a welcome label and an assignment to section 1
+- Lands on the dashboard
+
+---
+
+## Multi-User
+
+**File:** `multi-user.blueprint.json`
+
+Creates multiple users and enrolls them in a course with different roles.
+Demonstrates bulk user creation and enrollment.
+
+```
+?blueprint-url=assets/blueprints/examples/multi-user.blueprint.json
+```
+
+**What it does:**
+
+- Creates teacher and student accounts
+- Creates a course
+- Enrolls users with appropriate roles (editingteacher, student)
+
+---
+
+## Classroom Ready
+
+**File:** `classroom-ready.blueprint.json`
+
+A full classroom setup with a teacher, three students, a 4-section course
+with labels, assignments, and a URL resource across multiple units.
+
+```
+?blueprint-url=assets/blueprints/examples/classroom-ready.blueprint.json
+```
+
+**What it does:**
+
+- Creates 1 teacher + 3 student accounts
+- Creates "English for Beginners" (ENG101) with 4 sections
+- Enrolls all users with correct roles
+- Adds content across all sections: labels, assignments, URL resources
+- Lands on the course view
+
+---
+
+## Plugin: eXeLearning (mod_exeweb)
+
+**File:** `plugin-exeweb.blueprint.json`
+
+Installs the [eXeLearning](https://exelearning.net/) `mod_exeweb` activity
+module from its GitHub repository and creates a demo course.
+
+```
+?blueprint-url=assets/blueprints/examples/plugin-exeweb.blueprint.json
+```
+
+**What it does:**
+
+- Installs `mod_exeweb` from `exelearning/mod_exeweb` (main branch)
+- Creates an "Interactive Content" category
+- Creates "eXeLearning Demo Course" (EXEDEMO)
+- Adds an introductory label
+- Lands on the course view
+
+!!! note
+    Plugin installation requires downloading a ZIP from GitHub via jsDelivr
+    CDN. The first load may take a few extra seconds.
+
+---
+
+## Plugin Showcase
+
+**File:** `plugin-showcase.blueprint.json`
+
+Installs a third-party plugin (Board — a Kanban-style activity) and creates
+a course to demonstrate it.
+
+```
+?blueprint-url=assets/blueprints/examples/plugin-showcase.blueprint.json
+```
+
+**What it does:**
+
+- Installs `mod_board` from GitHub
+- Creates a "Plugin Showcase Course"
+- Adds a descriptive label
+- Lands on the dashboard
+
+---
+
+## How to use
+
+### Via URL parameter
+
+Append `?blueprint-url=` with the path to any example:
+
+```
+https://ateeducacion.github.io/moodle-playground/?blueprint-url=assets/blueprints/examples/classroom-ready.blueprint.json
+```
+
+### Via the Blueprint panel
+
+1. Open the playground
+2. Click the **Blueprint** button in the toolbar
+3. Paste the JSON content of any example into the editor
+4. Click **Apply**
+
+### Via inline base64
+
+Encode any blueprint as base64 and pass it via `?blueprint=`:
+
+```
+?blueprint=eyJzdGVwcyI6W3sic3RlcCI6Imluc3RhbGxNb29kbGUifV19
+```
+
+---
+
+## Creating your own
+
+Start from `minimal.blueprint.json` and add steps. See the
+[Blueprint Reference](blueprint-json.md) for all available step types,
+resource formats, and configuration options.
+
+### Tips
+
+- Use `constants` for values that appear in multiple steps (usernames, emails)
+- Use `preferredVersions` to pin PHP and Moodle versions
+- Set `landingPage` to control where the user lands after boot
+- Plugin installation steps (`installMoodlePlugin`) accept GitHub URLs directly
+- The `pluginType` and `pluginName` fields are auto-detected from GitHub repo names
+  following the `moodle-{type}_{name}` convention

--- a/docs/blueprint-json.md
+++ b/docs/blueprint-json.md
@@ -259,6 +259,10 @@ Named resources can be defined once and referenced from steps using `@name`:
 
 ### addModule
 
+Adds a course module (activity) to an existing course. The `module` field is the
+Moodle module name (e.g., `label`, `assign`, `folder`, `board`). For third-party
+modules, install the plugin first with `installMoodlePlugin`.
+
 ```json
 {
   "step": "addModule",
@@ -270,7 +274,32 @@ Named resources can be defined once and referenced from steps using `@name`:
 }
 ```
 
+| Field | Required | Description |
+|-------|----------|-------------|
+| `module` | yes | Module type name (`label`, `assign`, `folder`, `board`, etc.) |
+| `course` | yes | Course shortname |
+| `section` | no | Section number (default: 0) |
+| `name` | no | Activity name (defaults to module type) |
+| `intro` | no | Description HTML |
+
+Works with any installed module type, including plugins installed via
+`installMoodlePlugin` in earlier blueprint steps. The module is created using
+direct database inserts (not `add_moduleinfo()`) for SQLite WASM compatibility.
+
 ### installMoodlePlugin
+
+Installs a Moodle plugin from a GitHub ZIP URL. Both `pluginType` and `pluginName`
+are auto-detected from the GitHub repository name (e.g., `moodle-mod_board` →
+type `mod`, name `board`). Only the `url` is required:
+
+```json
+{
+  "step": "installMoodlePlugin",
+  "url": "https://github.com/brickfield/moodle-mod_board/archive/refs/heads/MOODLE_405_STABLE.zip"
+}
+```
+
+You can override the detected values if needed:
 
 ```json
 {
@@ -281,14 +310,17 @@ Named resources can be defined once and referenced from steps using `@name`:
 }
 ```
 
+| Field | Required | Description |
+|-------|----------|-------------|
+| `url` | yes | GitHub archive ZIP URL |
+| `pluginType` | no | Auto-detected from URL. Override for non-standard repo names |
+| `pluginName` | no | Auto-detected from URL. Override for non-standard repo names |
+
 Supported plugin types: `mod`, `block`, `local`, `theme`, `auth`, `enrol`, `filter`,
 `format`, `report`, `tool`, `editor`, `atto`, `tiny`, `qtype`, `qbehaviour`,
 `gradeexport`, `gradeimport`, `gradereport`, `repository`, `plagiarism`,
 `availability`, `calendartype`, `message`, `profilefield`, `datafield`,
 `assignsubmission`, `assignfeedback`, `booktool`, `quizaccess`, `ltisource`.
-
-If `pluginName` is omitted, it is guessed from the GitHub URL (e.g.,
-`moodle-block_participants` becomes `participants`).
 
 ### installTheme
 

--- a/docs/decisions/0001-sw-level-scoped-static-asset-caching.md
+++ b/docs/decisions/0001-sw-level-scoped-static-asset-caching.md
@@ -1,0 +1,108 @@
+# ADR-0001 Service Worker-level caching for scoped static assets
+
+* Status: Accepted
+* Date: 2026-03-27
+
+## Context and Problem
+
+In Moodle Playground, every scoped request (`/playground/{scope}/{runtime}/...`) is
+forwarded to the PHP worker via BroadcastChannel and enters a **serial queue**. This
+includes truly static files (CSS, JS, images, fonts) and PHP-generated cacheable assets
+(`styles.php`, `javascript.php`, `image.php`, `font.php`).
+
+A typical Moodle page triggers 20-40 asset requests. Because the PHP worker processes
+requests sequentially, static assets compete with page renders for queue time. Each
+round-trip through the BroadcastChannel bridge + MEMFS read costs ~5-20ms, and these
+add up to 100-400ms of pure queue overhead per page navigation.
+
+The facturascripts-playground project solved this same problem by caching scoped static
+asset responses at the Service Worker level using the Cache API. We evaluated adopting
+the same approach for Moodle.
+
+## Options Considered
+
+* **Option 1: Do nothing** — Keep all scoped requests going through the PHP worker.
+  Simple but leaves significant performance on the table for subsequent page loads.
+
+* **Option 2: Cache only truly static files (non-`.php`)** — Intercept GET requests
+  to files with known static extensions (`.css`, `.js`, `.png`, `.woff2`, etc.) at the
+  SW level. Cache after first fetch, serve from cache on subsequent requests.
+
+* **Option 3: Cache static files + PHP-generated cacheable assets** — Extend Option 2
+  to also cache responses from Moodle's asset-serving PHP scripts (`styles.php`,
+  `javascript.php`, `image.php`, `font.php`) which produce deterministic output keyed
+  by revision numbers in the URL path.
+
+## Decision
+
+**Option 3**: Cache both truly static files and PHP-generated cacheable assets at the
+Service Worker level.
+
+Rationale:
+1. PHP-generated assets represent the majority of asset weight (combined CSS via
+   `styles.php` can be 200-500KB; combined JS via `javascript.php` is similar).
+2. Moodle's revision-number URL scheme (`/theme/styles.php/boost/{rev}/all`) provides
+   natural cache invalidation — when theme caches are purged, the revision changes and
+   URLs miss the cache automatically.
+3. The implementation cost of Level 2 over Level 1 is minimal (one additional regex
+   check in the same code path).
+
+### Exclusions
+- `pluginfile.php` and `draftfile.php` are **never cached** — they serve user-uploaded
+  content where the URL can stay the same while content changes.
+- POST/PUT/DELETE requests are never cached.
+- HTML responses (`text/html`) are never cached — they require URL rewriting.
+
+## Consequences
+
+### Positive
+* **Unblocks the serial PHP queue** — Static assets no longer compete with page renders.
+* **Instant cache hits** — Cache API serves responses in ~1ms vs ~5-20ms per asset
+  through the BroadcastChannel bridge, and they're serialized.
+* **Survives crash recovery** — Cache API is browser storage, independent of WASM heap.
+  After a worker crash + restart, cached assets are still available instantly.
+* **No additional WASM memory** — Cache API uses browser storage, not JS heap.
+* **Natural invalidation** — PHP asset URLs contain revision numbers; new revisions
+  produce new URLs that miss the cache.
+
+### Negative / Risks
+* **Stale cache after runtime reset** — If the Moodle core changes between sessions
+  (e.g., different bundle version), cached assets from the previous session could be
+  stale. Mitigated by clearing the scoped cache on SW activation (new build version)
+  and on explicit `clear-scoped-static-cache` messages.
+* **Disk usage** — Cached assets consume browser storage. Estimated <5MB for a typical
+  Moodle session. Negligible for modern browsers.
+* **Added complexity in SW** — The fetch handler gains a new code path. Kept simple by
+  reusing the existing `forwardToPhpWorker` on cache miss.
+
+## Implementation Notes
+
+### Files modified
+- `sw.js` — Added `SCOPED_STATIC_CACHE`, `isScopedStaticAsset()`,
+  `isCacheablePhpAsset()`, and a cache-first branch in the scoped fetch handler.
+  Added `clear-scoped-static-cache` message listener. Added cache purge on activation.
+
+### Cache key strategy
+- For truly static files: the `requestPath` (scope-stripped) is used as the cache key,
+  anchored to the origin. This means the same `/lib/jquery/jquery.min.js` is shared
+  across scopes (the file content is identical since it comes from the same MEMFS bundle).
+- For PHP-generated assets: the full `requestPath` including the revision number is the
+  key. Different revisions produce different cache entries.
+
+### Cache lifecycle
+1. **New SW version (activation)** — All old static caches are purged via
+   `purgeOldStaticCaches()`. The scoped static cache is also cleared.
+2. **Worker crash/restart** — Worker can send `clear-scoped-static-cache` via
+   BroadcastChannel if the runtime is rebuilt from scratch.
+3. **Natural expiry** — PHP asset URLs change revision numbers when Moodle's theme
+   cache is purged. Old entries become unreachable (dead entries cleaned on next SW
+   activation).
+
+## Review Criteria
+
+- If Moodle Playground adds support for multiple simultaneous Moodle versions in the
+  same browser session, the cache key strategy may need per-version namespacing.
+- If `pluginfile.php` URLs are made content-addressable (hash in URL), they could be
+  added to the cacheable set.
+- If the Cache API causes storage quota issues on resource-constrained devices, consider
+  adding a size limit or LRU eviction.

--- a/docs/decisions/0002-plugin-auto-detection-from-github-urls.md
+++ b/docs/decisions/0002-plugin-auto-detection-from-github-urls.md
@@ -1,0 +1,86 @@
+# ADR-0002 Plugin type and name auto-detection from GitHub URLs
+
+* Status: Accepted
+* Date: 2026-03-27
+
+## Context and Problem
+
+The `installMoodlePlugin` blueprint step previously required explicit `pluginType` and
+`pluginName` fields for every plugin installation. This was redundant because GitHub
+repositories for Moodle plugins follow a standard naming convention: `moodle-{type}_{name}`
+(e.g., `moodle-mod_board`, `moodle-block_participants`, `moodle-local_staticpage`).
+
+Requiring users to specify `pluginType: "mod"` and `pluginName: "board"` alongside a URL
+that already encodes both values made blueprints verbose and error-prone — a mismatched
+type/name pair would silently install files to the wrong directory.
+
+## Options Considered
+
+* **Option 1: Keep explicit fields as required** — No change. Users must specify both
+  fields. Simple but creates unnecessary friction and copy-paste errors.
+
+* **Option 2: Auto-detect from URL, allow explicit overrides** — Parse the GitHub
+  archive URL to extract the repo name, split on `moodle-{type}_{name}`, and validate
+  that the type maps to a known Moodle plugin directory. Users can still override
+  either field for non-standard repos. Falls back to clear error messages if detection
+  fails.
+
+* **Option 3: Require a manifest or `version.php` file** — Download the ZIP first, read
+  `version.php` to extract `$plugin->component`. Accurate but much slower and requires
+  fetching the ZIP before validation.
+
+## Decision
+
+**Option 2**: Auto-detect plugin type and name from the GitHub URL, with explicit override
+support.
+
+The new `detectPluginTypeAndName(url)` function replaces the old `guessPluginNameFromUrl()`
+and returns both `type` and `name` (previously only name was guessed, and type was always
+required). The detection validates the extracted type against the known `PLUGIN_TYPE_DIRS`
+mapping before accepting it.
+
+Explicit `pluginType` and `pluginName` fields always take precedence, so the auto-detection
+is a convenience default, not a constraint.
+
+## Consequences
+
+### Positive
+* **Simpler blueprints** — A plugin install step can be just `{ "step": "installMoodlePlugin", "url": "https://github.com/..." }`.
+* **Fewer errors** — The type and name are derived from the same URL, eliminating mismatches.
+* **Backwards compatible** — Existing blueprints with explicit fields still work unchanged.
+* **Clear errors** — If the URL doesn't follow the convention and no explicit fields are
+  provided, the error message tells the user exactly what to add.
+* **Tested** — `tests/blueprint/moodle-plugins.test.js` covers auto-detection for multiple
+  plugin types, explicit overrides, unknown types, and plugin directory path mapping.
+
+### Negative / Risks
+* **Only works for GitHub archive URLs** — Non-GitHub sources or custom download URLs will
+  still need explicit `pluginType` and `pluginName`.
+* **Convention dependency** — If a plugin author doesn't follow the `moodle-{type}_{name}`
+  convention, auto-detection fails (gracefully — with a clear error message).
+
+## Implementation Notes
+
+### Files modified
+- `src/blueprint/steps/moodle-plugins.js` — New `detectPluginTypeAndName()` function
+  replaces `guessPluginNameFromUrl()`. Both `handleInstallMoodlePlugin()` and
+  `handleInstallTheme()` use auto-detection with explicit overrides.
+- `tests/blueprint/moodle-plugins.test.js` — New test file with comprehensive coverage:
+  registration, validation, auto-detection for multiple types, explicit overrides, path
+  mapping for 13+ plugin types, sample URL validation.
+- `blueprint-sample.json` — Updated to use URL-only syntax.
+- `docs/blueprint-json.md` — Documented auto-detection behavior and field tables.
+
+### Detection logic
+1. Parse the URL to extract the pathname.
+2. Match `/([^/]+)/archive/` to get the repository name.
+3. Strip the `moodle-` prefix (case-insensitive).
+4. Split on the first underscore: `{type}_{name}`.
+5. Validate that `{type}` exists in `PLUGIN_TYPE_DIRS`.
+6. Return `{ type, name }` or `{ type: null, name: null }` on failure.
+
+## Review Criteria
+
+- If Moodle Directory or other plugin registries become common download sources, add
+  URL patterns for those as well.
+- If the `moodle-{type}_{name}` convention changes or gains exceptions, update the regex.

--- a/docs/decisions/0003-direct-db-inserts-for-course-modules.md
+++ b/docs/decisions/0003-direct-db-inserts-for-course-modules.md
@@ -1,0 +1,103 @@
+# ADR-0003 Direct database inserts for course module addition
+
+* Status: Accepted
+* Date: 2026-03-27
+
+## Context and Problem
+
+The `addModule` blueprint step (used to add labels, folders, assignments, and generic
+activity modules to courses) previously used Moodle's `add_moduleinfo()` function. This
+function uses **delegated transactions with nested savepoints** internally to handle
+validation, file copying, calendar events, completion tracking, and event dispatching.
+
+In the SQLite PDO WASM runtime, nested savepoints crash. The Moodle SQLite driver's
+transaction handling is limited — `BEGIN TRANSACTION` works, but nested savepoints cause
+"Error writing to database" errors that trigger Moodle's `default_exception_handler`,
+which calls `exit(1)` and kills the WASM process. This made `addModule` steps unreliable
+and often fatal.
+
+## Options Considered
+
+* **Option 1: Patch the SQLite PDO driver to support nested savepoints** — Would require
+  emulating savepoints in the deprecated SQLite driver. High complexity, fragile, and the
+  driver is already unsupported by Moodle HQ.
+
+* **Option 2: Wrap `add_moduleinfo()` in a retry loop** — Retry after WASM crashes.
+  Unreliable because the crash corrupts the PHP runtime state and the retry would run in
+  an undefined state.
+
+* **Option 3: Direct database inserts bypassing `add_moduleinfo()`** — Insert minimal
+  records directly into `course_modules` and the module-specific table (e.g., `assign`,
+  `label`, `folder`), then create the context and link to the course section. Skips the
+  transaction machinery entirely.
+
+## Decision
+
+**Option 3**: Use direct database inserts for course module creation.
+
+The generated PHP code now:
+1. Overrides Moodle's `default_exception_handler` to prevent `exit(1)` on errors — instead,
+   it outputs a JSON error and exits cleanly with `exit(0)`.
+2. Inserts a `course_modules` record with required fields (`course`, `module`, `instance=0`,
+   `section=0`, `visible`, `groupmode`, `groupingid`, `added`).
+3. Inserts a module instance record (e.g., into the `assign` table) with `course`, `name`,
+   `intro`, `introformat`, `timemodified`.
+4. Updates `course_modules.instance` to point to the new instance.
+5. Creates the module context via `context_module::instance($cmid)`.
+6. Links the module to the correct course section via `course_add_cm_to_section()`.
+
+This produces functional course modules visible in the course page. Advanced features
+(calendar events, completion rules, grading setup) are not configured, which is acceptable
+for the playground's provisioning use case.
+
+## Consequences
+
+### Positive
+* **Reliable module creation** — No more crashes from nested savepoints in SQLite WASM.
+* **Simpler code** — The shared `ADD_MODULE_SETUP` and `ADD_MODULE_EXEC` constants in
+  `helpers.js` are reused across all module types (label, folder, assign, generic).
+* **Graceful errors** — The exception handler override ensures errors are reported as
+  JSON output instead of killing the WASM process.
+* **Works with third-party modules** — The generic module path uses the same direct insert
+  approach, so blueprint-installed plugins can also have modules added.
+
+### Negative / Risks
+* **Incomplete module setup** — Calendar events, completion defaults, grading areas, and
+  event dispatching are skipped. Modules work for viewing and basic interaction but may
+  lack some admin-configured features.
+* **Diverges from Moodle API** — If Moodle adds required columns to `course_modules` or
+  module tables in future versions, the direct inserts may need updating.
+* **No file handling** — Modules that require file records at creation time (e.g., resource
+  module with an uploaded file) won't work with this approach. The `intro` field supports
+  text content only.
+
+## Implementation Notes
+
+### Files modified
+- `src/blueprint/php/helpers.js` — Added `ADD_MODULE_SETUP` (exception handler override)
+  and `ADD_MODULE_EXEC` (shared insert logic) constants. Updated `phpAddLabel()`,
+  `phpAddFolder()`, `phpAddAssign()`, `phpAddGenericModule()` to use them instead of
+  `add_moduleinfo()`.
+- `src/blueprint/steps/moodle-modules.js` — Updated `handleAddModule()` with try/catch
+  wrapping and graceful error reporting via `publish()`.
+- `tests/blueprint/php-helpers.test.js` — Updated tests to verify `insert_record` in
+  generated PHP code instead of `add_moduleinfo`.
+
+### Exception handler pattern
+```php
+set_exception_handler(function($e) {
+    while (ob_get_level()) ob_end_clean();
+    echo json_encode(['ok' => false, 'error' => $e->getMessage()]);
+    exit(0);  // Clean exit, not exit(1)
+});
+```
+This pattern is reused in module addition and plugin upgrade steps.
+
+## Review Criteria
+
+- If the Moodle SQLite driver is improved to support nested savepoints (unlikely — it's
+  deprecated), `add_moduleinfo()` could be restored for fuller feature support.
+- If a future Moodle version adds required `NOT NULL` columns to `course_modules`, the
+  insert records in `ADD_MODULE_EXEC` must be updated.
+- If users need completion, calendar, or grading features on provisioned modules, consider
+  adding optional post-insert setup calls that run outside transactions.

--- a/docs/decisions/0004-opcache-tuning-and-runtime-ux-defaults.md
+++ b/docs/decisions/0004-opcache-tuning-and-runtime-ux-defaults.md
@@ -1,0 +1,101 @@
+# ADR-0004 OPcache tuning and runtime UX defaults for WASM
+
+* Status: Accepted
+* Date: 2026-03-27
+
+## Context and Problem
+
+Two separate but related runtime issues affected the playground experience:
+
+**Performance**: PHP in WASM was recompiling every script on every request. In a native
+server, OPcache stores compiled bytecode between requests. The `@php-wasm/web` runtime
+includes OPcache support, but it was not configured. Each Moodle page load executes
+50-100+ PHP files — recompilation on every request adds measurable overhead.
+
+**UX distraction**: Moodle's user tours (interactive guided walkthroughs) activate on
+first visit to the dashboard, course listing, and course pages. In a playground context,
+these tours cover the UI and require dismissal clicks, which is confusing for users who
+are exploring or demoing features — not learning the Moodle UI for the first time.
+
+## Options Considered
+
+### OPcache
+* **Option 1: Do nothing** — Accept the recompilation overhead. Simple but wasteful.
+* **Option 2: Enable OPcache with file-based cache** — Configure OPcache to store
+  compiled bytecode in a MEMFS directory. Since the Moodle source tree is readonly within
+  a session (extracted from ZIP at boot), timestamp validation can be disabled for maximum
+  performance. The cache directory is ephemeral (MEMFS), matching the runtime model.
+
+### User tours
+* **Option 1: Patch tour PHP files at build time** — Remove or disable tour definitions in
+  the Moodle source. Fragile — tours change between versions and the patch would need
+  maintenance per branch.
+* **Option 2: Disable tours via SQL at boot time** — After the install snapshot is loaded,
+  run `UPDATE {tool_usertours_tours} SET enabled = 0`. Simple, version-agnostic, and
+  gracefully handles the case where the table doesn't exist (wrapped in try/catch).
+
+## Decision
+
+**OPcache: Option 2** — Enable OPcache with file-based caching in MEMFS.
+
+**User tours: Option 2** — Disable via SQL at boot time.
+
+### OPcache configuration
+```ini
+opcache.enable = 1
+opcache.file_cache = /internal/shared/opcache
+opcache.file_cache_only = 1
+opcache.max_accelerated_files = 10000
+opcache.memory_consumption = 128
+opcache.interned_strings_buffer = 32
+opcache.validate_timestamps = 0
+opcache.file_cache_consistency_checks = 0
+```
+
+Key choices:
+- `file_cache_only = 1` — Use only the file cache (stored in MEMFS), not shared memory.
+  This avoids SHM-related issues in WASM.
+- `validate_timestamps = 0` — The Moodle bundle is immutable within a session. No need
+  to stat files for changes.
+- `file_cache_consistency_checks = 0` — Skip checksum verification on cached bytecode.
+  The MEMFS cache can't be corrupted by external processes.
+- `max_accelerated_files = 10000` — Moodle has thousands of PHP files.
+
+## Consequences
+
+### Positive
+* **Faster page loads** — Scripts are compiled once, reused across requests within a session.
+  Second page loads are noticeably faster.
+* **Cleaner playground UX** — No tour popups covering the interface on first visit.
+* **Version-agnostic** — Both changes work across all supported Moodle branches without
+  branch-specific patches.
+* **Graceful failures** — Tour disable is wrapped in try/catch. OPcache config is applied
+  via `setPhpIniEntries()` — if the extension isn't available, settings are ignored.
+
+### Negative / Risks
+* **OPcache memory** — Compiled bytecode consumes JS heap memory (via MEMFS). Estimated
+  10-30MB for a full Moodle session. Acceptable given the performance benefit.
+* **No OPcache invalidation** — If runtime patches modify PHP files after boot, OPcache
+  will serve the pre-patch version. Currently mitigated because runtime patches are applied
+  before the first request. If this changes, `opcache_invalidate()` calls would be needed.
+* **User tours disabled unconditionally** — Users who want to see tours for testing/demo
+  purposes cannot re-enable them via the playground UI. Acceptable trade-off since the
+  playground is for exploration, not Moodle onboarding.
+
+## Implementation Notes
+
+### Files modified
+- `src/runtime/config-template.js` — Added OPcache php.ini entries to `createPhpIniEntries()`.
+- `src/runtime/php-loader.js` — Creates `/internal/shared/opcache` directory via
+  `FS.mkdirTree()` during runtime initialization.
+- `src/runtime/bootstrap.js` — Added `UPDATE {tool_usertours_tours} SET enabled = 0`
+  query in the post-install config normalization block, wrapped in try/catch.
+
+## Review Criteria
+
+- If `@php-wasm/web` changes OPcache support or shared memory semantics, review the
+  `file_cache_only` setting.
+- If Moodle versions add new tours that are relevant for playground demos (unlikely),
+  consider making tour disabling configurable via blueprint `runtime` options.
+- If OPcache memory consumption becomes a problem on resource-constrained devices,
+  consider reducing `max_accelerated_files` or `memory_consumption`.

--- a/docs/decisions/0005-resilient-blueprint-step-execution.md
+++ b/docs/decisions/0005-resilient-blueprint-step-execution.md
@@ -1,0 +1,132 @@
+# ADR-0005 Resilient blueprint step execution with graceful error handling
+
+* Status: Accepted
+* Date: 2026-03-27
+
+## Context and Problem
+
+Blueprint steps that execute PHP code (`addModule`, `installMoodlePlugin`, `installTheme`)
+previously threw JavaScript errors on failure, aborting the entire blueprint execution.
+This was problematic for two reasons:
+
+1. **Moodle's exception handler calls `exit(1)`** — When a PHP error occurs during module
+   addition or plugin upgrade, Moodle's `default_exception_handler` calls
+   `abort_all_db_transactions()` and then `die(1)`. The `die(1)` triggers a non-zero exit
+   code in `php.run()`, which throws a JavaScript error. Our PHP try/catch blocks never
+   execute because the exception handler runs first and exits.
+
+2. **All-or-nothing execution** — A single failing step (e.g., one plugin's upgrade
+   crashes) would prevent all subsequent steps from running. In a playground context, it's
+   better to install what we can and report failures than to abort everything.
+
+## Options Considered
+
+* **Option 1: Abort on first error (previous behavior)** — Simple but poor UX. A blueprint
+  that installs 3 plugins and creates 5 modules would fail entirely if the second plugin
+  has an upgrade issue, even though the other steps would succeed independently.
+
+* **Option 2: Override the exception handler + catch JS errors + publish to UI** — Replace
+  Moodle's exception handler in generated PHP code with one that outputs JSON and exits
+  cleanly (`exit(0)` instead of `exit(1)`). Wrap `php.run()` calls in JavaScript try/catch
+  to handle cases where the override doesn't apply (e.g., errors before our handler is
+  registered). Report failures via the `publish()` progress callback instead of throwing.
+
+* **Option 3: Pre-validate before execution** — Check prerequisites (DB schema, module
+  availability, etc.) before running the step. Reduces failures but can't eliminate them
+  — many errors only manifest during execution.
+
+## Decision
+
+**Option 2**: Multi-layer error resilience with progress-based reporting.
+
+The implementation uses three layers of protection:
+
+### Layer 1: PHP exception handler override
+Generated PHP code registers a custom exception handler that outputs JSON and exits
+cleanly:
+```php
+set_exception_handler(function($e) {
+    while (ob_get_level()) ob_end_clean();
+    echo json_encode(['ok' => false, 'error' => $e->getMessage()]);
+    exit(0);
+});
+```
+
+### Layer 2: JavaScript try/catch around `php.run()`
+If the PHP handler doesn't catch the error (e.g., fatal errors, segfaults, or errors
+before the handler is registered), the JavaScript catch block handles it:
+```javascript
+try {
+  result = await php.run(code);
+} catch (err) {
+  // Extract stdout in case it contains success JSON despite non-zero exit
+  const stdout = err.message?.match(/=== Stdout ===\s*([\s\S]*?)(?:=== Stderr|$)/)?.[1];
+  if (stdout?.includes('"ok":true')) return; // Actually succeeded
+  if (publish) publish(`Step failed: ${err.message.slice(0, 200)}`, 0.95);
+  return; // Don't throw — let next step continue
+}
+```
+
+### Layer 3: Response parsing with publish-based reporting
+Even when `php.run()` succeeds, the response is checked for `"ok":false` and PHP stderr
+output. Failures are reported via `publish()` (visible in the progress bar) instead of
+throwing.
+
+## Consequences
+
+### Positive
+* **Blueprint execution continues** — A failing plugin or module doesn't block subsequent
+  steps. Users get as much of their blueprint as possible.
+* **Visible error reporting** — Failures appear in the progress UI as messages, not as
+  silent failures or opaque JS errors.
+* **Handles Moodle's `exit(1)` pattern** — The PHP handler override prevents the most
+  common failure mode. The JS catch handles edge cases.
+* **Stdout recovery** — Even when `php.run()` throws, the stdout may contain `"ok":true`
+  from successful execution before an exit-code mismatch. The catch block checks for this.
+* **Plugin files persist** — For plugin installation, the ZIP is already extracted to the
+  target directory before the upgrade step runs. Even if the upgrade fails, the plugin files
+  are in place and may work after a manual cache purge or page reload.
+
+### Negative / Risks
+* **Silent partial failures** — Users might not notice that a step failed if they don't
+  watch the progress messages. The progress bar is transient. Consider adding a summary
+  log after blueprint execution.
+* **Inconsistent state** — A module with a DB insert but a failed context creation, or a
+  plugin with files but no upgrade, is in an intermediate state. In a playground context
+  this is acceptable; in production it would not be.
+* **Error messages are truncated** — Messages are sliced to 150-300 characters for the
+  progress bar. Full errors go to `console.warn` but the user may not have DevTools open.
+
+## Implementation Notes
+
+### Files modified
+- `src/blueprint/steps/moodle-plugins.js`:
+  - `runMoodleUpgrade()` now wraps `php.run()` in try/catch, reports via `publish()`.
+  - Added `playground_refresh_installed_plugin_cache()` call to register new plugins
+    in the component cache before upgrade.
+  - Clears `allversionshash` config to force upgrade detection.
+  - Calls `upgrade_noncore(true)` unconditionally instead of checking
+    `moodle_needs_upgrading()` first.
+- `src/blueprint/steps/moodle-modules.js`:
+  - `handleAddModule()` wraps `php.run()` in try/catch with stdout recovery.
+  - Removed the old `checkPhpResult()` function that threw on failure.
+- `src/blueprint/php/helpers.js`:
+  - `ADD_MODULE_SETUP` constant includes the exception handler override.
+  - Used by all `phpAdd*()` functions.
+
+### Error handling patterns used
+
+| Layer | Catches | Reports via | Continues? |
+|-------|---------|-------------|------------|
+| PHP handler | Moodle exceptions | JSON in stdout | Yes (`exit(0)`) |
+| JS try/catch | `php.run()` throws | `publish()` | Yes (return) |
+| Response parse | `"ok":false` in JSON | `publish()` | Yes (no throw) |
+
+## Review Criteria
+
+- If a post-execution summary or log panel is added to the playground UI, route step
+  failures there in addition to the progress bar.
+- If blueprint steps gain rollback semantics (undo on failure), the "continue on error"
+  approach would need to record which steps succeeded for selective rollback.
+- If Moodle changes its exception handling (e.g., Moodle 5.x removes
+  `default_exception_handler`), the PHP override may need updating.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,8 @@ Moodle Playground lets you run a full Moodle LMS instance in your browser for le
 
 The runtime is **fully ephemeral**: all state lives in memory and is lost when you close the tab.
 
+Default credentials: username `admin`, password `password`.
+
 ## How it works
 
 The project follows a layered architecture:

--- a/index.html
+++ b/index.html
@@ -28,9 +28,16 @@
             <div class="toolbar-brand" aria-label="Moodle Playground">
               <img src="logo.png" alt="Moodle Playground" class="toolbar-brand__logo">
             </div>
-            <button type="button" id="refresh-button" class="icon-button" aria-label="Refresh page" title="Refresh page">
-              <span aria-hidden="true">↻</span>
-            </button>
+            <div class="nav-buttons">
+              <button type="button" id="home-button" class="icon-button" aria-label="Go to homepage" title="Go to homepage">
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+                  <path d="M2.5 6.5V14h4v-4h3v4h4V6.5L8 2 2.5 6.5Z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round" fill="none"/>
+                </svg>
+              </button>
+              <button type="button" id="refresh-button" class="icon-button" aria-label="Refresh page" title="Refresh page">
+                <span aria-hidden="true">↻</span>
+              </button>
+            </div>
             <div class="address-form__input">
               <input id="address-input" type="text" spellcheck="false" value="/" aria-label="URL inside the Moodle site">
             </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ nav:
   - Getting started: getting-started.md
   - Architecture: architecture.md
   - Blueprint reference: blueprint-json.md
+  - Blueprint gallery: blueprint-gallery.md
   - Development: development.md
   - Troubleshooting: TROUBLESHOOTING.md
   - Known issues: KNOWN-ISSUES.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,15 +12,16 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.7",
+        "@playwright/test": "^1.58.2",
         "concurrently": "^9.2.1",
         "esbuild": "^0.27.4",
         "http-server": "^14.1.1"
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.7.tgz",
-      "integrity": "sha512-vXrgcmNGZ4lpdwZSpMf1hWw1aWS6B+SyeSYKTLrNsiUsAdSRN0J4d/7mF3ogJFbIwFFSOL3wT92Zzxia/d5/ng==",
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.9.tgz",
+      "integrity": "sha512-wvZW92FrwitTcacvCBT8xdAbfbxWfDLwjYMmU3djjqQTh7Ni4ZdiWIT/x5VcZ+RQuxiKzIOzi5D+dcyJDFZMsA==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -34,20 +35,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.4.7",
-        "@biomejs/cli-darwin-x64": "2.4.7",
-        "@biomejs/cli-linux-arm64": "2.4.7",
-        "@biomejs/cli-linux-arm64-musl": "2.4.7",
-        "@biomejs/cli-linux-x64": "2.4.7",
-        "@biomejs/cli-linux-x64-musl": "2.4.7",
-        "@biomejs/cli-win32-arm64": "2.4.7",
-        "@biomejs/cli-win32-x64": "2.4.7"
+        "@biomejs/cli-darwin-arm64": "2.4.9",
+        "@biomejs/cli-darwin-x64": "2.4.9",
+        "@biomejs/cli-linux-arm64": "2.4.9",
+        "@biomejs/cli-linux-arm64-musl": "2.4.9",
+        "@biomejs/cli-linux-x64": "2.4.9",
+        "@biomejs/cli-linux-x64-musl": "2.4.9",
+        "@biomejs/cli-win32-arm64": "2.4.9",
+        "@biomejs/cli-win32-x64": "2.4.9"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.7.tgz",
-      "integrity": "sha512-Oo0cF5mHzmvDmTXw8XSjhCia8K6YrZnk7aCS54+/HxyMdZMruMO3nfpDsrlar/EQWe41r1qrwKiCa2QDYHDzWA==",
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.9.tgz",
+      "integrity": "sha512-d5G8Gf2RpH5pYwiHLPA+UpG3G9TLQu4WM+VK6sfL7K68AmhcEQ9r+nkj/DvR/GYhYox6twsHUtmWWWIKfcfQQA==",
       "cpu": [
         "arm64"
       ],
@@ -62,9 +63,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.7.tgz",
-      "integrity": "sha512-I+cOG3sd/7HdFtvDSnF9QQPrWguUH7zrkIMMykM3PtfWU9soTcS2yRb9Myq6MHmzbeCT08D1UmY+BaiMl5CcoQ==",
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.9.tgz",
+      "integrity": "sha512-LNCLNgqDMG7BLdc3a8aY/dwKPK7+R8/JXJoXjCvZh2gx8KseqBdFDKbhrr7HCWF8SzNhbTaALhTBoh/I6rf9lA==",
       "cpu": [
         "x64"
       ],
@@ -79,13 +80,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.7.tgz",
-      "integrity": "sha512-om6FugwmibzfP/6ALj5WRDVSND4H2G9X0nkI1HZpp2ySf9lW2j0X68oQSaHEnls6666oy4KDsc5RFjT4m0kV0w==",
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.9.tgz",
+      "integrity": "sha512-4adnkAUi6K4C/emPRgYznMOcLlUqZdXWM6aIui4VP4LraE764g6Q4YguygnAUoxKjKIXIWPteKMgRbN0wsgwcg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -96,13 +100,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.7.tgz",
-      "integrity": "sha512-I2NvM9KPb09jWml93O2/5WMfNR7Lee5Latag1JThDRMURVhPX74p9UDnyTw3Ae6cE1DgXfw7sqQgX7rkvpc0vw==",
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.9.tgz",
+      "integrity": "sha512-8RCww5xnPn2wpK4L/QDGDOW0dq80uVWfppPxHIUg6mOs9B6gRmqPp32h1Ls3T8GnW8Wo5A8u7vpTwz4fExN+sw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -113,13 +120,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.7.tgz",
-      "integrity": "sha512-bV8/uo2Tj+gumnk4sUdkerWyCPRabaZdv88IpbmDWARQQoA/Q0YaqPz1a+LSEDIL7OfrnPi9Hq1Llz4ZIGyIQQ==",
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.9.tgz",
+      "integrity": "sha512-L10na7POF0Ks/cgLFNF1ZvIe+X4onLkTi5oP9hY+Rh60Q+7fWzKDDCeGyiHUFf1nGIa9dQOOUPGe2MyYg8nMSQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -130,13 +140,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.7.tgz",
-      "integrity": "sha512-00kx4YrBMU8374zd2wHuRV5wseh0rom5HqRND+vDldJPrWwQw+mzd/d8byI9hPx926CG+vWzq6AeiT7Yi5y59g==",
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.9.tgz",
+      "integrity": "sha512-5TD+WS9v5vzXKzjetF0hgoaNFHMcpQeBUwKKVi3JbG1e9UCrFuUK3Gt185fyTzvRdwYkJJEMqglRPjmesmVv4A==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -147,9 +160,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.7.tgz",
-      "integrity": "sha512-hOUHBMlFCvDhu3WCq6vaBoG0dp0LkWxSEnEEsxxXvOa9TfT6ZBnbh72A/xBM7CBYB7WgwqboetzFEVDnMxelyw==",
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.9.tgz",
+      "integrity": "sha512-aDZr0RBC3sMGJOU10BvG7eZIlWLK/i51HRIfScE2lVhfts2dQTreowLiJJd+UYg/tHKxS470IbzpuKmd0MiD6g==",
       "cpu": [
         "arm64"
       ],
@@ -164,9 +177,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.7.tgz",
-      "integrity": "sha512-qEpGjSkPC3qX4ycbMUthXvi9CkRq7kZpkqMY1OyhmYlYLnANnooDQ7hDerM8+0NJ+DZKVnsIc07h30XOpt7LtQ==",
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.9.tgz",
+      "integrity": "sha512-NS4g/2G9SoQ4ktKtz31pvyc/rmgzlcIDCGU/zWbmHJAqx6gcRj2gj5Q/guXhoWTzCUaQZDIqiCQXHS7BcGYc0w==",
       "cpu": [
         "x64"
       ],
@@ -1136,12 +1149,12 @@
       "license": "MIT"
     },
     "node_modules/@php-wasm/cli-util": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.12.tgz",
-      "integrity": "sha512-DpOeQotdE4QVF0/ynmC1PawelIIzk6DkLuOZ1oF/+S/kXAyrMp8LoAbDGf4Iii8CordDmIOp+Ab2JTllTvEd2Q==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.13.tgz",
+      "integrity": "sha512-vDFDAEmAYHoC/XQZ7/wfQPgOIuPOvFSXBebRQ8S+6ABcDgKbjylQqyXZej4z0sh7n4IJ6ebS1H/vRPywPOK2kw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/util": "3.1.12",
+        "@php-wasm/util": "3.1.13",
         "fast-xml-parser": "^5.5.1",
         "jsonc-parser": "3.3.1"
       },
@@ -1151,15 +1164,15 @@
       }
     },
     "node_modules/@php-wasm/fs-journal": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@php-wasm/fs-journal/-/fs-journal-3.1.12.tgz",
-      "integrity": "sha512-pD4uHyXYwjg4UHXt/xc2mAzcqy14jH9gUM+GUn1FnR2CL3iKJEAIogg/E9ZsYfS920kJDtWaDNbfqi8mGYm0+w==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@php-wasm/fs-journal/-/fs-journal-3.1.13.tgz",
+      "integrity": "sha512-/3lc4soXYjHV3RPNoGBUadB/Qqeur186BXvc+v4i0W8tHEqKndSRwgd7B0NkKuRIAjSrhQViyUFeikdJDvHEjQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.1.12",
-        "@php-wasm/node": "3.1.12",
-        "@php-wasm/universal": "3.1.12",
-        "@php-wasm/util": "3.1.12",
+        "@php-wasm/logger": "3.1.13",
+        "@php-wasm/node": "3.1.13",
+        "@php-wasm/universal": "3.1.13",
+        "@php-wasm/util": "3.1.13",
         "express": "4.22.0",
         "fast-xml-parser": "^5.5.1",
         "fs-ext-extra-prebuilt": "2.2.7",
@@ -1175,12 +1188,12 @@
       }
     },
     "node_modules/@php-wasm/logger": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.12.tgz",
-      "integrity": "sha512-6isXP5+KDaTB11034XGDtYW7/y+5ZhOODAePHs97k52TIvUQn9T0BfKYR1Zbcvdtuh/jy7i2Q3JYlIHTvxBUEg==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.13.tgz",
+      "integrity": "sha512-8wYZtN+9dNvGSf3ttUDEaNDvU680W+FmCFcpXo4U8JLnsySbRivN8RD6lAedJnSpxgXUV83zwlXV2dybK8awVQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/node-polyfills": "3.1.12"
+        "@php-wasm/node-polyfills": "3.1.13"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1188,24 +1201,24 @@
       }
     },
     "node_modules/@php-wasm/node": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.12.tgz",
-      "integrity": "sha512-gOl1VQ+/I39euhU+2GpLsSFDaExdDwAb7INkqMDviXrz7pShAtxG18dezYX7gsKM8Gr0Okdyccv0lE0KsQnGWA==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.13.tgz",
+      "integrity": "sha512-jrNz8C9msy59/X6nJh1JTZvvJZ/wIA2HHUDWYe6sRbMDkvi0CdHnYGAk2g33GMnOwvWFCiQRrDvU/dCcSmCfHw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/cli-util": "3.1.12",
-        "@php-wasm/logger": "3.1.12",
-        "@php-wasm/node-7-4": "3.1.12",
-        "@php-wasm/node-8-0": "3.1.12",
-        "@php-wasm/node-8-1": "3.1.12",
-        "@php-wasm/node-8-2": "3.1.12",
-        "@php-wasm/node-8-3": "3.1.12",
-        "@php-wasm/node-8-4": "3.1.12",
-        "@php-wasm/node-8-5": "3.1.12",
-        "@php-wasm/node-polyfills": "3.1.12",
-        "@php-wasm/universal": "3.1.12",
-        "@php-wasm/util": "3.1.12",
-        "@wp-playground/common": "3.1.12",
+        "@php-wasm/cli-util": "3.1.13",
+        "@php-wasm/logger": "3.1.13",
+        "@php-wasm/node-7-4": "3.1.13",
+        "@php-wasm/node-8-0": "3.1.13",
+        "@php-wasm/node-8-1": "3.1.13",
+        "@php-wasm/node-8-2": "3.1.13",
+        "@php-wasm/node-8-3": "3.1.13",
+        "@php-wasm/node-8-4": "3.1.13",
+        "@php-wasm/node-8-5": "3.1.13",
+        "@php-wasm/node-polyfills": "3.1.13",
+        "@php-wasm/universal": "3.1.13",
+        "@php-wasm/util": "3.1.13",
+        "@wp-playground/common": "3.1.13",
         "express": "4.22.0",
         "fast-xml-parser": "^5.5.1",
         "fs-ext-extra-prebuilt": "2.2.7",
@@ -1221,12 +1234,12 @@
       }
     },
     "node_modules/@php-wasm/node-7-4": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.12.tgz",
-      "integrity": "sha512-5Sb/b8u6J7Q4iDqm0bF0UHj38xqti7K9Xtzf/j54AwOy4lTDfDbnMlw3QOVSxY2iEOLn7qHDGPZc4dAuFmxVrQ==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.13.tgz",
+      "integrity": "sha512-LerA9TcAEKntZYKYPqfPvB39GwLzu8MzsAN/frTzBaSo5ybyLXfccRmvUsrg40m1+bl3zE5agOm77CjbPJ4SEA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.12",
+        "@php-wasm/universal": "3.1.13",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.3"
@@ -1237,12 +1250,12 @@
       }
     },
     "node_modules/@php-wasm/node-8-0": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.12.tgz",
-      "integrity": "sha512-I1OxJJN5Hh9t81TQ73lbRjAP++Uz7uteilGETRqtPQi/kDa2iweYM+vuwLAp1t5DW3XZw0+O0cq2dTzyW9FXwA==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.13.tgz",
+      "integrity": "sha512-7bdkE0KY9Q7taICadOacA0L1GjZ7Pgdrl2kH3Tnp5SWmkTgpcEQTBJJS8XUNo6cGRprw8+z5fJqBNDCpqaIzCg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.12",
+        "@php-wasm/universal": "3.1.13",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.3"
@@ -1253,12 +1266,12 @@
       }
     },
     "node_modules/@php-wasm/node-8-1": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.12.tgz",
-      "integrity": "sha512-CYROT4gdgxbnS3vCrogQMz5sqT2rzeSuNdn7wTDV43uGRyLONfj7jkqjlGalIIe2rVhrP1JIRTMW5Ju+N0OMHg==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.13.tgz",
+      "integrity": "sha512-mdtR4oX0OgD+A+vJejJorBKvoSf73sfxl7A4kVMVnV+VEjFGH+QVlSzkRA3j9szXscZKzdTTeE3bECmrV8jh/w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.12",
+        "@php-wasm/universal": "3.1.13",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.3"
@@ -1269,12 +1282,12 @@
       }
     },
     "node_modules/@php-wasm/node-8-2": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.12.tgz",
-      "integrity": "sha512-nZuHxpptMlTk58L6dDieAp3RVjtd6VHhtV77KANDGFOxp7l+DCxQ77npS2pX5vW9fzl6h6NTMfa9GezZXV1xnA==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.13.tgz",
+      "integrity": "sha512-WoBox5LktTQm6mM2UvTRiSxCyYvdsSUOLuSC/djy17JSxkfyFom/YczbSfzpOz4mNBb/4uNecoHd8ARxMjYWCg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.12",
+        "@php-wasm/universal": "3.1.13",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.3"
@@ -1285,12 +1298,12 @@
       }
     },
     "node_modules/@php-wasm/node-8-3": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.12.tgz",
-      "integrity": "sha512-PzLKJyvPbBzRfDJ15fyIt8xihpisTM15rp1t4HaPhqa5FYGnrh751pkQYEjurzygqh7M4S2k8U+GUy5OS452UQ==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.13.tgz",
+      "integrity": "sha512-SIYOCE87jBqIh4bKId8DvsrQJxY0o9386aZcQBqhH+YRNnpsGKxL1jUeSjYdQy+aJj8CnfVxRKxaed36E54KMw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.12",
+        "@php-wasm/universal": "3.1.13",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.3"
@@ -1301,12 +1314,12 @@
       }
     },
     "node_modules/@php-wasm/node-8-4": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.12.tgz",
-      "integrity": "sha512-52LnvStQ5jm+q8oqyIw0HvDelZkSAIOrArbyO/jUakrLFkUlgvXG8E67uHVsr3x1QUOvFNe2HMTcAdZ5oNLk5A==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.13.tgz",
+      "integrity": "sha512-iQvfRXmVVNaRMxbaOoSdqi0eBm5eljuwHK+C1sz5SfoxcXwe8gszLk04q9n9kK/95UO3PIh55YZwWFOraOLgDA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.12",
+        "@php-wasm/universal": "3.1.13",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.3"
@@ -1317,12 +1330,12 @@
       }
     },
     "node_modules/@php-wasm/node-8-5": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.12.tgz",
-      "integrity": "sha512-6KswpSyMXTLinakkHRnVJZ3ft42g+odM4SlZJJ2rFhgQ4uFTLJ6Pz+WEybHGcIwE7e7Z1+2Ip8g8CBDDuVSRXQ==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.13.tgz",
+      "integrity": "sha512-ob35CoY12XPI0rj6igoiwZS9/WtFjJrcjK1Mxh2vUXcvqRUeQ6x390KWRhTjsldG7HxrmES9T61x5I8M3M0Mlg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.12",
+        "@php-wasm/universal": "3.1.13",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.3"
@@ -1333,19 +1346,19 @@
       }
     },
     "node_modules/@php-wasm/node-polyfills": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-3.1.12.tgz",
-      "integrity": "sha512-PTIojNH3oKnb63M48kZ3k2L5AirRj5pxlPX6BCET6FIqAzBh/KkFrHJE4enynGYQEiJLsgj43MuY/ZqU0c5nPA==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-3.1.13.tgz",
+      "integrity": "sha512-X1MAroRlVkvF40EcNcB9SZL9NRZJSFOKvL/oD5fsvKxcPN45d4IP27aD3ZtkJx4sm3tTD3bD9W/HDt0Phs82Bg==",
       "license": "GPL-2.0-or-later"
     },
     "node_modules/@php-wasm/progress": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.12.tgz",
-      "integrity": "sha512-KZBtzod+P3tQ7yDX70ExMbjEfJRG1ENOcR1wh+1TJXqsXjvqx+Vx5PBKrV9zP7x6yQX5mxqEP2YRrcrt9M3H1w==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.13.tgz",
+      "integrity": "sha512-yL9ny4/1EXIig9v4cB1gtZ+RBUJy+OaJ13D0+VyhY7/c5G3doA3VkxeCxv1qkaWIcvmqY2zBGRmPsBJp5L52vA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.1.12",
-        "@php-wasm/node-polyfills": "3.1.12"
+        "@php-wasm/logger": "3.1.13",
+        "@php-wasm/node-polyfills": "3.1.13"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1353,9 +1366,9 @@
       }
     },
     "node_modules/@php-wasm/scopes": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.12.tgz",
-      "integrity": "sha512-Y0ZoWGJWAfROlnwGf2N1+WbL1NTa0nXrx+aiceOg5jrh5X1yToESI9hnERh0vrV91RHC7IA3GEKX7XtA/M8AxQ==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.13.tgz",
+      "integrity": "sha512-Zf69PJ5qXdOEPpj5glxQuV/fyXP4CKLdPfePGcnx36MiDyfaK0x+GT0yBdOjhFGB7HK32cy4eJPiErvbYZppuQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=20.10.0",
@@ -1363,26 +1376,26 @@
       }
     },
     "node_modules/@php-wasm/stream-compression": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.12.tgz",
-      "integrity": "sha512-9oNPQ4V81SDfCHDEofK8eA69fd0Bbkl0evGVdDlvJLhOJNhjby2auVdDQwlynPGifeNzLAq05uBSPlT4yu7rDw==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.13.tgz",
+      "integrity": "sha512-ScBZJrBYumtIWowuhge3gmUGOrHsTl5SY6Ih6zYdoujULTv0hGrkX50An8G7qiwl8ym3vzv0VaxSYX+jjgIUPQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/node-polyfills": "3.1.12",
-        "@php-wasm/util": "3.1.12"
+        "@php-wasm/node-polyfills": "3.1.13",
+        "@php-wasm/util": "3.1.13"
       }
     },
     "node_modules/@php-wasm/universal": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.12.tgz",
-      "integrity": "sha512-kL12Pwfn1MeofK/9hT5Ilh5mi5XvM9P3pznAEDYSlaa+7zhQ4t/VkONelokrOEswwW2R1i9fd35E/narLCnLjg==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.13.tgz",
+      "integrity": "sha512-1SzLlvDPb0hDp3pHBGofSxGVQMTED3r3WOC0bD7uYgNkd3hj9TOnJ6vl0llgjadxZLld5d2NRWwDydPwD6LXPg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.1.12",
-        "@php-wasm/node-polyfills": "3.1.12",
-        "@php-wasm/progress": "3.1.12",
-        "@php-wasm/stream-compression": "3.1.12",
-        "@php-wasm/util": "3.1.12",
+        "@php-wasm/logger": "3.1.13",
+        "@php-wasm/node-polyfills": "3.1.13",
+        "@php-wasm/progress": "3.1.13",
+        "@php-wasm/stream-compression": "3.1.13",
+        "@php-wasm/util": "3.1.13",
         "ini": "4.1.2"
       },
       "engines": {
@@ -1391,34 +1404,34 @@
       }
     },
     "node_modules/@php-wasm/util": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.12.tgz",
-      "integrity": "sha512-f5LdqCTQGne3MQcu2UJsoG9HBWLmZ8eq+Et6Mdy1ud0K4Y08ssX/ztg8YQIvrxpReCoigrQBVmARObkXB/NdQA==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.13.tgz",
+      "integrity": "sha512-jGUWzZV2A2tNggAoIUhKWOXBw9+03zb9jF+R3c/nsvyd2NdVxUBWb6Q/mVk2syo+KfSuelsJkksohBNXn9PQBQ==",
       "engines": {
         "node": ">=20.10.0",
         "npm": ">=10.2.3"
       }
     },
     "node_modules/@php-wasm/web": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web/-/web-3.1.12.tgz",
-      "integrity": "sha512-liVBu5GcsdH5aMyalTscII8CTtV4l3CfKqjs23wKxLDOmHOsW6fP9uflve23xQE8EcVdbS3TDhUpO7jVd0SudQ==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web/-/web-3.1.13.tgz",
+      "integrity": "sha512-DHNMQGmHlYZvQ8s8eC/svM2yubZxLvLov3ok0yvqjmoz9Uu+DvEJSDpfuKsOnM/uFWphW1mm6BUnViiokxlDZg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/fs-journal": "3.1.12",
-        "@php-wasm/logger": "3.1.12",
-        "@php-wasm/universal": "3.1.12",
-        "@php-wasm/util": "3.1.12",
-        "@php-wasm/web-7-4": "3.1.12",
-        "@php-wasm/web-8-0": "3.1.12",
-        "@php-wasm/web-8-1": "3.1.12",
-        "@php-wasm/web-8-2": "3.1.12",
-        "@php-wasm/web-8-3": "3.1.12",
-        "@php-wasm/web-8-4": "3.1.12",
-        "@php-wasm/web-8-5": "3.1.12",
-        "@php-wasm/web-service-worker": "3.1.12",
-        "@wp-playground/common": "3.1.12",
-        "@wp-playground/storage": "3.1.12",
+        "@php-wasm/fs-journal": "3.1.13",
+        "@php-wasm/logger": "3.1.13",
+        "@php-wasm/universal": "3.1.13",
+        "@php-wasm/util": "3.1.13",
+        "@php-wasm/web-7-4": "3.1.13",
+        "@php-wasm/web-8-0": "3.1.13",
+        "@php-wasm/web-8-1": "3.1.13",
+        "@php-wasm/web-8-2": "3.1.13",
+        "@php-wasm/web-8-3": "3.1.13",
+        "@php-wasm/web-8-4": "3.1.13",
+        "@php-wasm/web-8-5": "3.1.13",
+        "@php-wasm/web-service-worker": "3.1.13",
+        "@wp-playground/common": "3.1.13",
+        "@wp-playground/storage": "3.1.13",
         "@zip.js/zip.js": "2.7.57",
         "async-lock": "1.4.1",
         "clean-git-ref": "2.0.1",
@@ -1447,12 +1460,12 @@
       }
     },
     "node_modules/@php-wasm/web-7-4": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-7-4/-/web-7-4-3.1.12.tgz",
-      "integrity": "sha512-eM6mUTTMJ+LYhpG3LL4pKTg43F9Ung8XqxQFIoxiquGe1klMx4TwV7jny9+sKhHFkQmPLHuuxDxe3KWZxS1OZg==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-7-4/-/web-7-4-3.1.13.tgz",
+      "integrity": "sha512-L+F0TKIHEMKNT4M9V+XdFfwj9YrTYWdXbFspfEhfORd/8hH70oggcJjS4EGWB5auIMOejhY/HhC3IPLYka8jKg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.12",
+        "@php-wasm/universal": "3.1.13",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0"
       },
@@ -1462,12 +1475,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-0": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-0/-/web-8-0-3.1.12.tgz",
-      "integrity": "sha512-UR/z8oVz/3b4o9MPE+TrRRjA7ifxK/SC7xDJ8OCw/EA4dg3dpD8Qffv2J6p+XSXkCZXO77uv/Tggqo3CuQD6sQ==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-0/-/web-8-0-3.1.13.tgz",
+      "integrity": "sha512-qy0jhlFCo+zPkjIT1WTBpYxnTnXFQXg0eLTq7PxUdvSwKg4Ci/6Z8aP/EybOEIHepa7i/IWfjgDpmDfysNPd6w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.12",
+        "@php-wasm/universal": "3.1.13",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0"
       },
@@ -1477,12 +1490,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-1": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-1/-/web-8-1-3.1.12.tgz",
-      "integrity": "sha512-SP3NTWfN8pysnJKdnxNK9tTsRBm+9mNIKcF22HVF/emKVods29wiQ6fQ8IKJK2D/hiDtX77nBw/gCUZInHF2nA==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-1/-/web-8-1-3.1.13.tgz",
+      "integrity": "sha512-puviZEhwkEWihRh0zDGcB7F5WxEYz3AfnTIOrcXpbE3MQsTtHv47OISLenbNe4q4f/KTHoDub0rRjQEaQlpOBw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.12",
+        "@php-wasm/universal": "3.1.13",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0"
       },
@@ -1492,12 +1505,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-2": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-2/-/web-8-2-3.1.12.tgz",
-      "integrity": "sha512-twQBjAc9cwqAGf2DoqTLB1Cx/dpRaJuHQCTU6LS6tCqIE6pT5cg7nwAStpAdmZKcGCerI48V9GVBsrYPgLlKFA==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-2/-/web-8-2-3.1.13.tgz",
+      "integrity": "sha512-DtQHeDNXlfj6K0aUWDovHt7WcZOBSuAGjcRyOSzzR0YI0l9yvYSBLAQP+NXogHw2zMEN+9X0TTqkRExOHZ5Guw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.12",
+        "@php-wasm/universal": "3.1.13",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0"
       },
@@ -1507,12 +1520,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-3": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-3/-/web-8-3-3.1.12.tgz",
-      "integrity": "sha512-+HubIAmQfO3T70vsRZlcZD9hv53o7PFVHa44ZrqizoERxp7A/LX9dRXsXcHSg74lTwMnI3+pE59mf5oa3qQujA==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-3/-/web-8-3-3.1.13.tgz",
+      "integrity": "sha512-smBiVdwtRLP/ba3kapdWkP18NITI9TRJ9jRekRfkvonXBUjhLFOKNEMuwpjBP6A2B2+N0x8mPfIc3BtuBI//Zw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.12",
+        "@php-wasm/universal": "3.1.13",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0"
       },
@@ -1522,12 +1535,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-4": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-4/-/web-8-4-3.1.12.tgz",
-      "integrity": "sha512-u3FXkZLkEBnE0pu/CjybXtw5xsxCp5R/fVUB58NREgUWmqu9fubznGd78ExpQ3/GUWULjRSqc3deUNu6p+/vlA==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-4/-/web-8-4-3.1.13.tgz",
+      "integrity": "sha512-S3866Woot0QGnb3n4qztcHffuNyRQFkfqx4sgiYL05xdD5X1kE08hf7TYCq7hzXZPpu8NypMVe1xHlXWNHEpcQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.12",
+        "@php-wasm/universal": "3.1.13",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0"
       },
@@ -1537,12 +1550,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-5": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-5/-/web-8-5-3.1.12.tgz",
-      "integrity": "sha512-vkCCCApjMyWo+8Hl6loy3KRiNwrceXgowNCHEcWCCZjRSg63D7sEcyP3y1rnqJykPMoeDrR6q7lkIJloouJ0sg==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-5/-/web-8-5-3.1.13.tgz",
+      "integrity": "sha512-e6GE73xH9e307iWaoG0PUEICjYjb/ClxymWSNVqe+XMy7VU5v62FZa4qYfMXcVui8SxLngqtvEDLKQ4dvpupvQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.12",
+        "@php-wasm/universal": "3.1.13",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0"
       },
@@ -1552,18 +1565,34 @@
       }
     },
     "node_modules/@php-wasm/web-service-worker": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.12.tgz",
-      "integrity": "sha512-yOZ48wc9PP3/80hZ8tr7V6DW2Mb11cFflwA1gvH4KFwQ2yB0RgPhVGdLsgVwoAy/lYlDAeW9DHh1f9CqiIBGzg==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.13.tgz",
+      "integrity": "sha512-5p0hNQrZgAnuSWMyPQyhs32gU7nSWJU+q5KNAGvfs77UhZVsVSK0irfTYQbmKsmAPlS5QoNmQXpUCw8fNH9U5w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/scopes": "3.1.12",
-        "@php-wasm/universal": "3.1.12",
+        "@php-wasm/scopes": "3.1.13",
+        "@php-wasm/universal": "3.1.13",
         "ini": "4.1.2"
       },
       "engines": {
         "node": ">=20.10.0",
         "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@types/aws-lambda": {
@@ -1604,13 +1633,13 @@
       }
     },
     "node_modules/@wp-playground/common": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.12.tgz",
-      "integrity": "sha512-UGUaGL3JQB15eBU+yJ6MQAl/dGXr9LKDDsSNwpYRizmzQ3727D99vzOx8LJ4cS3TCSq7W3T6vbfCIbbrT0/SsA==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.13.tgz",
+      "integrity": "sha512-Z9bIxYdJOb5g3IlFKt389vncuG+ZPqTLV6ntb0jG5xjZE2JSda/oX3U+DHjUuqzzcyRTQJ61/dSVBuHsQy8S1A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.12",
-        "@php-wasm/util": "3.1.12",
+        "@php-wasm/universal": "3.1.13",
+        "@php-wasm/util": "3.1.13",
         "ini": "4.1.2"
       },
       "engines": {
@@ -1619,14 +1648,14 @@
       }
     },
     "node_modules/@wp-playground/storage": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.12.tgz",
-      "integrity": "sha512-6ItiAFsUnbj4D1PLQEc6RSooX+WszOgN6s2nhrjYuHqI7QB5YB+4RtVjJYDnHOViSpljslMEaInVF6Y2GvaWuQ==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.13.tgz",
+      "integrity": "sha512-XdwHi9d0Jjqc15WiEmEwilYEKbT2qcjibYCkDeHo8/571IqUokKs9Vt3wombVPTzT2FwUtyDJ72ykbS/Z1n6BQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/stream-compression": "3.1.12",
-        "@php-wasm/universal": "3.1.12",
-        "@php-wasm/util": "3.1.12",
+        "@php-wasm/stream-compression": "3.1.13",
+        "@php-wasm/universal": "3.1.13",
+        "@php-wasm/util": "3.1.13",
         "@zip.js/zip.js": "2.7.57",
         "async-lock": "^1.4.1",
         "clean-git-ref": "^2.0.1",
@@ -2318,9 +2347,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.7",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.7.tgz",
-      "integrity": "sha512-LteOsISQ2GEiDHZch6L9hB0+MLoYVLToR7xotrzU0opCICBkxOPgHAy1HxAvtxfJNXDJpgAsQN30mkrfpO2Prg==",
+      "version": "5.5.9",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz",
+      "integrity": "sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==",
       "funding": [
         {
           "type": "github",
@@ -2330,8 +2359,8 @@
       "license": "MIT",
       "dependencies": {
         "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.1.3",
-        "strnum": "^2.2.0"
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.2"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -2426,6 +2455,21 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -2951,9 +2995,9 @@
       "license": "MIT"
     },
     "node_modules/nan": {
-      "version": "2.26.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.1.tgz",
-      "integrity": "sha512-vodKprLlmaKmraa9E/TxHQwpH4eKYTJbLdeQE49pb9GOmrLs68zESjJu0LQOz1W6JwJmftOWD5Ls4dpd/elQtQ==",
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -3045,9 +3089,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
-      "integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
+      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
       "funding": [
         {
           "type": "github",
@@ -3060,9 +3104,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/pify": {
@@ -3072,6 +3116,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/portfinder": {
@@ -3522,9 +3598,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
-      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
+      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "bundle:all:pretty": "concurrently --names 404,405,500,501,main --prefix name --prefix-colors blue,magenta,green,yellow,cyan \"sh -c 'BRANCH=MOODLE_404_STABLE ./scripts/build-moodle-bundle.sh'\" \"sh -c 'BRANCH=MOODLE_405_STABLE ./scripts/build-moodle-bundle.sh'\" \"sh -c 'BRANCH=MOODLE_500_STABLE ./scripts/build-moodle-bundle.sh'\" \"sh -c 'BRANCH=MOODLE_501_STABLE ./scripts/build-moodle-bundle.sh'\" \"sh -c 'BRANCH=main ./scripts/build-moodle-bundle.sh'\"",
     "bundle": "./scripts/build-moodle-bundle.sh",
     "test": "node --test tests/**/*.test.js",
-    "test:blueprint": "node --test tests/blueprint/*.test.js"
+    "test:blueprint": "node --test tests/blueprint/*.test.js",
+    "test:e2e": "playwright test",
+    "test:e2e:install": "playwright install chromium"
   },
   "dependencies": {
     "@php-wasm/universal": "^3.1.12",
@@ -22,6 +24,7 @@
     "@biomejs/biome": "^2.4.7",
     "concurrently": "^9.2.1",
     "esbuild": "^0.27.4",
+    "@playwright/test": "^1.58.2",
     "http-server": "^14.1.1"
   }
 }

--- a/php-worker.js
+++ b/php-worker.js
@@ -130,6 +130,17 @@ const PLUGIN_TYPE_DIRS = {
   booktool: "mod/book/tool",
   quizaccess: "mod/quiz/accessrule",
   ltisource: "mod/lti/source",
+  workshopform: "mod/workshop/form",
+  workshopallocation: "mod/workshop/allocation",
+  workshopeval: "mod/workshop/eval",
+  contenttype: "contentbank/contenttype",
+  customfield: "customfield/field",
+  media: "media/player",
+  paygw: "payment/gateway",
+  qbank: "question/bank",
+  search: "search/engine",
+  aiprovider: "ai/provider",
+  aiplacement: "ai/placement",
 };
 
 /**
@@ -401,9 +412,13 @@ function deserializeRequest(requestLike) {
   return new Request(requestLike.url, init);
 }
 
+function escapeHtml(str) {
+  return String(str).replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#39;");
+}
+
 function buildLoadingResponse(message, status = 503) {
   return new Response(
-    `<!doctype html><meta charset="utf-8"><title>Moodle Playground</title><body><pre>${message}</pre></body>`,
+    `<!doctype html><meta charset="utf-8"><title>Moodle Playground</title><body><pre>${escapeHtml(message)}</pre></body>`,
     {
       status,
       headers: {
@@ -728,6 +743,12 @@ function installMessageListener() {
       if (params.profile !== undefined) profile = params.profile;
       // Reset any cached runtime state so it boots with the new params
       runtimeStatePromise = null;
+      // Recreate bridge channel if scopeId changed
+      if (params.scopeId !== undefined && bridgeChannel) {
+        bridgeChannel.close();
+        bridgeChannel = new BroadcastChannel(createPhpBridgeChannel(scopeId));
+        installBridgeListener();
+      }
     }
 
     activeBlueprint = event.data.blueprint || null;

--- a/php-worker.js
+++ b/php-worker.js
@@ -565,7 +565,7 @@ async function getRuntimeState() {
     postShell({
       kind: "ready",
       detail: `Moodle bootstrapped for PHP ${phpVersion || "8.3"}${branchMeta ? ` + ${branchMeta.label}` : ""}. [${totalMs}ms total]`,
-      path: bootstrapState.readyPath || activeBlueprint?.landingPage || config.landingPath,
+      path: bootstrapState.readyPath || activeBlueprint?.landingPage || config.landingPath || "/?redirect=0",
     });
 
     return { php };

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,0 +1,27 @@
+import { defineConfig } from "@playwright/test";
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL || "http://127.0.0.1:8085";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: false,
+  timeout: 180_000,
+  expect: {
+    timeout: 30_000,
+  },
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+  },
+  webServer:
+    process.env.PLAYWRIGHT_EXTERNAL_SERVER === "1"
+      ? undefined
+      : {
+          command:
+            "sh -lc 'if [ -f assets/manifests/latest.json ]; then PORT=8085 make serve; else PORT=8085 make up; fi'",
+          url: baseURL,
+          reuseExistingServer: !process.env.CI,
+          timeout: 300_000,
+        },
+  reporter: process.env.CI ? "line" : "list",
+});

--- a/scripts/generate-install-snapshot.sh
+++ b/scripts/generate-install-snapshot.sh
@@ -130,7 +130,7 @@ INSTALL_LOG="$TMPROOT/install.log"
 ${PHP_BIN:-php} -d max_input_vars=5000 "$SOURCE_DIR/admin/cli/install_database.php" \
   --agree-license \
   --adminuser=admin \
-  --adminpass=admin \
+  --adminpass=password \
   --adminemail=admin@example.com \
   --fullname="Moodle Playground" \
   --shortname="Playground" \

--- a/src/blueprint/executor.js
+++ b/src/blueprint/executor.js
@@ -55,6 +55,7 @@ export async function executeBlueprint(blueprint, context) {
     if (!handler) {
       return {
         success: false,
+        landingPage,
         failedStep: `${i + 1}:${stepName}`,
         error: `Unknown step type: ${stepName}`,
       };
@@ -75,6 +76,7 @@ export async function executeBlueprint(blueprint, context) {
       publish(`Blueprint step ${stepName} failed: ${message}`, progress);
       return {
         success: false,
+        landingPage,
         failedStep: `${i + 1}:${stepName}`,
         error: message,
       };

--- a/src/blueprint/parser.js
+++ b/src/blueprint/parser.js
@@ -41,7 +41,9 @@ export function parseBlueprint(input) {
   }
 
   // base64-encoded JSON — typically starts with "ey" (base64 of "{")
-  if (/^[A-Za-z0-9+/=]+$/u.test(trimmed)) {
+  // Accept both standard base64 (+/=) and base64url (-_) variants.
+  // Require minimum length to avoid false positives on short strings like "hello"
+  if (trimmed.length >= 20 && /^[A-Za-z0-9+/=_-]+$/u.test(trimmed)) {
     try {
       const decoded = decodeBase64(trimmed);
       return JSON.parse(decoded);
@@ -78,10 +80,27 @@ function parseDataUrl(dataUrl) {
   }
 }
 
+function normalizeBase64(str) {
+  // Convert base64url to standard base64: - → +, _ → /
+  let b64 = str.replaceAll("-", "+").replaceAll("_", "/");
+  // Add padding if missing
+  const pad = b64.length % 4;
+  if (pad === 2) b64 += "==";
+  else if (pad === 3) b64 += "=";
+  return b64;
+}
+
 function decodeBase64(str) {
+  const normalized = normalizeBase64(str);
   if (typeof atob === "function") {
-    return atob(str);
+    // atob returns Latin-1; decode via Uint8Array for correct UTF-8 handling
+    const binary = atob(normalized);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return new TextDecoder().decode(bytes);
   }
   // Node.js fallback
-  return Buffer.from(str, "base64").toString("utf-8");
+  return Buffer.from(normalized, "base64").toString("utf-8");
 }

--- a/src/blueprint/php/helpers.js
+++ b/src/blueprint/php/helpers.js
@@ -17,6 +17,54 @@ define('CLI_SCRIPT', true);
 require('${MOODLE_ROOT}/config.php');
 `;
 
+// Shared setup for addModule steps.
+// Overrides Moodle's default_exception_handler to prevent exit(1) on DB errors —
+// Moodle's handler calls abort_all_db_transactions() + die(1) which kills the
+// WASM process before our try/catch can capture the error.
+const ADD_MODULE_SETUP = `require_once($CFG->dirroot . '/course/lib.php');
+global $DB;
+set_exception_handler(function($e) {
+    while (ob_get_level()) ob_end_clean();
+    echo json_encode(['ok' => false, 'error' => $e->getMessage()]);
+    exit(0);
+});`;
+
+// Shared execution block — inserts course module records directly.
+// We avoid add_moduleinfo() because it uses delegated transactions that
+// crash in SQLite PDO WASM (nested savepoints + events/calendar/completion
+// writes cause "Error writing to database" + exit(1) via default_exception_handler).
+const ADD_MODULE_EXEC = `
+try {
+    $modid = $DB->get_field('modules', 'id', ['name' => $moduleInfo->modulename], MUST_EXIST);
+
+    $cm = new stdClass();
+    $cm->course = $course->id;
+    $cm->module = $modid;
+    $cm->instance = 0;
+    $cm->section = 0;
+    $cm->visible = $moduleInfo->visible ?? 1;
+    $cm->groupmode = $moduleInfo->groupmode ?? 0;
+    $cm->groupingid = $moduleInfo->groupingid ?? 0;
+    $cm->added = time();
+    $cmid = $DB->insert_record('course_modules', $cm);
+
+    $instance = new stdClass();
+    $instance->course = $course->id;
+    $instance->name = $moduleInfo->name;
+    $instance->intro = $moduleInfo->intro ?? '';
+    $instance->introformat = $moduleInfo->introformat ?? 1;
+    $instance->timemodified = time();
+    $instanceid = $DB->insert_record($moduleInfo->modulename, $instance);
+
+    $DB->set_field('course_modules', 'instance', $instanceid, ['id' => $cmid]);
+    context_module::instance($cmid);
+    course_add_cm_to_section($course, $cmid, $moduleInfo->section);
+
+    echo json_encode(['ok' => true, 'cmid' => $cmid]);
+} catch (\\Throwable $e) {
+    echo json_encode(['ok' => false, 'error' => $e->getMessage()]);
+}`;
+
 export function phpSetConfig(name, value, plugin = null) {
   const pluginArg = plugin ? `'${escapePhp(plugin)}'` : "null";
   return `${CLI_HEADER}
@@ -220,9 +268,7 @@ export function phpAddModule(mod) {
 
 function phpAddLabel(course, section, name, intro) {
   return `${CLI_HEADER}
-require_once($CFG->dirroot . '/course/modlib.php');
-require_once($CFG->dirroot . '/course/lib.php');
-global $DB;
+${ADD_MODULE_SETUP}
 $course = $DB->get_record('course', ['shortname' => '${course}'], '*', MUST_EXIST);
 $moduleInfo = new stdClass();
 $moduleInfo->modulename = 'label';
@@ -235,16 +281,13 @@ $moduleInfo->visible = 1;
 $moduleInfo->cmidnumber = '';
 $moduleInfo->groupmode = 0;
 $moduleInfo->groupingid = 0;
-$cm = add_moduleinfo($moduleInfo, $course);
-echo json_encode(['ok' => true, 'cmid' => $cm->coursemodule]);
+${ADD_MODULE_EXEC}
 `;
 }
 
 function phpAddFolder(course, section, name, intro) {
   return `${CLI_HEADER}
-require_once($CFG->dirroot . '/course/modlib.php');
-require_once($CFG->dirroot . '/course/lib.php');
-global $DB;
+${ADD_MODULE_SETUP}
 $course = $DB->get_record('course', ['shortname' => '${course}'], '*', MUST_EXIST);
 $moduleInfo = new stdClass();
 $moduleInfo->modulename = 'folder';
@@ -259,17 +302,14 @@ $moduleInfo->groupmode = 0;
 $moduleInfo->groupingid = 0;
 $moduleInfo->files = 0;
 $moduleInfo->display = 0;
-$cm = add_moduleinfo($moduleInfo, $course);
-echo json_encode(['ok' => true, 'cmid' => $cm->coursemodule]);
+${ADD_MODULE_EXEC}
 `;
 }
 
 function phpAddAssign(course, section, name, intro) {
   return `${CLI_HEADER}
-require_once($CFG->dirroot . '/course/modlib.php');
-require_once($CFG->dirroot . '/course/lib.php');
+${ADD_MODULE_SETUP}
 require_once($CFG->dirroot . '/mod/assign/lib.php');
-global $DB;
 $course = $DB->get_record('course', ['shortname' => '${course}'], '*', MUST_EXIST);
 $moduleInfo = new stdClass();
 $moduleInfo->modulename = 'assign';
@@ -293,16 +333,13 @@ $moduleInfo->requireallteammemberssubmit = 0;
 $moduleInfo->blindmarking = 0;
 $moduleInfo->markingworkflow = 0;
 $moduleInfo->markingallocation = 0;
-$cm = add_moduleinfo($moduleInfo, $course);
-echo json_encode(['ok' => true, 'cmid' => $cm->coursemodule]);
+${ADD_MODULE_EXEC}
 `;
 }
 
 function phpAddGenericModule(moduleName, course, section, name, intro) {
   return `${CLI_HEADER}
-require_once($CFG->dirroot . '/course/modlib.php');
-require_once($CFG->dirroot . '/course/lib.php');
-global $DB;
+${ADD_MODULE_SETUP}
 $course = $DB->get_record('course', ['shortname' => '${course}'], '*', MUST_EXIST);
 $moduleInfo = new stdClass();
 $moduleInfo->modulename = '${escapePhp(moduleName)}';
@@ -315,8 +352,7 @@ $moduleInfo->visible = 1;
 $moduleInfo->cmidnumber = '';
 $moduleInfo->groupmode = 0;
 $moduleInfo->groupingid = 0;
-$cm = add_moduleinfo($moduleInfo, $course);
-echo json_encode(['ok' => true, 'cmid' => $cm->coursemodule]);
+${ADD_MODULE_EXEC}
 `;
 }
 

--- a/src/blueprint/php/helpers.js
+++ b/src/blueprint/php/helpers.js
@@ -8,8 +8,13 @@
 // script file, so __DIR__ does not resolve to the Moodle directory.
 const MOODLE_ROOT = "/www/moodle";
 
-function escapePhp(value) {
-  return String(value).replaceAll("\\", "\\\\").replaceAll("'", "\\'");
+export function escapePhp(value) {
+  return String(value)
+    .replaceAll("\\", "\\\\")
+    .replaceAll("'", "\\'")
+    .replaceAll("\0", "\\0")
+    .replaceAll("\n", "\\n")
+    .replaceAll("\r", "\\r");
 }
 
 const CLI_HEADER = `<?php
@@ -54,6 +59,15 @@ try {
     $instance->intro = $moduleInfo->intro ?? '';
     $instance->introformat = $moduleInfo->introformat ?? 1;
     $instance->timemodified = time();
+    // Copy module-specific fields (e.g. assign grade, submissiondrafts)
+    // that type-specific generators set on $moduleInfo.
+    $skip = ['modulename','name','intro','introformat','course','section',
+             'visible','cmidnumber','groupmode','groupingid','files','display'];
+    foreach (get_object_vars($moduleInfo) as $k => $v) {
+        if (!isset($instance->$k) && !in_array($k, $skip)) {
+            $instance->$k = $v;
+        }
+    }
     $instanceid = $DB->insert_record($moduleInfo->modulename, $instance);
 
     $DB->set_field('course_modules', 'instance', $instanceid, ['id' => $cmid]);
@@ -203,12 +217,16 @@ echo json_encode(['ok' => true, 'section' => $sectionnum]);
 }
 
 export function phpCreateSections(sections) {
-  const blocks = sections.map(
-    (s, i) => `
+  const blocks = sections.map((s, i) => {
+    const nameEscaped = escapePhp(s.name || "");
+    return `
 $course${i} = $DB->get_record('course', ['shortname' => '${escapePhp(s.course)}'], '*', MUST_EXIST);
 $sec${i} = course_create_section($course${i}->id, ${parseInt(s.position || 0, 10)});
-$results[] = $sec${i};`,
-  );
+if ('${nameEscaped}') {
+    course_update_section($course${i}->id, $sec${i}, ['name' => '${nameEscaped}']);
+}
+$results[] = $sec${i};`;
+  });
 
   return `${CLI_HEADER}
 require_once($CFG->dirroot . '/course/lib.php');
@@ -230,6 +248,7 @@ export function phpEnrolUsers(enrolments) {
 $user${i} = $DB->get_record('user', ['username' => '${escapePhp(e.username)}'], '*', MUST_EXIST);
 $course${i} = $DB->get_record('course', ['shortname' => '${escapePhp(e.course)}'], '*', MUST_EXIST);
 $roleId${i} = $DB->get_field('role', 'id', ['shortname' => '${role}']);
+if (!$roleId${i}) { throw new \\moodle_exception('invalidroleid', 'error', '', '${role}'); }
 enrol_try_internal_enrol($course${i}->id, $user${i}->id, $roleId${i});
 $enrolled[] = ['user' => '${escapePhp(e.username)}', 'course' => '${escapePhp(e.course)}'];`;
   });

--- a/src/blueprint/resolver.js
+++ b/src/blueprint/resolver.js
@@ -1,4 +1,5 @@
 import { parseBlueprint } from "./parser.js";
+import { validateBlueprint } from "./schema.js";
 import { loadBlueprint, saveBlueprint } from "./storage.js";
 
 /**
@@ -52,6 +53,10 @@ export async function resolveBlueprint({
           throw new Error(`HTTP ${response.status}`);
         }
         const blueprint = await response.json();
+        const validation = validateBlueprint(blueprint);
+        if (!validation.valid) {
+          throw new Error(`Invalid blueprint: ${validation.errors.join(", ")}`);
+        }
         console.log("[blueprint] Resolved from ?blueprint-url= param.");
         saveBlueprint(scopeId, blueprint);
         return blueprint;
@@ -80,6 +85,13 @@ export async function resolveBlueprint({
       });
       if (response.ok) {
         const blueprint = await response.json();
+        const validation = validateBlueprint(blueprint);
+        if (!validation.valid) {
+          console.warn(
+            "[blueprint] Default blueprint invalid:",
+            validation.errors,
+          );
+        }
         console.log("[blueprint] Resolved from defaultBlueprintUrl.");
         saveBlueprint(scopeId, blueprint);
         return blueprint;

--- a/src/blueprint/resolver.js
+++ b/src/blueprint/resolver.js
@@ -101,7 +101,7 @@ export async function resolveBlueprint({
 
 function buildMinimalDefault() {
   return {
-    landingPage: "/my/",
+    landingPage: "/?redirect=0",
     preferredVersions: { php: "8.3", moodle: "5.0" },
     constants: {
       ADMIN_USER: "admin",

--- a/src/blueprint/resources.js
+++ b/src/blueprint/resources.js
@@ -88,13 +88,24 @@ export class ResourceRegistry {
       const resolved = this.#appBaseUrl
         ? new URL(descriptor.url, this.#appBaseUrl).toString()
         : descriptor.url;
-      const response = await fetch(resolved);
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 30000);
+      let response;
+      try {
+        response = await fetch(resolved, { signal: controller.signal });
+      } finally {
+        clearTimeout(timeoutId);
+      }
       if (!response.ok) {
         throw new Error(
           `Failed to fetch resource from ${resolved}: ${response.status}`,
         );
       }
-      return new Uint8Array(await response.arrayBuffer());
+      const buffer = await response.arrayBuffer();
+      if (buffer.byteLength > 50 * 1024 * 1024) {
+        throw new Error(`Resource from ${resolved} exceeds 50MB size limit.`);
+      }
+      return new Uint8Array(buffer);
     }
 
     if (descriptor.base64) {

--- a/src/blueprint/steps/check-result.js
+++ b/src/blueprint/steps/check-result.js
@@ -1,0 +1,18 @@
+/**
+ * Shared utility for checking PHP execution results from blueprint steps.
+ *
+ * @param {object} result - The result from php.run()
+ * @param {string} stepName - The step name for error messages
+ */
+export function checkPhpResult(result, stepName) {
+  const text = result?.text || "";
+  const errors = result?.errors || "";
+  if (errors) {
+    console.warn(`[blueprint] ${stepName} PHP errors:`, errors);
+  }
+  if (text?.includes('"ok":false')) {
+    throw new Error(
+      `${stepName}: PHP returned failure: ${text.substring(0, 500)}`,
+    );
+  }
+}

--- a/src/blueprint/steps/filesystem.js
+++ b/src/blueprint/steps/filesystem.js
@@ -1,6 +1,7 @@
 /**
  * Filesystem step handlers: mkdir, rmdir, writeFile, writeFiles, copyFile, moveFile, unzip.
  */
+import { escapePhp } from "../php/helpers.js";
 
 export function registerFilesystemSteps(register) {
   register("mkdir", handleMkdir);
@@ -22,7 +23,7 @@ async function handleMkdir(step, { php }) {
   for (const seg of segments) {
     current += `/${seg}`;
     try {
-      await php.run(`<?php @mkdir('${escapePath(current)}', 0777);`);
+      await php.run(`<?php @mkdir('${escapePhp(current)}', 0777);`);
     } catch {
       /* already exists */
     }
@@ -46,7 +47,7 @@ function rrmdir($dir, $recursive) {
     }
     rmdir($dir);
 }
-rrmdir('${escapePath(path)}', ${recursive});
+rrmdir('${escapePhp(path)}', ${recursive});
 echo json_encode(['ok' => true]);
 `);
 }
@@ -101,7 +102,7 @@ async function handleMoveFile(step, { php }) {
 
   const data = await php.readFile(from);
   await php.writeFile(to, data);
-  await php.run(`<?php @unlink('${escapePath(from)}');`);
+  await php.run(`<?php @unlink('${escapePhp(from)}');`);
 }
 
 async function handleUnzip(step, { php, resources }) {
@@ -109,15 +110,10 @@ async function handleUnzip(step, { php, resources }) {
   if (!destination)
     throw new Error("unzip: 'destination' (or 'path') is required.");
 
-  let zipBytes;
-  if (step.data) {
-    zipBytes =
-      typeof step.data === "string" && step.data.startsWith("@")
-        ? await resources.resolve(step.data)
-        : await resources.resolve(step.data);
-  } else {
+  if (!step.data) {
     throw new Error("unzip: 'data' is required.");
   }
+  const zipBytes = await resources.resolve(step.data);
 
   // Use fflate for decompression
   const { unzipSync } = await import("fflate");
@@ -130,13 +126,9 @@ async function handleUnzip(step, { php, resources }) {
     // Ensure parent directory exists
     const parentDir = fullPath.substring(0, fullPath.lastIndexOf("/"));
     if (parentDir) {
-      await php.run(`<?php @mkdir('${escapePath(parentDir)}', 0777, true);`);
+      await php.run(`<?php @mkdir('${escapePhp(parentDir)}', 0777, true);`);
     }
 
     await php.writeFile(fullPath, entryData);
   }
-}
-
-function escapePath(path) {
-  return String(path).replaceAll("\\", "\\\\").replaceAll("'", "\\'");
 }

--- a/src/blueprint/steps/moodle-categories.js
+++ b/src/blueprint/steps/moodle-categories.js
@@ -1,4 +1,5 @@
 import { phpCreateCategories, phpCreateCategory } from "../php/helpers.js";
+import { checkPhpResult } from "./check-result.js";
 
 export function registerMoodleCategorySteps(register) {
   register("createCategory", handleCreateCategory);
@@ -18,17 +19,4 @@ async function handleCreateCategories(step, { php }) {
   const code = phpCreateCategories(step.categories);
   const result = await php.run(code);
   checkPhpResult(result, "createCategories");
-}
-
-function checkPhpResult(result, stepName) {
-  const text = result?.text || "";
-  const errors = result?.errors || "";
-  if (errors) {
-    console.warn(`[blueprint] ${stepName} PHP errors:`, errors);
-  }
-  if (text?.includes('"ok":false')) {
-    throw new Error(
-      `${stepName}: PHP returned failure: ${text.substring(0, 500)}`,
-    );
-  }
 }

--- a/src/blueprint/steps/moodle-courses.js
+++ b/src/blueprint/steps/moodle-courses.js
@@ -4,6 +4,7 @@ import {
   phpCreateSection,
   phpCreateSections,
 } from "../php/helpers.js";
+import { checkPhpResult } from "./check-result.js";
 
 export function registerMoodleCourseSteps(register) {
   register("createCourse", handleCreateCourse);
@@ -42,17 +43,4 @@ async function handleCreateSections(step, { php }) {
   const code = phpCreateSections(step.sections);
   const result = await php.run(code);
   checkPhpResult(result, "createSections");
-}
-
-function checkPhpResult(result, stepName) {
-  const text = result?.text || "";
-  const errors = result?.errors || "";
-  if (errors) {
-    console.warn(`[blueprint] ${stepName} PHP errors:`, errors);
-  }
-  if (text?.includes('"ok":false')) {
-    throw new Error(
-      `${stepName}: PHP returned failure: ${text.substring(0, 500)}`,
-    );
-  }
 }

--- a/src/blueprint/steps/moodle-enrol.js
+++ b/src/blueprint/steps/moodle-enrol.js
@@ -1,4 +1,5 @@
 import { phpEnrolUser, phpEnrolUsers } from "../php/helpers.js";
+import { checkPhpResult } from "./check-result.js";
 
 export function registerMoodleEnrolSteps(register) {
   register("enrolUser", handleEnrolUser);
@@ -20,17 +21,4 @@ async function handleEnrolUsers(step, { php }) {
   const code = phpEnrolUsers(step.enrolments);
   const result = await php.run(code);
   checkPhpResult(result, "enrolUsers");
-}
-
-function checkPhpResult(result, stepName) {
-  const text = result?.text || "";
-  const errors = result?.errors || "";
-  if (errors) {
-    console.warn(`[blueprint] ${stepName} PHP errors:`, errors);
-  }
-  if (text?.includes('"ok":false')) {
-    throw new Error(
-      `${stepName}: PHP returned failure: ${text.substring(0, 500)}`,
-    );
-  }
 }

--- a/src/blueprint/steps/moodle-install.js
+++ b/src/blueprint/steps/moodle-install.js
@@ -56,20 +56,10 @@ async function handleLogin(step, { php, webRoot }) {
   }
 }
 
-async function writeAndRun(php, webRoot, code) {
-  const scriptPath = `${webRoot || "/www/moodle"}/__blueprint_step.php`;
-  await php.writeFile(scriptPath, new TextEncoder().encode(code));
-  try {
-    const result = await php.run(code);
-    if (result.errors) {
-      console.warn("[blueprint] Step PHP errors:", result.errors);
-    }
-    return result;
-  } finally {
-    try {
-      await php.run(`<?php @unlink('${scriptPath.replaceAll("'", "\\'")}');`);
-    } catch {
-      /* non-fatal */
-    }
+async function writeAndRun(php, _webRoot, code) {
+  const result = await php.run(code);
+  if (result.errors) {
+    console.warn("[blueprint] Step PHP errors:", result.errors);
   }
+  return result;
 }

--- a/src/blueprint/steps/moodle-modules.js
+++ b/src/blueprint/steps/moodle-modules.js
@@ -4,24 +4,39 @@ export function registerMoodleModuleSteps(register) {
   register("addModule", handleAddModule);
 }
 
-async function handleAddModule(step, { php }) {
+async function handleAddModule(step, { php, publish }) {
   if (!step.module) throw new Error("addModule: 'module' type is required.");
   if (!step.course)
     throw new Error("addModule: 'course' shortname is required.");
   const code = phpAddModule(step);
-  const result = await php.run(code);
-  checkPhpResult(result, "addModule");
-}
-
-function checkPhpResult(result, stepName) {
+  let result;
+  try {
+    result = await php.run(code);
+  } catch (err) {
+    // php.run() throws on non-zero exit code. Check stdout for success.
+    const stdout = err.message
+      ?.match(/=== Stdout ===\s*([\s\S]*?)(?:=== Stderr|$)/)?.[1]
+      ?.trim();
+    if (stdout?.includes('"ok":true')) {
+      return;
+    }
+    // Log but don't fail the blueprint — subsequent steps should continue.
+    if (publish)
+      publish(
+        `addModule ${step.module} failed: ${String(err.message || err).slice(0, 150)}`,
+        0.95,
+      );
+    return;
+  }
   const text = result?.text || "";
   const errors = result?.errors || "";
-  if (errors) {
-    console.warn(`[blueprint] ${stepName} PHP errors:`, errors);
-  }
-  if (text?.includes('"ok":false')) {
-    throw new Error(
-      `${stepName}: PHP returned failure: ${text.substring(0, 500)}`,
+  if (errors && publish) {
+    publish(
+      `addModule ${step.module} PHP errors: ${errors.slice(0, 200)}`,
+      0.95,
     );
+  }
+  if (text?.includes('"ok":false') && publish) {
+    publish(`addModule ${step.module} failed: ${text.slice(0, 200)}`, 0.95);
   }
 }

--- a/src/blueprint/steps/moodle-modules.js
+++ b/src/blueprint/steps/moodle-modules.js
@@ -20,13 +20,9 @@ async function handleAddModule(step, { php, publish }) {
     if (stdout?.includes('"ok":true')) {
       return;
     }
-    // Log but don't fail the blueprint — subsequent steps should continue.
-    if (publish)
-      publish(
-        `addModule ${step.module} failed: ${String(err.message || err).slice(0, 150)}`,
-        0.95,
-      );
-    return;
+    const detail = `addModule ${step.module} failed: ${String(err.message || err).slice(0, 150)}`;
+    if (publish) publish(detail, 0.95);
+    throw new Error(detail);
   }
   const text = result?.text || "";
   const errors = result?.errors || "";
@@ -36,7 +32,9 @@ async function handleAddModule(step, { php, publish }) {
       0.95,
     );
   }
-  if (text?.includes('"ok":false') && publish) {
-    publish(`addModule ${step.module} failed: ${text.slice(0, 200)}`, 0.95);
+  if (text?.includes('"ok":false')) {
+    const detail = `addModule ${step.module} failed: ${text.slice(0, 200)}`;
+    if (publish) publish(detail, 0.95);
+    throw new Error(detail);
   }
 }

--- a/src/blueprint/steps/moodle-plugins.js
+++ b/src/blueprint/steps/moodle-plugins.js
@@ -48,24 +48,30 @@ export function registerMoodlePluginSteps(register) {
 }
 
 async function handleInstallMoodlePlugin(step, context) {
-  if (!step.pluginType) {
-    throw new Error("installMoodlePlugin: 'pluginType' is required.");
-  }
   if (!step.url) {
     throw new Error("installMoodlePlugin: 'url' is required.");
   }
 
-  const pluginName =
-    step.pluginName || guessPluginNameFromUrl(step.url, step.pluginType);
+  // Auto-detect pluginType and pluginName from the URL if not provided.
+  // GitHub repos follow the convention: moodle-{type}_{name}
+  const detected = detectPluginTypeAndName(step.url);
+  const pluginType = step.pluginType || detected.type;
+  const pluginName = step.pluginName || detected.name;
+
+  if (!pluginType) {
+    throw new Error(
+      "installMoodlePlugin: 'pluginType' could not be detected from URL. Provide it explicitly.",
+    );
+  }
   if (!pluginName) {
     throw new Error(
-      "installMoodlePlugin: 'pluginName' is required (or could not be guessed from URL).",
+      "installMoodlePlugin: 'pluginName' could not be detected from URL. Provide it explicitly.",
     );
   }
 
-  const targetDir = resolvePluginDir(step.pluginType, pluginName);
+  const targetDir = resolvePluginDir(pluginType, pluginName);
   await installPluginFiles(step.url, targetDir, context);
-  await runMoodleUpgrade(context);
+  await runMoodleUpgrade(pluginType, pluginName, targetDir, context);
   context.onPluginInstalled?.(targetDir);
 }
 
@@ -74,17 +80,17 @@ async function handleInstallTheme(step, context) {
     throw new Error("installTheme: 'url' is required.");
   }
 
-  const pluginName =
-    step.pluginName || guessPluginNameFromUrl(step.url, "theme");
+  const detected = detectPluginTypeAndName(step.url);
+  const pluginName = step.pluginName || detected.name;
   if (!pluginName) {
     throw new Error(
-      "installTheme: 'pluginName' is required (or could not be guessed from URL).",
+      "installTheme: 'pluginName' could not be detected from URL. Provide it explicitly.",
     );
   }
 
   const targetDir = resolvePluginDir("theme", pluginName);
   await installPluginFiles(step.url, targetDir, context);
-  await runMoodleUpgrade(context);
+  await runMoodleUpgrade("theme", pluginName, targetDir, context);
   context.onPluginInstalled?.(targetDir);
 }
 
@@ -290,8 +296,16 @@ async function installViaZipDownload(zipUrl, targetDir, { php, publish }) {
 /**
  * Run Moodle's upgrade process to register the newly installed plugin.
  */
-async function runMoodleUpgrade({ php, publish }) {
+async function runMoodleUpgrade(
+  pluginType,
+  pluginName,
+  targetDir,
+  { php, publish },
+) {
   if (publish) publish("Running Moodle upgrade to register plugin.", 0.945);
+
+  const component = `${pluginType}_${pluginName}`;
+  const safeDir = targetDir.replaceAll("'", "\\'");
 
   const code = `<?php
 define('CLI_SCRIPT', true);
@@ -300,52 +314,87 @@ require_once($CFG->libdir . '/upgradelib.php');
 require_once($CFG->libdir . '/clilib.php');
 require_once($CFG->libdir . '/adminlib.php');
 
-// Reset component cache so new plugin is discovered
+// Register the plugin in the alternative_component_cache.
+// This writes the updated cache file so core_component sees the new plugin.
+\\core_component::playground_refresh_installed_plugin_cache('${component}', '${safeDir}');
+
+// Reset clears in-memory state; next init() re-reads the updated cache file.
 \\core_component::reset();
 if (function_exists('purge_all_caches')) {
     purge_all_caches();
 }
 
-// Run the upgrade
+// Force upgrade detection by clearing the stored hash.
+set_config('allversionshash', '');
+
+// Run the upgrade unconditionally.
 try {
-    if (moodle_needs_upgrading()) {
-        upgrade_noncore(true);
-    }
+    upgrade_noncore(true);
     echo json_encode(['ok' => true]);
 } catch (\\Throwable $e) {
     echo json_encode(['ok' => false, 'error' => $e->getMessage()]);
 }
 `;
 
-  const result = await php.run(code);
+  let result;
+  try {
+    result = await php.run(code);
+  } catch (err) {
+    // php.run() throws on non-zero exit code (e.g. Moodle's
+    // default_exception_handler calls exit(1) before our PHP catch runs).
+    // Log the error but don't fail the blueprint step — the plugin files
+    // are already installed and may work even without a full upgrade.
+    if (publish)
+      publish(
+        `Plugin upgrade crashed: ${String(err.message || err).slice(0, 200)}`,
+        0.95,
+      );
+    return;
+  }
   const text = result?.text || "";
   const errors = result?.errors || "";
-  if (errors) {
-    console.warn("[blueprint] Plugin upgrade PHP errors:", errors);
+  if (errors && publish) {
+    publish(`Plugin upgrade errors: ${errors.slice(0, 300)}`, 0.95);
   }
-  if (text.includes('"ok":false')) {
-    console.warn("[blueprint] Plugin upgrade returned:", text);
+  if (text.includes('"ok":false') && publish) {
+    publish(`Plugin upgrade failed: ${text.slice(0, 200)}`, 0.95);
   }
 }
 
 /**
- * Guess the plugin name from a GitHub ZIP URL.
+ * Detect plugin type and name from a URL.
+ *
+ * GitHub repos follow the convention: moodle-{type}_{name}
+ * Examples:
+ *   moodle-mod_board       → { type: "mod",   name: "board" }
+ *   moodle-block_participants → { type: "block", name: "participants" }
+ *   moodle-local_staticpage   → { type: "local", name: "staticpage" }
+ *
+ * @param {string} url
+ * @returns {{ type: string|null, name: string|null }}
  */
-function guessPluginNameFromUrl(url, pluginType) {
+function detectPluginTypeAndName(url) {
   try {
     const pathname = new URL(url).pathname;
     const repoMatch = pathname.match(/\/([^/]+)\/archive\//);
     if (repoMatch) {
-      const repoName = repoMatch[1];
-      const stripped = repoName
-        .replace(/^moodle-/i, "")
-        .replace(new RegExp(`^${pluginType}_`, "i"), "");
-      if (stripped) return stripped;
+      const repoName = repoMatch[1].replace(/^moodle-/i, "");
+      // Try to split on underscore: type_name
+      const underscoreIdx = repoName.indexOf("_");
+      if (underscoreIdx > 0) {
+        const candidateType = repoName.substring(0, underscoreIdx);
+        const candidateName = repoName.substring(underscoreIdx + 1);
+        if (PLUGIN_TYPE_DIRS[candidateType] && candidateName) {
+          return { type: candidateType, name: candidateName };
+        }
+      }
+      // No recognized type prefix — return name only
+      return { type: null, name: repoName || null };
     }
   } catch {
     // not a valid URL
   }
-  return null;
+  return { type: null, name: null };
 }
 
 function findCommonPrefix(paths) {

--- a/src/blueprint/steps/moodle-plugins.js
+++ b/src/blueprint/steps/moodle-plugins.js
@@ -40,6 +40,17 @@ const PLUGIN_TYPE_DIRS = {
   booktool: "mod/book/tool",
   quizaccess: "mod/quiz/accessrule",
   ltisource: "mod/lti/source",
+  workshopform: "mod/workshop/form",
+  workshopallocation: "mod/workshop/allocation",
+  workshopeval: "mod/workshop/eval",
+  contenttype: "contentbank/contenttype",
+  customfield: "customfield/field",
+  media: "media/player",
+  paygw: "payment/gateway",
+  qbank: "question/bank",
+  search: "search/engine",
+  aiprovider: "ai/provider",
+  aiplacement: "ai/placement",
 };
 
 export function registerMoodlePluginSteps(register) {

--- a/src/blueprint/steps/moodle-users.js
+++ b/src/blueprint/steps/moodle-users.js
@@ -1,4 +1,5 @@
 import { phpCreateUser, phpCreateUsers } from "../php/helpers.js";
+import { checkPhpResult } from "./check-result.js";
 
 export function registerMoodleUserSteps(register) {
   register("createUser", handleCreateUser);
@@ -18,17 +19,4 @@ async function handleCreateUsers(step, { php }) {
   const code = phpCreateUsers(step.users);
   const result = await php.run(code);
   checkPhpResult(result, "createUsers");
-}
-
-function checkPhpResult(result, stepName) {
-  const text = result?.text || "";
-  const errors = result?.errors || "";
-  if (errors) {
-    console.warn(`[blueprint] ${stepName} PHP errors:`, errors);
-  }
-  if (text?.includes('"ok":false')) {
-    throw new Error(
-      `${stepName}: PHP returned failure: ${text.substring(0, 500)}`,
-    );
-  }
 }

--- a/src/runtime/bootstrap.js
+++ b/src/runtime/bootstrap.js
@@ -819,6 +819,19 @@ try {
         $result['set']['adminsetuppending'] = 'unset';
     }
 
+    // Disable user tours — they are distracting in the playground and cover
+    // the UI on first visit to dashboard, courses, and course pages.
+    try {
+        $disabledTours = $DB->execute(
+            "UPDATE {tool_usertours_tours} SET enabled = 0 WHERE enabled = 1"
+        );
+        if ($disabledTours) {
+            $result['set']['usertours'] = 'disabled';
+        }
+    } catch (Throwable $tourError) {
+        $result['warning']['usertours'] = $tourError->getMessage();
+    }
+
     $result['ok'] = true;
 } catch (Throwable $error) {
     $result['error'] = [

--- a/src/runtime/bootstrap.js
+++ b/src/runtime/bootstrap.js
@@ -1763,7 +1763,7 @@ async function loadInstallSnapshot(
     }
   }
 
-  if (!response || !response.ok) {
+  if (!response?.ok) {
     publish("Snapshot not available, falling back to full install.", 0.875);
     return false;
   }
@@ -2433,7 +2433,7 @@ export async function bootstrapMoodle({
   // opens directly to the dashboard, just like WordPress Playground does.
   // If the blueprint already includes a `login` step, skip this hardcoded login.
   const AUTO_LOGIN_PATH = `${webRoot}/__playground_autologin.php`;
-  let readyPath = blueprintLandingPage || "/my/";
+  let readyPath = blueprintLandingPage || blueprint?.landingPage || "/my/";
   if (!hasLoginStep) {
     try {
       publish("Creating admin session for auto-login.", 0.95);

--- a/src/runtime/config-template.js
+++ b/src/runtime/config-template.js
@@ -112,6 +112,17 @@ if (!property_exists($CFG, 'registerauth')) {
 if (!property_exists($CFG, 'langmenu')) {
     $CFG->langmenu = 0;
 }
+// Extend session timeout to 8 hours and disable the JS timeout warning.
+// The runtime is ephemeral (tab close = full reset) so session expiry is
+// irrelevant. The default config makes Moodle's network.js initialize a
+// session-timeout watcher on every page load, logging "Starting Moodle
+// session timeout warning" to the console — noise with no value here.
+if (!property_exists($CFG, 'sessiontimeout')) {
+    $CFG->sessiontimeout = 28800;
+}
+if (!property_exists($CFG, 'sessiontimeoutwarning')) {
+    $CFG->sessiontimeoutwarning = 0;
+}
 
 if (!defined('NO_DEBUG_DISPLAY')) {
     define('NO_DEBUG_DISPLAY', ${Number(debugdisplay) ? "false" : "true"});
@@ -253,5 +264,16 @@ export function createPhpIniEntries({
     upload_tmp_dir: TEMP_ROOT,
     "session.save_handler": "files",
     "session.save_path": `${TEMP_ROOT}/sessions`,
+    // OPcache tuning — use in-memory file cache with a high file limit
+    // and no timestamp checks (the readonly bundle never changes within
+    // a session), so PHP avoids recompiling on every request.
+    "opcache.enable": "1",
+    "opcache.file_cache": "/internal/shared/opcache",
+    "opcache.file_cache_only": "1",
+    "opcache.max_accelerated_files": "10000",
+    "opcache.memory_consumption": "128",
+    "opcache.interned_strings_buffer": "32",
+    "opcache.validate_timestamps": "0",
+    "opcache.file_cache_consistency_checks": "0",
   };
 }

--- a/src/runtime/crash-recovery.js
+++ b/src/runtime/crash-recovery.js
@@ -37,15 +37,25 @@ export function isFatalWasmError(error) {
     return false;
   }
 
+  // Check for actual WebAssembly.RuntimeError instances first
+  if (
+    typeof WebAssembly !== "undefined" &&
+    error instanceof WebAssembly.RuntimeError
+  ) {
+    return true;
+  }
+
   const message = String(error.message || error);
   return (
-    (typeof WebAssembly !== "undefined" &&
-      error instanceof WebAssembly.RuntimeError) ||
     message.includes("memory access out of bounds") ||
-    message.includes("unreachable") ||
-    message.includes("RuntimeError") ||
+    message.includes("table index is out of bounds") ||
+    message.includes("null function or function signature mismatch") ||
+    // Match "unreachable" as a WASM trap keyword
+    /\bunreachable\b/u.test(message) ||
+    // Match wrapped RuntimeError messages from WASM
+    /\bRuntimeError\b/u.test(message) ||
     message.includes("No file descriptors available") ||
-    message.includes("Failed opening required")
+    message.includes("Failed opening required '/internal/shared/")
   );
 }
 

--- a/src/runtime/php-compat.js
+++ b/src/runtime/php-compat.js
@@ -212,18 +212,20 @@ export function wrapPhpInstance(
         PATH_INFO: pathInfo || "",
       };
 
-      // Add HTTP_* headers from the request
+      // Add HTTP_* headers from the request.
+      // Per CGI spec, Content-Type and Content-Length use CONTENT_TYPE and
+      // CONTENT_LENGTH without the HTTP_ prefix (RFC 3875 §4.1.3/4.1.2).
       const headers = req.headers || {};
       for (const [key, value] of Object.entries(headers)) {
-        if (key.toLowerCase() === "host") continue;
-        const envKey = `HTTP_${key.toUpperCase().replace(/-/g, "_")}`;
-        serverVars[envKey] = value;
-        // Also set content-type/content-length without HTTP_ prefix
-        if (key.toLowerCase() === "content-type") {
+        const lowerKey = key.toLowerCase();
+        if (lowerKey === "host") continue;
+        if (lowerKey === "content-type") {
           serverVars.CONTENT_TYPE = value;
-        }
-        if (key.toLowerCase() === "content-length") {
+        } else if (lowerKey === "content-length") {
           serverVars.CONTENT_LENGTH = value;
+        } else {
+          const envKey = `HTTP_${key.toUpperCase().replace(/-/g, "_")}`;
+          serverVars[envKey] = value;
         }
       }
 

--- a/src/runtime/php-loader.js
+++ b/src/runtime/php-loader.js
@@ -72,6 +72,11 @@ export function createPhpRuntime(
       } catch {
         /* exists */
       }
+      try {
+        FS.mkdirTree("/internal/shared/opcache");
+      } catch {
+        /* exists */
+      }
       php.writeFile(CHDIR_FIX_PRELOAD_PATH, createChdirFixPhp());
 
       const absoluteUrl = (appBaseUrl || "http://localhost:8080").replace(

--- a/src/shared/version-resolver.js
+++ b/src/shared/version-resolver.js
@@ -7,7 +7,7 @@ export const MOODLE_BRANCHES = [
   {
     branch: "MOODLE_404_STABLE",
     version: "4.4",
-    label: "Moodle 4.4",
+    label: "Moodle 4.4.x",
     gitRef: "MOODLE_404_STABLE",
     webRoot: "/www/moodle",
     manifestFile: "MOODLE_404_STABLE.json",
@@ -19,7 +19,7 @@ export const MOODLE_BRANCHES = [
   {
     branch: "MOODLE_405_STABLE",
     version: "4.5",
-    label: "Moodle 4.5 (LTS)",
+    label: "Moodle 4.5.x (LTS)",
     gitRef: "MOODLE_405_STABLE",
     webRoot: "/www/moodle",
     manifestFile: "MOODLE_405_STABLE.json",
@@ -31,7 +31,7 @@ export const MOODLE_BRANCHES = [
   {
     branch: "MOODLE_500_STABLE",
     version: "5.0",
-    label: "Moodle 5.0",
+    label: "Moodle 5.0.x",
     gitRef: "MOODLE_500_STABLE",
     webRoot: "/www/moodle",
     manifestFile: "MOODLE_500_STABLE.json",
@@ -43,7 +43,7 @@ export const MOODLE_BRANCHES = [
   {
     branch: "MOODLE_501_STABLE",
     version: "5.1",
-    label: "Moodle 5.1",
+    label: "Moodle 5.1.x",
     gitRef: "MOODLE_501_STABLE",
     webRoot: "/www/moodle/public",
     manifestFile: "MOODLE_501_STABLE.json",
@@ -55,7 +55,7 @@ export const MOODLE_BRANCHES = [
   {
     branch: "main",
     version: "dev",
-    label: "Development (main)",
+    label: "Moodle 5.2dev (main)",
     gitRef: "main",
     webRoot: "/www/moodle/public",
     manifestFile: "main.json",

--- a/src/shell/main.js
+++ b/src/shell/main.js
@@ -1,4 +1,5 @@
 import {
+  clearBlueprint,
   parseBlueprint,
   resolveBlueprint,
   saveBlueprint,
@@ -42,6 +43,7 @@ const els = {
   phpInfoPanel: document.querySelector("#phpinfo-panel"),
   phpInfoTab: document.querySelector("#phpinfo-tab"),
   refreshPhpInfoButton: document.querySelector("#refresh-phpinfo-button"),
+  home: document.querySelector("#home-button"),
   refresh: document.querySelector("#refresh-button"),
   reset: document.querySelector("#reset-button"),
   settingsButton: document.querySelector("#settings-button"),
@@ -67,13 +69,13 @@ let currentPhpVersion = DEFAULT_PHP_VERSION;
 let currentMoodleBranch = null;
 let currentDebugParam = null;
 let currentProfileParam = null;
-let currentPath = "/";
+let currentPath = "/?redirect=0";
 let channel;
 let serviceWorkerReady = null;
 let activeBlueprint;
 let remoteFrameBooted = false;
 let uiLocked = true;
-let remoteReloadToken = 0;
+const remoteReloadToken = 0;
 let pendingCleanBoot = false;
 let latestPhpInfoHtml = "";
 // biome-ignore lint/correctness/noUnusedVariables: reserved for future phpinfo capture tracking
@@ -212,21 +214,6 @@ function refreshWithinRuntime() {
   void updateFrame();
 }
 
-function restartRuntime() {
-  if (uiLocked) {
-    return;
-  }
-
-  pendingCleanBoot = true;
-  remoteReloadToken = Date.now();
-  remoteFrameBooted = false;
-  serviceWorkerReady = null;
-  setUiLocked(true);
-  appendLog(`Restarting runtime for ${currentRuntimeId}`);
-  els.frame.src = "about:blank";
-  void updateFrame();
-}
-
 function setPhpInfoContent(html = "") {
   latestPhpInfoHtml = typeof html === "string" ? html : "";
   if (!els.phpInfoFrame) {
@@ -235,13 +222,33 @@ function setPhpInfoContent(html = "") {
 
   if (!latestPhpInfoHtml) {
     els.phpInfoFrame.srcdoc = `<!doctype html><meta charset="utf-8"><style>
-      body{font:14px/1.5 ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;padding:16px;color:#1f2937;background:#fff}
+      html,body{height:100%}
+      body{margin:0;font:14px/1.5 ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;padding:16px;color:#1f2937;background:#fff;box-sizing:border-box}
       p{margin:0}
     </style><p>No PHP diagnostics captured yet.</p>`;
     return;
   }
 
-  els.phpInfoFrame.srcdoc = latestPhpInfoHtml;
+  const responsivePhpInfoHtml = latestPhpInfoHtml.replace(
+    "</head>",
+    `<style>
+      html,body{height:100%}
+      body{margin:0;padding:12px;box-sizing:border-box;overflow:auto;background:#fff;color:#222;font-family:sans-serif}
+      .center{width:100%}
+      .center table{width:100%;max-width:100%;margin:1em auto;text-align:left}
+      table{border-collapse:collapse;border:0;width:100%;max-width:100%;box-shadow:0 1px 3px rgba(0,0,0,.12);table-layout:auto}
+      td,th{border:1px solid #666;font-size:75%;vertical-align:baseline;padding:4px 5px}
+      th{position:sticky;top:0;background:inherit}
+      .e{width:28%;min-width:180px}
+      .v{max-width:none;overflow-wrap:anywhere;word-break:break-word}
+      hr{width:100%;max-width:100%}
+      img{max-width:100%;height:auto}
+      pre{white-space:pre-wrap;overflow-wrap:anywhere}
+      h1,h2{scroll-margin-top:12px}
+    </style></head>`,
+  );
+
+  els.phpInfoFrame.srcdoc = responsivePhpInfoHtml;
 }
 
 function requestPhpInfoCapture() {
@@ -350,7 +357,7 @@ async function importPayload(file) {
   activeBlueprint = blueprint;
   saveBlueprint(scopeId, activeBlueprint);
   pendingCleanBoot = true;
-  currentPath = activeBlueprint.landingPage || config.landingPath || "/";
+  currentPath = activeBlueprint.landingPage || config.landingPath || "/?redirect=0";
   els.address.value = currentPath;
   updateBlueprintTextarea();
   saveState({ importedBlueprintAt: new Date().toISOString() });
@@ -567,7 +574,7 @@ async function main() {
 
   const previous = loadSessionState(scopeId);
   const preferredPath =
-    activeBlueprint?.landingPage || config.landingPath || "/";
+    activeBlueprint?.landingPage || config.landingPath || "/?redirect=0";
   const shouldBypassSavedLogin =
     config.autologin && previous?.path === "/login";
   const shouldBypassInternalPath = isInternalRuntimePath(previous?.path);
@@ -624,8 +631,12 @@ async function main() {
   await updateFrame();
 }
 
+els.home.addEventListener("click", () => {
+  navigateWithinRuntime("/?redirect=0");
+});
+
 els.refresh.addEventListener("click", () => {
-  restartRuntime();
+  navigateWithinRuntime(currentPath);
 });
 
 els.panelToggle.addEventListener("click", toggleSidePanel);
@@ -680,6 +691,23 @@ els.reset.addEventListener("click", () => {
     return;
   }
   clearScopeSession(scopeId);
+  // Clear the imported blueprint unless it was supplied via URL parameter,
+  // so a plain reset boots without any previously loaded blueprint.
+  const url = new URL(window.location.href);
+  if (
+    !url.searchParams.has("blueprint") &&
+    !url.searchParams.has("blueprint-url")
+  ) {
+    clearBlueprint(scopeId);
+    activeBlueprint = resolveBlueprint({
+      scopeId,
+      location: window.location,
+      defaultBlueprintUrl: config.defaultBlueprintUrl,
+    });
+    updateBlueprintTextarea();
+  }
+  currentPath = activeBlueprint?.landingPage || config.landingPath || "/?redirect=0";
+  els.address.value = currentPath;
   pendingCleanBoot = true;
   remoteFrameBooted = false;
   serviceWorkerReady = null;

--- a/src/shell/main.js
+++ b/src/shell/main.js
@@ -105,6 +105,8 @@ function isInternalRuntimePath(path) {
   return typeof path === "string" && /^\/__[^/]+\.php(?:[?#].*)?$/u.test(path);
 }
 
+const MAX_LOG_ENTRIES = 500;
+
 function appendLog(message, isError = false) {
   const line = `[${new Date().toISOString()}] ${message}`;
   const span = document.createElement("span");
@@ -113,6 +115,10 @@ function appendLog(message, isError = false) {
     span.className = "error";
   }
   els.logPanel.append(span);
+  // Prune oldest entries to prevent unbounded DOM growth
+  while (els.logPanel.childElementCount > MAX_LOG_ENTRIES) {
+    els.logPanel.firstElementChild?.remove();
+  }
   els.logPanel.scrollTop = els.logPanel.scrollHeight;
 }
 
@@ -357,7 +363,8 @@ async function importPayload(file) {
   activeBlueprint = blueprint;
   saveBlueprint(scopeId, activeBlueprint);
   pendingCleanBoot = true;
-  currentPath = activeBlueprint.landingPage || config.landingPath || "/?redirect=0";
+  currentPath =
+    activeBlueprint.landingPage || config.landingPath || "/?redirect=0";
   els.address.value = currentPath;
   updateBlueprintTextarea();
   saveState({ importedBlueprintAt: new Date().toISOString() });
@@ -686,7 +693,7 @@ els.importInput.addEventListener("change", async () => {
   }
 });
 
-els.reset.addEventListener("click", () => {
+els.reset.addEventListener("click", async () => {
   if (uiLocked) {
     return;
   }
@@ -699,14 +706,15 @@ els.reset.addEventListener("click", () => {
     !url.searchParams.has("blueprint-url")
   ) {
     clearBlueprint(scopeId);
-    activeBlueprint = resolveBlueprint({
+    activeBlueprint = await resolveBlueprint({
       scopeId,
       location: window.location,
       defaultBlueprintUrl: config.defaultBlueprintUrl,
     });
     updateBlueprintTextarea();
   }
-  currentPath = activeBlueprint?.landingPage || config.landingPath || "/?redirect=0";
+  currentPath =
+    activeBlueprint?.landingPage || config.landingPath || "/?redirect=0";
   els.address.value = currentPath;
   pendingCleanBoot = true;
   remoteFrameBooted = false;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -231,6 +231,12 @@ button.danger:hover {
 }
 
 /* Toolbar icon buttons (on orange background) */
+.nav-buttons {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
 .browser-toolbar .icon-button {
   width: 36px;
   min-width: 36px;
@@ -551,10 +557,12 @@ button.danger:hover {
 /* ── PHP info frame ───────────────────────────────── */
 .panel-frame {
   width: 100%;
-  min-height: 240px;
+  height: 100%;
+  min-height: 0;
   border: 1px solid var(--border-light);
   border-radius: var(--radius-md);
   background: #fff;
+  display: block;
 }
 
 /* ── Blueprint textarea ───────────────────────────── */

--- a/sw.js
+++ b/sw.js
@@ -1,11 +1,34 @@
 import { createPhpBridgeChannel, createWorkerRequestId } from "./src/shared/protocol.js";
+import { BUILD_VERSION as IMPORTED_BUILD_VERSION } from "./src/generated/build-version.js";
 
 const bridges = new Map();
 const pending = new Map();
 const clientContexts = new Map();
-const BUILD_VERSION = new URL(self.location.href).searchParams.get("build") || "dev";
+// Use the imported build version so that when it changes, the SW file's
+// import tree changes → the browser detects a new SW → installs + activates
+// automatically on page reload. The URL param is a fallback for cache busting.
+const BUILD_VERSION = IMPORTED_BUILD_VERSION || new URL(self.location.href).searchParams.get("build") || "dev";
 const STATIC_CACHE_PREFIX = "moodle-playground-static";
 const STATIC_CACHE_NAME = `${STATIC_CACHE_PREFIX}-${BUILD_VERSION}`;
+
+// Cache for scoped runtime static assets (CSS, JS, images, fonts, etc.)
+// that would otherwise queue through the serial PHP worker bridge.
+// See docs/decisions/0001-sw-level-scoped-static-asset-caching.md
+const SCOPED_STATIC_CACHE = `moodle-playground-scoped-static-${BUILD_VERSION}`;
+const SCOPED_STATIC_RE = /\.(css|js|mjs|woff2?|ttf|otf|eot|png|jpe?g|gif|svg|ico|webp|map)$/iu;
+// PHP scripts that serve cacheable assets with revision numbers in the URL.
+// The revision acts as a natural cache key — when content changes, the URL changes.
+// Excludes pluginfile.php and draftfile.php (user content, not cacheable).
+const CACHEABLE_PHP_ASSET_RE = /\/(theme\/styles\.php|lib\/javascript\.php|theme\/image\.php|theme\/font\.php)\//u;
+
+function isScopedStaticAsset(requestPath) {
+  return SCOPED_STATIC_RE.test(requestPath.split("?")[0]);
+}
+
+function isCacheablePhpAsset(requestPath) {
+  return CACHEABLE_PHP_ASSET_RE.test(requestPath);
+}
+
 const STATIC_PREFIXES = [
   "/assets/",
   "/dist/",
@@ -67,6 +90,7 @@ function isSensitiveStaticPath(pathname) {
     || strippedPathname === "/remote.html"
     || strippedPathname === "/playground.config.json"
     || strippedPathname === "/assets/build-version.json"
+    || strippedPathname === "/src/generated/build-version.js"
     || /^\/assets\/manifests\/[^/]+\.json$/u.test(strippedPathname)
     || strippedPathname.startsWith("/assets/moodle/")
   );
@@ -149,9 +173,13 @@ async function networkFirstStaticFetch(request) {
 
 async function purgeOldStaticCaches() {
   const cacheNames = await caches.keys();
+  const SCOPED_STATIC_PREFIX = "moodle-playground-scoped-static-";
   await Promise.all(
     cacheNames
-      .filter((cacheName) => cacheName.startsWith(`${STATIC_CACHE_PREFIX}-`) && cacheName !== STATIC_CACHE_NAME)
+      .filter((cacheName) =>
+        (cacheName.startsWith(`${STATIC_CACHE_PREFIX}-`) && cacheName !== STATIC_CACHE_NAME)
+        || (cacheName.startsWith(SCOPED_STATIC_PREFIX) && cacheName !== SCOPED_STATIC_CACHE),
+      )
       .map((cacheName) => caches.delete(cacheName)),
   );
 }
@@ -260,15 +288,15 @@ async function resolveScopedRequest(event, url) {
 
   const clientUrl = new URL(client.url);
   const scoped = extractScopedRuntime(clientUrl.pathname);
-  if (!scoped || clientUrl.origin !== url.origin) {
-    return null;
+  if (scoped && clientUrl.origin === url.origin) {
+    return {
+      scopeId: scoped.scopeId,
+      runtimeId: scoped.runtimeId,
+      requestPath: `${strippedPathname}${url.search}`,
+    };
   }
 
-  return {
-    scopeId: scoped.scopeId,
-    runtimeId: scoped.runtimeId,
-    requestPath: `${strippedPathname}${url.search}`,
-  };
+  return null;
 }
 
 async function serializeRequest(request) {
@@ -395,10 +423,39 @@ function rewriteHtmlAttributeUrl(rawValue, { origin, scopeId, runtimeId }) {
 }
 
 function rewriteHtmlDocument(html, scope) {
-  return html.replace(
+  const { origin, scopeId, runtimeId } = scope;
+  const scopedBase = `${origin}${getScopedBasePath(scopeId, runtimeId)}`;
+
+  let result = html.replace(
     /((?:href|src|action|data-[\w-]*url|data-url|data-action)=["'])([^"']*)(["'])/giu,
     (match, prefix, rawValue, suffix) => `${prefix}${rewriteHtmlAttributeUrl(rawValue, scope)}${suffix}`,
   );
+
+  // Rewrite M.cfg.wwwroot in inline <script> blocks so Moodle's JavaScript
+  // (AJAX calls, dynamic navigation) uses the scoped URL instead of the bare
+  // origin. Without this, POST requests to /lib/ajax/service.php bypass the
+  // scoped runtime and hit the static dev server (405 Method Not Allowed).
+  // Moodle JSON-escapes forward slashes in its inline JS config, so we must
+  // match both escaped (http:\/\/host) and unescaped (http://host) forms.
+  const jsonEscapedOrigin = origin.replace(/\//gu, "\\/");
+  const jsonEscapedBase = scopedBase.replace(/\//gu, "\\/");
+  // Match JSON-escaped form: "wwwroot":"http:\/\/localhost:8080"
+  result = result.replaceAll(
+    `"wwwroot":"${jsonEscapedOrigin}"`,
+    `"wwwroot":"${jsonEscapedBase}"`,
+  );
+  // Match unescaped form (if present): "wwwroot":"http://localhost:8080"
+  result = result.replaceAll(
+    `"wwwroot":"${origin}"`,
+    `"wwwroot":"${scopedBase}"`,
+  );
+  // Also rewrite apibase which some Moodle JS uses for REST API calls
+  result = result.replaceAll(
+    `"apibase":"${jsonEscapedOrigin}\\/r.php\\/api"`,
+    `"apibase":"${jsonEscapedBase}\\/r.php\\/api"`,
+  );
+
+  return result;
 }
 
 async function rewriteScopedHtmlResponse(response, scope) {
@@ -446,6 +503,12 @@ function forwardToPhpWorker({ request, scopeId }) {
   });
 }
 
+self.addEventListener("message", (event) => {
+  if (event.data?.kind === "clear-scoped-static-cache") {
+    caches.delete(SCOPED_STATIC_CACHE).catch(() => {});
+  }
+});
+
 self.addEventListener("install", (event) => {
   event.waitUntil(self.skipWaiting());
 });
@@ -467,6 +530,29 @@ self.addEventListener("fetch", (event) => {
     try {
       const url = new URL(event.request.url);
       if (url.origin !== self.location.origin) {
+        // Block moodle.org iframe loads (plugin directory) — the remote
+        // server sets X-Frame-Options: sameorigin which causes console
+        // errors. Return a friendly notice instead.
+        if (url.hostname === "moodle.org" || url.hostname === "www.moodle.org") {
+          return new Response(
+            `<!doctype html><meta charset="utf-8"><style>
+              body{font:14px/1.5 system-ui,sans-serif;margin:0;display:flex;align-items:center;justify-content:center;min-height:100vh;background:#f8f9fa;color:#333;text-align:center;padding:16px}
+              .box{max-width:420px}
+              h3{margin:0 0 8px}
+              p{margin:0 0 12px;color:#555}
+              code{background:#e9ecef;padding:2px 6px;border-radius:4px;font-size:13px}
+            </style>
+            <div class="box">
+              <h3>Moodle Plugin Directory unavailable</h3>
+              <p>The external plugin directory at moodle.org cannot be loaded inside the playground iframe.</p>
+              <p>To install plugins, use the <code>installMoodlePlugin</code> blueprint step with a direct GitHub ZIP URL.</p>
+            </div>`,
+            {
+              status: 200,
+              headers: { "content-type": "text/html; charset=utf-8" },
+            },
+          );
+        }
         return fetch(event.request);
       }
 
@@ -501,6 +587,38 @@ self.addEventListener("fetch", (event) => {
       }
 
       const forwardedUrl = new URL(requestPath, `${url.origin}/`);
+      const pathOnly = requestPath.split("?")[0];
+
+      // Serve cached scoped static assets without hitting the PHP worker queue.
+      // This avoids serializing CSS/JS/image requests through the BroadcastChannel
+      // bridge, significantly improving subsequent page load times.
+      if (
+        event.request.method === "GET"
+        && (isScopedStaticAsset(requestPath) || isCacheablePhpAsset(pathOnly))
+      ) {
+        const scopedCache = await caches.open(SCOPED_STATIC_CACHE);
+        const cacheKey = new URL(requestPath, url.origin).toString();
+        const cached = await scopedCache.match(cacheKey);
+        if (cached) {
+          return cached;
+        }
+
+        // Cache miss — forward to worker, then cache successful non-HTML responses.
+        const fresh = await forwardToPhpWorker({
+          request: buildPhpRequest(event.request, forwardedUrl, earlyBody),
+          runtimeId,
+          scopeId,
+        }).catch((error) => buildErrorResponse(String(error?.stack || error?.message || error)));
+
+        if (fresh.ok) {
+          const contentType = fresh.headers.get("content-type") || "";
+          // Never cache HTML responses — they need URL rewriting and are dynamic.
+          if (!/text\/html|application\/xhtml\+xml/iu.test(contentType)) {
+            scopedCache.put(cacheKey, fresh.clone()).catch(() => {});
+          }
+        }
+        return fresh;
+      }
 
       const response = await forwardToPhpWorker({
         request: buildPhpRequest(event.request, forwardedUrl, earlyBody),

--- a/sw.js
+++ b/sw.js
@@ -184,9 +184,13 @@ async function purgeOldStaticCaches() {
   );
 }
 
+function escapeHtml(str) {
+  return String(str).replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#39;");
+}
+
 function buildErrorResponse(message, status = 500) {
   return new Response(
-    `<!doctype html><meta charset="utf-8"><title>Moodle Playground Error</title><body><pre>${message}</pre></body>`,
+    `<!doctype html><meta charset="utf-8"><title>Moodle Playground Error</title><body><pre>${escapeHtml(message)}</pre></body>`,
     {
       status,
       headers: {
@@ -483,23 +487,19 @@ function buildScopedUrl(url, { scopeId, runtimeId, requestPath }) {
   return new URL(`${scopedPath}`, url.origin);
 }
 
-function forwardToPhpWorker({ request, scopeId }) {
+async function forwardToPhpWorker({ request, scopeId }) {
   const bridge = ensureBridge(scopeId);
   const id = createWorkerRequestId();
+  const serialized = await serializeRequest(request);
 
-  return new Promise(async (resolve) => {
+  return new Promise((resolve) => {
     const timeoutId = self.setTimeout(() => {
       pending.delete(id);
       resolve(buildErrorResponse("PHP worker bridge timed out.", 504));
     }, 300000);
 
     pending.set(id, { resolve, timeoutId });
-
-    bridge.postMessage({
-      kind: "http-request",
-      id,
-      request: await serializeRequest(request),
-    });
+    bridge.postMessage({ kind: "http-request", id, request: serialized });
   });
 }
 
@@ -581,6 +581,15 @@ self.addEventListener("fetch", (event) => {
         clientContexts.set(event.clientId, { scopeId, runtimeId });
       }
 
+      // Prune stale clientContexts entries periodically
+      if (clientContexts.size > 50) {
+        const activeClients = await self.clients.matchAll({ type: "window" });
+        const activeIds = new Set(activeClients.map((c) => c.id));
+        for (const cid of clientContexts.keys()) {
+          if (!activeIds.has(cid)) clientContexts.delete(cid);
+        }
+      }
+
       const directScoped = extractScopedRuntime(url.pathname, url.search);
       if (!directScoped && event.request.mode === "navigate" && event.request.method === "GET") {
         return Response.redirect(buildScopedUrl(url, scopedRequest), 302);
@@ -615,6 +624,14 @@ self.addEventListener("fetch", (event) => {
           // Never cache HTML responses — they need URL rewriting and are dynamic.
           if (!/text\/html|application\/xhtml\+xml/iu.test(contentType)) {
             scopedCache.put(cacheKey, fresh.clone()).catch(() => {});
+            // Evict oldest entries when cache grows too large
+            scopedCache.keys().then((keys) => {
+              if (keys.length > 300) {
+                for (let i = 0; i < keys.length - 300; i++) {
+                  scopedCache.delete(keys[i]).catch(() => {});
+                }
+              }
+            }).catch(() => {});
           }
         }
         return fresh;

--- a/tests/blueprint/moodle-plugins.test.js
+++ b/tests/blueprint/moodle-plugins.test.js
@@ -1,0 +1,197 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { getStepHandler } from "../../src/blueprint/steps/index.js";
+
+describe("installMoodlePlugin step handler", () => {
+  const handler = getStepHandler("installMoodlePlugin");
+
+  it("is registered", () => {
+    assert.ok(handler, "installMoodlePlugin handler should be registered");
+    assert.strictEqual(typeof handler, "function");
+  });
+
+  it("throws if url is missing", async () => {
+    await assert.rejects(() => handler({}, {}), /url.*required/i);
+  });
+
+  it("throws if pluginType cannot be detected from non-GitHub URL", async () => {
+    await assert.rejects(
+      () => handler({ url: "https://example.com/random.zip" }, {}),
+      /pluginType.*could not be detected/i,
+    );
+  });
+
+  it("throws if pluginName cannot be detected from non-GitHub URL", async () => {
+    await assert.rejects(
+      () =>
+        handler(
+          { pluginType: "block", url: "https://example.com/random.zip" },
+          {},
+        ),
+      /pluginName.*could not be detected/i,
+    );
+  });
+});
+
+describe("installTheme step handler", () => {
+  const handler = getStepHandler("installTheme");
+
+  it("is registered", () => {
+    assert.ok(handler, "installTheme handler should be registered");
+    assert.strictEqual(typeof handler, "function");
+  });
+
+  it("throws if url is missing", async () => {
+    await assert.rejects(() => handler({}, {}), /url.*required/i);
+  });
+
+  it("throws if pluginName cannot be detected", async () => {
+    await assert.rejects(
+      () => handler({ url: "https://example.com/random.zip" }, {}),
+      /pluginName.*could not be detected/i,
+    );
+  });
+});
+
+describe("auto-detection of pluginType and pluginName from GitHub URL", () => {
+  const handler = getStepHandler("installMoodlePlugin");
+
+  // These tests verify auto-detection by triggering the handler with URLs
+  // that match the GitHub archive pattern. The handler will fail at the
+  // fetch stage (no network in tests) but we verify it gets past validation.
+  function assertPassesValidation(step) {
+    return assert.rejects(
+      () => handler(step, {}),
+      (err) => {
+        assert.ok(
+          !err.message.includes("pluginType") &&
+            !err.message.includes("pluginName"),
+          `Should auto-detect type and name but got: ${err.message}`,
+        );
+        return true;
+      },
+    );
+  }
+
+  it("detects mod type: moodle-mod_board → mod/board", async () => {
+    await assertPassesValidation({
+      url: "https://github.com/brickfield/moodle-mod_board/archive/refs/heads/MOODLE_405_STABLE.zip",
+    });
+  });
+
+  it("detects block type: moodle-block_participants → block/participants", async () => {
+    await assertPassesValidation({
+      url: "https://github.com/moodlehq/moodle-block_participants/archive/refs/heads/master.zip",
+    });
+  });
+
+  it("detects local type: moodle-local_staticpage → local/staticpage", async () => {
+    await assertPassesValidation({
+      url: "https://github.com/moodle-an-hochschulen/moodle-local_staticpage/archive/refs/heads/MOODLE_404_STABLE.zip",
+    });
+  });
+
+  it("detects from tag URL", async () => {
+    await assertPassesValidation({
+      url: "https://github.com/org/moodle-tool_mytool/archive/refs/tags/v1.0.zip",
+    });
+  });
+
+  it("detects from simple archive URL", async () => {
+    await assertPassesValidation({
+      url: "https://github.com/org/moodle-format_tiles/archive/main.zip",
+    });
+  });
+
+  it("explicit pluginType and pluginName override detection", async () => {
+    await assertPassesValidation({
+      pluginType: "mod",
+      pluginName: "custommod",
+      url: "https://github.com/org/moodle-mod_board/archive/main.zip",
+    });
+  });
+
+  it("explicit pluginType with auto-detected name", async () => {
+    await assertPassesValidation({
+      pluginType: "block",
+      url: "https://github.com/moodlehq/moodle-block_participants/archive/refs/heads/master.zip",
+    });
+  });
+});
+
+describe("plugin type validation", () => {
+  const handler = getStepHandler("installMoodlePlugin");
+
+  it("throws for unknown plugin type", async () => {
+    await assert.rejects(
+      () =>
+        handler(
+          {
+            pluginType: "nonexistent",
+            pluginName: "test",
+            url: "https://github.com/org/moodle-nonexistent_test/archive/refs/heads/main.zip",
+          },
+          {},
+        ),
+      /Unknown plugin type.*nonexistent/i,
+    );
+  });
+});
+
+describe("resolvePluginDir path mapping", () => {
+  const handler = getStepHandler("installMoodlePlugin");
+
+  const testCases = [
+    ["mod", "mymod", "/www/moodle/mod/mymod"],
+    ["block", "myblock", "/www/moodle/blocks/myblock"],
+    ["local", "mylocal", "/www/moodle/local/mylocal"],
+    ["theme", "mytheme", "/www/moodle/theme/mytheme"],
+    ["tool", "mytool", "/www/moodle/admin/tool/mytool"],
+    ["atto", "myatto", "/www/moodle/lib/editor/atto/plugins/myatto"],
+    ["tiny", "mytiny", "/www/moodle/lib/editor/tiny/plugins/mytiny"],
+    ["format", "myformat", "/www/moodle/course/format/myformat"],
+    ["assignfeedback", "myfb", "/www/moodle/mod/assign/feedback/myfb"],
+    ["assignsubmission", "mysub", "/www/moodle/mod/assign/submission/mysub"],
+    ["qtype", "myqtype", "/www/moodle/question/type/myqtype"],
+    ["auth", "myauth", "/www/moodle/auth/myauth"],
+    ["enrol", "myenrol", "/www/moodle/enrol/myenrol"],
+    ["repository", "myrepo", "/www/moodle/repository/myrepo"],
+  ];
+
+  for (const [type, name, expectedDir] of testCases) {
+    it(`${type}/${name} → ${expectedDir}`, async () => {
+      const step = {
+        pluginType: type,
+        pluginName: name,
+        url: "https://example.com/plugin.zip",
+      };
+      await assert.rejects(
+        () => handler(step, {}),
+        (err) => {
+          assert.ok(
+            !err.message.includes("Unknown plugin type"),
+            `Type '${type}' should be valid but got: ${err.message}`,
+          );
+          return true;
+        },
+      );
+    });
+  }
+});
+
+describe("sample blueprint URLs are valid", () => {
+  it("all sample URLs follow GitHub archive format", () => {
+    const urls = [
+      "https://github.com/brickfield/moodle-mod_board/archive/refs/heads/MOODLE_405_STABLE.zip",
+      "https://github.com/moodlehq/moodle-block_participants/archive/refs/heads/master.zip",
+      "https://github.com/moodle-an-hochschulen/moodle-local_staticpage/archive/refs/heads/MOODLE_404_STABLE.zip",
+    ];
+
+    for (const url of urls) {
+      const parsed = new URL(url);
+      assert.strictEqual(parsed.hostname, "github.com");
+      assert.ok(parsed.pathname.includes("/archive/"), `${url}`);
+      assert.ok(parsed.pathname.endsWith(".zip"), `${url}`);
+    }
+  });
+});

--- a/tests/blueprint/php-helpers.test.js
+++ b/tests/blueprint/php-helpers.test.js
@@ -214,8 +214,9 @@ describe("PHP helpers: addModule", () => {
       intro: "<p>Hello</p>",
     });
     assert.ok(script.includes("'label'"));
-    assert.ok(script.includes("add_moduleinfo"));
+    assert.ok(script.includes("insert_record"));
     assert.ok(script.includes("PHYS101"));
+    assert.ok(script.includes("course_add_cm_to_section"));
   });
 
   it("generates assign module code", () => {
@@ -226,6 +227,6 @@ describe("PHP helpers: addModule", () => {
       name: "HW1",
     });
     assert.ok(script.includes("'assign'"));
-    assert.ok(script.includes("add_moduleinfo"));
+    assert.ok(script.includes("insert_record"));
   });
 });

--- a/tests/e2e/blueprint-courses.spec.mjs
+++ b/tests/e2e/blueprint-courses.spec.mjs
@@ -1,0 +1,118 @@
+import { expect, test } from "@playwright/test";
+
+test.describe.configure({ timeout: 180_000 });
+
+function buildBlueprintParam(payload) {
+  return Buffer.from(JSON.stringify(payload)).toString("base64url");
+}
+
+async function waitForRuntimeReady(page) {
+  await expect(page.locator("#address-input")).toBeEnabled({
+    timeout: 120_000,
+  });
+  await expect(page.locator("#site-frame")).toHaveAttribute(
+    "src",
+    /scope=|playground\//,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Blueprint: course creation with users and enrollment
+// ---------------------------------------------------------------------------
+
+test("blueprint creates a course with a user and enrollment", async ({
+  page,
+}) => {
+  const bp = buildBlueprintParam({
+    landingPage: "/course/view.php?id=2",
+    steps: [
+      {
+        step: "installMoodle",
+        options: {
+          adminUser: "admin",
+          adminPass: "password",
+          adminEmail: "admin@example.com",
+          siteName: "E2E Course Test",
+        },
+      },
+      { step: "login", username: "admin" },
+      {
+        step: "createUser",
+        username: "student1",
+        password: "Student1!",
+        email: "student1@example.com",
+        firstname: "Alice",
+        lastname: "Test",
+      },
+      {
+        step: "createCourse",
+        fullname: "E2E Test Course",
+        shortname: "E2ETEST",
+        summary: "Created by Playwright e2e test",
+      },
+      {
+        step: "enrolUser",
+        username: "student1",
+        course: "E2ETEST",
+        role: "student",
+      },
+      {
+        step: "addModule",
+        module: "label",
+        course: "E2ETEST",
+        section: 1,
+        name: "Welcome Label",
+        intro: "<p>Welcome to the E2E test course!</p>",
+      },
+      {
+        step: "addModule",
+        module: "assign",
+        course: "E2ETEST",
+        section: 1,
+        name: "E2E Assignment",
+        intro: "This assignment was created by the Playwright e2e test suite.",
+      },
+      { step: "setLandingPage", path: "/course/view.php?id=2" },
+    ],
+  });
+
+  // Capture browser console for debugging
+  const consoleLogs = [];
+  page.on("console", (msg) =>
+    consoleLogs.push(`[${msg.type()}] ${msg.text()}`),
+  );
+
+  await page.goto(`/?blueprint=${bp}`);
+  await waitForRuntimeReady(page);
+
+  // Dump runtime logs for debugging if address doesn't match
+  const address = await page.locator("#address-input").inputValue();
+  if (!address.includes("/course/view.php")) {
+    await page.locator("#panel-toggle-button").click();
+    await page.locator("#logs-tab").click();
+    const runtimeLogs = await page.locator("#log-panel").textContent();
+    console.log("=== RUNTIME LOGS (last 3000 chars) ===");
+    console.log(runtimeLogs.slice(-3000));
+    console.log("=== BROWSER CONSOLE (last 30 lines) ===");
+    for (const line of consoleLogs.slice(-30)) console.log(line);
+    console.log("=== ADDRESS BAR ===", address);
+  }
+
+  // Verify the address bar shows the course view
+  expect(address).toContain("/course/view.php");
+
+  // Verify the blueprint tab contains our custom data
+  await page.locator("#panel-toggle-button").click();
+  await page.locator("#blueprint-tab").click();
+  await expect(page.locator("#blueprint-textarea")).toHaveValue(
+    /E2E Test Course/,
+  );
+  await expect(page.locator("#blueprint-textarea")).toHaveValue(
+    /E2E Assignment/,
+  );
+
+  // Verify logs show successful bootstrap
+  await page.locator("#logs-tab").click();
+  const logText = await page.locator("#log-panel").textContent();
+  expect(logText).toContain("Moodle");
+});

--- a/tests/e2e/moodle-boot.spec.mjs
+++ b/tests/e2e/moodle-boot.spec.mjs
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test";
+
+test.describe.configure({ timeout: 180_000 });
+
+async function waitForRuntimeReady(page) {
+  await expect(page.locator("#address-input")).toBeEnabled({
+    timeout: 120_000,
+  });
+  await expect(page.locator("#site-frame")).toHaveAttribute(
+    "src",
+    /scope=|playground\//,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Moodle runtime boot tests
+// ---------------------------------------------------------------------------
+
+test("Moodle dashboard loads after boot", async ({ page }) => {
+  await page.goto("/");
+  await waitForRuntimeReady(page);
+
+  // The address should point to a Moodle page
+  const address = await page.locator("#address-input").inputValue();
+  expect(address).toMatch(/^\//);
+});
+
+test("PHP Info tab captures runtime diagnostics", async ({ page }) => {
+  await page.goto("/");
+  await waitForRuntimeReady(page);
+
+  await page.locator("#panel-toggle-button").click();
+  await page.locator("#phpinfo-tab").click();
+
+  // Click refresh to capture PHP info
+  await page.locator("#refresh-phpinfo-button").click();
+
+  // Wait for the phpinfo frame to contain PHP version info
+  const phpinfoFrame = page.locator("#phpinfo-frame");
+  await expect(phpinfoFrame).toHaveAttribute("srcdoc", /PHP Version/, {
+    timeout: 30_000,
+  });
+});

--- a/tests/e2e/shell.spec.mjs
+++ b/tests/e2e/shell.spec.mjs
@@ -1,0 +1,156 @@
+import { expect, test } from "@playwright/test";
+
+test.describe.configure({ timeout: 180_000 });
+
+/**
+ * Encode a blueprint object as base64 for the ?blueprint= query param.
+ */
+function buildBlueprintParam(overrides = {}) {
+  const payload = {
+    landingPage: "/my/",
+    preferredVersions: { php: "8.3", moodle: "5.0" },
+    steps: [
+      {
+        step: "installMoodle",
+        options: {
+          adminUser: "admin",
+          adminPass: "password",
+          adminEmail: "admin@example.com",
+          siteName: "Playwright E2E",
+        },
+      },
+      { step: "login", username: "admin" },
+      { step: "setLandingPage", path: "/my/" },
+    ],
+    ...overrides,
+  };
+
+  return Buffer.from(JSON.stringify(payload)).toString("base64url");
+}
+
+/**
+ * Wait until the Moodle runtime has fully booted:
+ * - address bar is enabled (UI unlocked)
+ * - site-frame has a src pointing to the scoped runtime
+ */
+async function waitForRuntimeReady(page) {
+  await expect(page.locator("#address-input")).toBeEnabled({
+    timeout: 120_000,
+  });
+  await expect(page.locator("#site-frame")).toHaveAttribute(
+    "src",
+    /scope=|playground\//,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shell UI tests
+// ---------------------------------------------------------------------------
+
+test("loads the shell and boots the Moodle runtime", async ({ page }) => {
+  await page.goto("/");
+  await waitForRuntimeReady(page);
+
+  // The address bar should show a Moodle path after boot
+  const address = await page.locator("#address-input").inputValue();
+  expect(address).toBeTruthy();
+  expect(address.startsWith("/")).toBe(true);
+});
+
+test("side panel opens and shows tabs", async ({ page }) => {
+  await page.goto("/");
+  await waitForRuntimeReady(page);
+
+  // Panel starts collapsed
+  await expect(page.locator("#panel-toggle-button")).toHaveAttribute(
+    "aria-expanded",
+    "false",
+  );
+
+  // Open panel
+  await page.locator("#panel-toggle-button").click();
+  await expect(page.locator("#panel-toggle-button")).toHaveAttribute(
+    "aria-expanded",
+    "true",
+  );
+  await expect(page.locator("#side-panel")).not.toHaveClass(/is-collapsed/);
+
+  // Info tab shows version labels
+  await expect(page.locator("#current-moodle-label")).not.toHaveText("-");
+  await expect(page.locator("#current-php-label")).not.toHaveText("-");
+  await expect(page.locator("#current-runtime-label")).not.toHaveText("-");
+});
+
+test("logs tab displays runtime log entries", async ({ page }) => {
+  await page.goto("/");
+  await waitForRuntimeReady(page);
+
+  await page.locator("#panel-toggle-button").click();
+  await page.locator("#logs-tab").click();
+  await expect(page.locator("#log-panel")).toBeVisible();
+
+  // The log panel should have at least one entry from the bootstrap
+  const logText = await page.locator("#log-panel").textContent();
+  expect(logText.length).toBeGreaterThan(0);
+});
+
+test("blueprint tab shows the active blueprint JSON", async ({ page }) => {
+  await page.goto("/");
+  await waitForRuntimeReady(page);
+
+  await page.locator("#panel-toggle-button").click();
+  await page.locator("#blueprint-tab").click();
+  await expect(page.locator("#blueprint-textarea")).toBeVisible();
+
+  const blueprintText = await page.locator("#blueprint-textarea").inputValue();
+  expect(blueprintText).toContain('"steps"');
+  expect(blueprintText).toContain('"installMoodle"');
+});
+
+test("settings popover opens and shows version selectors", async ({ page }) => {
+  await page.goto("/");
+  await waitForRuntimeReady(page);
+
+  await page.locator("#settings-button").click();
+  await expect(page.locator("#settings-popover")).toHaveClass(/is-open/);
+
+  const moodleOptions = await page
+    .locator("#settings-moodle-version option")
+    .count();
+  expect(moodleOptions).toBeGreaterThan(0);
+
+  const phpOptions = await page.locator("#settings-php-version option").count();
+  expect(phpOptions).toBeGreaterThan(0);
+});
+
+// ---------------------------------------------------------------------------
+// Blueprint override test
+// ---------------------------------------------------------------------------
+
+test("accepts blueprint via ?blueprint= query param", async ({ page }) => {
+  const bp = buildBlueprintParam({
+    steps: [
+      {
+        step: "installMoodle",
+        options: {
+          adminUser: "admin",
+          adminPass: "password",
+          adminEmail: "admin@example.com",
+          siteName: "E2E Custom Site",
+        },
+      },
+      { step: "login", username: "admin" },
+      { step: "setLandingPage", path: "/my/" },
+    ],
+  });
+
+  await page.goto(`/?blueprint=${bp}`);
+  await waitForRuntimeReady(page);
+
+  // Blueprint tab should contain our custom site name
+  await page.locator("#panel-toggle-button").click();
+  await page.locator("#blueprint-tab").click();
+  await expect(page.locator("#blueprint-textarea")).toHaveValue(
+    /E2E Custom Site/,
+  );
+});

--- a/tests/shared/version-resolver.test.js
+++ b/tests/shared/version-resolver.test.js
@@ -24,7 +24,7 @@ describe("getBranchMetadata", () => {
     const meta = getBranchMetadata("MOODLE_500_STABLE");
     assert.ok(meta);
     assert.strictEqual(meta.version, "5.0");
-    assert.strictEqual(meta.label, "Moodle 5.0");
+    assert.strictEqual(meta.label, "Moodle 5.0.x");
   });
 
   it("returns null for unknown branch", () => {


### PR DESCRIPTION
## Summary

Comprehensive code quality improvements driven by specialist AI agent analysis, plus new testing infrastructure and documentation.

### Agent Skills (6 new)
- **moodle-internals** — Moodle APIs, plugin system, DB schema, SQLite compatibility
- **wp-playground-php-wasm** — @php-wasm runtime, PHP lifecycle, MEMFS, php-compat adapter
- **wasm-browser-runtime** — WASM crashes, service worker routing, crash recovery
- **blueprint-provisioning** — Blueprint JSON, step handlers, PHP code generation
- **unit-testing** — node:test patterns, mocking, test conventions
- **e2e-playwright** — Playwright e2e, WASM boot waits, iframe handling

### Critical Bug Fixes
- Assign module fields (grade, submissiondrafts, etc.) now propagated to DB insert
- XSS in error HTML responses — added `escapeHtml()` to sw.js and php-worker.js
- `escapePhp()` now escapes null bytes, newlines, and carriage returns
- Blueprint `landingPage` preserved on step failure (executor + bootstrap fallback)
- Blueprint parser accepts base64url encoding (fixes `?blueprint=` with URL-safe base64)

### Medium Bug Fixes
- BroadcastChannel recreated when scopeId changes in configure-blueprint
- `isFatalWasmError()` uses `instanceof WebAssembly.RuntimeError` first
- Promise constructor anti-pattern fixed in `forwardToPhpWorker`
- `resolveBlueprint` properly awaited on reset
- CGI spec compliance: `CONTENT_TYPE`/`CONTENT_LENGTH` without `HTTP_` prefix
- Role lookup validation added in enrollment
- URL resource fetch timeout (30s) and size limit (50MB)
- Remote blueprints validated before use
- Log panel capped at 500 entries, scoped cache evicts at 300 entries
- `clientContexts` map pruned when exceeding 50 entries

### Code Quality
- `checkPhpResult()` deduplicated from 4 files into shared `check-result.js`
- `escapePath()` replaced with shared `escapePhp()` from helpers
- 13 missing plugin types added to `PLUGIN_TYPE_DIRS`
- Dead code removed (`writeAndRun` file write, redundant unzip branch)
- Biome config migrated to 2.4.9

### E2E Tests (Playwright)
- `playwright.config.mjs` with auto-start dev server on port 8085
- `shell.spec.mjs` — 6 tests: boot, panels, tabs, settings, blueprint param
- `moodle-boot.spec.mjs` — 2 tests: dashboard load, PHP Info capture
- `blueprint-courses.spec.mjs` — 1 test: full course with users, enrollment, modules
- CI workflow updated to install Chromium and run e2e tests

### Blueprint Gallery
- 3 new examples: `plugin-exeweb`, `classroom-ready`, `plugin-showcase`
- `docs/blueprint-gallery.md` documenting all 6 examples
- Added to mkdocs navigation

## Test plan
- [x] `make test` — 286 unit tests pass
- [x] `make lint` — 0 errors, 0 warnings
- [x] `make test-e2e` — 9 e2e tests (8 pass, 1 requires fresh bundle with assign fix)
- [ ] Manual: verify assign module has grade/settings in course view
- [ ] Manual: verify `<script>` in error URLs is HTML-escaped