### PR TITLE
Improve WASM runtime, blueprint provisioning, and E2E test quality

### DIFF
--- a/.agents/skills/e2e-playwright/SKILL.md
+++ b/.agents/skills/e2e-playwright/SKILL.md
@@ -176,9 +176,7 @@ async function waitForNavigation(page, pathPattern) {
 The standard pattern for testing blueprint execution:
 
 ```javascript
-function buildBlueprintParam(payload) {
-  return Buffer.from(JSON.stringify(payload)).toString("base64url");
-}
+import { buildBlueprintParam } from "./helpers.mjs";
 
 test("blueprint does X", async ({ page }) => {
   const bp = buildBlueprintParam({

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
           - browser: chromium
             workers: 2
           - browser: firefox
-            workers: 1
+            workers: 2
     steps:
       - uses: actions/checkout@v6
 

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
   "linter": {
     "enabled": true,
     "rules": {

--- a/docs/research/php-process-manager-evaluation.md
+++ b/docs/research/php-process-manager-evaluation.md
@@ -1,0 +1,107 @@
+# PHP Process Manager & rotatePHPRuntime Evaluation
+
+## What rotatePHPRuntime does
+
+`rotatePHPRuntime` (from `@php-wasm/universal`) is a thin helper that calls
+`php.enableRuntimeRotation({ recreateRuntime, maxRequests })` on a PHP instance.
+It sets up *proactive* rotation: after a configurable number of requests
+(default 400), the PHP runtime is automatically discarded and a fresh one is
+created by calling the user-supplied `recreateRuntime()` callback.
+
+The underlying machinery consists of three methods on the `PHP` class:
+
+| Method | Purpose |
+|--------|---------|
+| `enableRuntimeRotation(opts)` | Marks the instance for rotation; stores `recreateRuntime` callback and `maxRequests` threshold |
+| `rotateRuntime()` | Calls `recreateRuntime()` then delegates to `hotSwapPHPRuntime()` |
+| `hotSwapPHPRuntime(newRuntime)` | Copies MEMFS nodes from the old Emscripten instance to the new one, restores mount handlers and CWD, then calls `this.exit()` on the old runtime |
+
+The key mechanic in `hotSwapPHPRuntime` is a **live MEMFS copy**: it walks the
+top-level directories of the old filesystem and calls `copyMEMFSNodes(oldFS,
+newFS, path)` for each. This means the entire in-memory filesystem — including
+the SQLite database file, plugin files, and moodledata — is transferred to the
+new runtime automatically.
+
+## What PHPProcessManager does
+
+`PHPProcessManager` is a concurrency pool. It maintains up to `maxPhpInstances`
+(default 2) live PHP instances. Callers call `acquirePHPInstance()` to get a
+`{ php, reap }` pair and must call `reap()` when done to return the instance to
+the idle pool. If all instances are busy, callers wait on a semaphore with a
+30 s timeout (raises `MaxPhpInstancesError` on expiry).
+
+It is designed for **WordPress Playground's request-per-instance concurrency
+model**, where multiple simultaneous HTTP requests may each need a dedicated PHP
+process. It does not handle crash recovery itself.
+
+## Fit with our crash recovery model
+
+Our crash recovery model (in `src/runtime/crash-recovery.js` and
+`php-worker.js`) is:
+
+1. Detect a fatal WASM error during request handling.
+2. **Snapshot** the DB file and tracked plugin files from MEMFS *before*
+   destroying the crashed runtime (MEMFS lives in JS heap and remains readable
+   even when WASM linear memory is corrupted).
+3. Null out `runtimeStatePromise` so the next request triggers a full
+   `bootstrapMoodle()` on a fresh runtime.
+4. **Restore** the DB and plugin files onto the fresh runtime after bootstrap.
+5. Re-register plugins via Moodle's upgrade runner.
+6. Replay safe (GET/HEAD) requests once.
+
+### Why rotatePHPRuntime/hotSwapPHPRuntime does NOT fit
+
+`hotSwapPHPRuntime` performs a **live MEMFS copy** from old to new runtime.
+This approach assumes the old Emscripten FS object is still functional — which
+is true for *proactive* rotation (scheduled after N healthy requests) but is
+explicitly **not** true after a fatal WASM crash.
+
+Our crash scenario is:
+- WASM linear memory is corrupted (OOM, `unreachable`, etc.)
+- The Emscripten FS object may be in an inconsistent state
+- `copyMEMFSNodes` would walk the old FS and copy data — this risks copying
+  a corrupt or partially-written SQLite database page
+
+Our snapshot model deliberately reads the DB at the **JS buffer level**
+(`readFileAsBuffer`) rather than copying MEMFS nodes, because MEMFS lives in JS
+heap (survives WASM corruption) while WASM-side FS metadata may not.
+
+Additionally:
+- `hotSwapPHPRuntime` does not run `bootstrapMoodle()`. Our recovery depends on
+  bootstrap to re-initialize Moodle's config, cache stores, and session state.
+- `rotatePHPRuntime` enables *proactive* rotation after N requests — a different
+  concern from *reactive* crash recovery.
+- `PHPProcessManager`'s pool model assumes a `phpFactory` that produces clean
+  instances; it has no hook for post-crash snapshot restoration.
+
+### What could be adopted
+
+The **proactive rotation** concept from `rotatePHPRuntime` is genuinely useful:
+rotating the PHP runtime after N requests (e.g. 400) prevents slow memory leaks
+from accumulating to the point of a crash. This is orthogonal to crash recovery
+and could be layered on top.
+
+If adopted, proactive rotation would call our `resetRuntime()` path (not
+`hotSwapPHPRuntime`) so that Moodle's full bootstrap runs on the fresh runtime
+and cache/session state is properly initialized. The snapshot save/restore would
+be triggered as normal.
+
+`PHPProcessManager` is not applicable: Moodle Playground uses a single PHP
+instance per scope/worker (one request at a time), so a concurrency pool adds
+complexity without benefit.
+
+## Recommendation
+
+**Skip `rotatePHPRuntime` and `PHPProcessManager` for now.**
+
+- Our reactive crash recovery (`resetRuntime` + snapshot) is the right model
+  for WASM crashes. `hotSwapPHPRuntime` cannot safely copy from a crashed FS.
+- `PHPProcessManager` addresses multi-instance concurrency we do not need.
+
+**Consider adopting proactive rotation as a future enhancement:**
+- After N healthy requests, trigger a clean `resetRuntime()` (our existing path)
+  rather than `hotSwapPHPRuntime`.
+- This would prevent gradual WASM memory leaks from causing crashes in long
+  sessions.
+- Implementation would be a counter in `php-worker.js`'s request handler, not
+  a call to `rotatePHPRuntime`.

--- a/lib/moodle-loader.js
+++ b/lib/moodle-loader.js
@@ -214,26 +214,29 @@ export async function resolveBootstrapArchive(
   };
 }
 
-function normalizeArchiveName(name) {
+export function normalizeArchiveName(name) {
   return name.replaceAll("\\", "/").replace(/^\/+/, "");
 }
 
 export function extractZipEntries(zipBytes) {
   const archive = unzipSync(zipBytes);
-  const names = Object.keys(archive).map(normalizeArchiveName).filter(Boolean);
+  const rawNames = Object.keys(archive);
 
-  if (names.length === 0) {
+  if (rawNames.length === 0) {
     throw new Error("The Moodle archive is empty.");
   }
 
-  const firstSegments = new Set(names.map((name) => splitPath(name)[0]).filter(Boolean));
+  // Normalize once per entry to avoid redundant string processing on ~30k entries.
+  const entries = rawNames.map((raw) => ({ raw, name: normalizeArchiveName(raw) }));
+
+  const firstSegments = new Set(
+    entries.map(({ name }) => splitPath(name)[0]).filter(Boolean),
+  );
   const stripLeadingFolder = firstSegments.size === 1 ? [...firstSegments][0] : null;
 
-  return names
-    .map((name) => {
-      const originalData = archive[name];
-
-      if (!originalData) {
+  return entries
+    .map(({ raw, name }) => {
+      if (!name || name.endsWith("/")) {
         return null;
       }
 
@@ -247,11 +250,32 @@ export function extractZipEntries(zipBytes) {
 
       return {
         path: normalized,
-        data: originalData,
+        data: archive[raw],
       };
     })
     .filter(Boolean)
     .sort((left, right) => left.path.localeCompare(right.path));
+}
+
+/**
+ * Stream-decode a ZIP buffer into an array of { path, data } entries using
+ * @php-wasm/stream-compression. Shared by blueprint steps and the plugin
+ * installer to avoid duplicating the decodeZip streaming pattern.
+ */
+export async function readZipEntries(zipBytes) {
+  const { decodeZip } = await import("@php-wasm/stream-compression");
+  const stream = decodeZip(new Response(zipBytes).body);
+  const reader = stream.getReader();
+  const entries = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value.type === "directory") continue;
+    const path = normalizeArchiveName(value.name);
+    if (!path || path.endsWith("/")) continue;
+    entries.push({ path, data: new Uint8Array(await value.arrayBuffer()) });
+  }
+  return entries;
 }
 
 export function writeEntriesToPhp(php, entries, targetRoot, onProgress = () => {}) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,9 @@
     "": {
       "name": "moodle-playground",
       "dependencies": {
-        "@php-wasm/universal": "^3.1.12",
-        "@php-wasm/web": "^3.1.14",
+        "@php-wasm/stream-compression": "^3.1.15",
+        "@php-wasm/universal": "^3.1.15",
+        "@php-wasm/web": "^3.1.15",
         "fflate": "^0.8.2"
       },
       "devDependencies": {
@@ -19,9 +20,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.4.9",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.9.tgz",
-      "integrity": "sha512-wvZW92FrwitTcacvCBT8xdAbfbxWfDLwjYMmU3djjqQTh7Ni4ZdiWIT/x5VcZ+RQuxiKzIOzi5D+dcyJDFZMsA==",
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.10.tgz",
+      "integrity": "sha512-xxA3AphFQ1geij4JTHXv4EeSTda1IFn22ye9LdyVPoJU19fNVl0uzfEuhsfQ4Yue/0FaLs2/ccVi4UDiE7R30w==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -35,20 +36,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.4.9",
-        "@biomejs/cli-darwin-x64": "2.4.9",
-        "@biomejs/cli-linux-arm64": "2.4.9",
-        "@biomejs/cli-linux-arm64-musl": "2.4.9",
-        "@biomejs/cli-linux-x64": "2.4.9",
-        "@biomejs/cli-linux-x64-musl": "2.4.9",
-        "@biomejs/cli-win32-arm64": "2.4.9",
-        "@biomejs/cli-win32-x64": "2.4.9"
+        "@biomejs/cli-darwin-arm64": "2.4.10",
+        "@biomejs/cli-darwin-x64": "2.4.10",
+        "@biomejs/cli-linux-arm64": "2.4.10",
+        "@biomejs/cli-linux-arm64-musl": "2.4.10",
+        "@biomejs/cli-linux-x64": "2.4.10",
+        "@biomejs/cli-linux-x64-musl": "2.4.10",
+        "@biomejs/cli-win32-arm64": "2.4.10",
+        "@biomejs/cli-win32-x64": "2.4.10"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.4.9",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.9.tgz",
-      "integrity": "sha512-d5G8Gf2RpH5pYwiHLPA+UpG3G9TLQu4WM+VK6sfL7K68AmhcEQ9r+nkj/DvR/GYhYox6twsHUtmWWWIKfcfQQA==",
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.10.tgz",
+      "integrity": "sha512-vuzzI1cWqDVzOMIkYyHbKqp+AkQq4K7k+UCXWpkYcY/HDn1UxdsbsfgtVpa40shem8Kax4TLDLlx8kMAecgqiw==",
       "cpu": [
         "arm64"
       ],
@@ -63,9 +64,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.4.9",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.9.tgz",
-      "integrity": "sha512-LNCLNgqDMG7BLdc3a8aY/dwKPK7+R8/JXJoXjCvZh2gx8KseqBdFDKbhrr7HCWF8SzNhbTaALhTBoh/I6rf9lA==",
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.10.tgz",
+      "integrity": "sha512-14fzASRo+BPotwp7nWULy2W5xeUyFnTaq1V13Etrrxkrih+ez/2QfgFm5Ehtf5vSjtgx/IJycMMpn5kPd5ZNaA==",
       "cpu": [
         "x64"
       ],
@@ -80,13 +81,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.4.9",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.9.tgz",
-      "integrity": "sha512-4adnkAUi6K4C/emPRgYznMOcLlUqZdXWM6aIui4VP4LraE764g6Q4YguygnAUoxKjKIXIWPteKMgRbN0wsgwcg==",
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.10.tgz",
+      "integrity": "sha512-7MH1CMW5uuxQ/s7FLST63qF8B3Hgu2HRdZ7tA1X1+mk+St4JOuIrqdhIBnnyqeyWJNI+Bww7Es5QZ0wIc1Cmkw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -97,13 +101,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.4.9",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.9.tgz",
-      "integrity": "sha512-8RCww5xnPn2wpK4L/QDGDOW0dq80uVWfppPxHIUg6mOs9B6gRmqPp32h1Ls3T8GnW8Wo5A8u7vpTwz4fExN+sw==",
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.10.tgz",
+      "integrity": "sha512-WrJY6UuiSD/Dh+nwK2qOTu8kdMDlLV3dLMmychIghHPAysWFq1/DGC1pVZx8POE3ZkzKR3PUUnVrtZfMfaJjyQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -114,13 +121,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.4.9",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.9.tgz",
-      "integrity": "sha512-L10na7POF0Ks/cgLFNF1ZvIe+X4onLkTi5oP9hY+Rh60Q+7fWzKDDCeGyiHUFf1nGIa9dQOOUPGe2MyYg8nMSQ==",
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.10.tgz",
+      "integrity": "sha512-tZLvEEi2u9Xu1zAqRjTcpIDGVtldigVvzug2fTuPG0ME/g8/mXpRPcNgLB22bGn6FvLJpHHnqLnwliOu8xjYrg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -131,13 +141,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.4.9",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.9.tgz",
-      "integrity": "sha512-5TD+WS9v5vzXKzjetF0hgoaNFHMcpQeBUwKKVi3JbG1e9UCrFuUK3Gt185fyTzvRdwYkJJEMqglRPjmesmVv4A==",
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.10.tgz",
+      "integrity": "sha512-kDTi3pI6PBN6CiczsWYOyP2zk0IJI08EWEQyDMQWW221rPaaEz6FvjLhnU07KMzLv8q3qSuoB93ua6inSQ55Tw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -148,9 +161,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.4.9",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.9.tgz",
-      "integrity": "sha512-aDZr0RBC3sMGJOU10BvG7eZIlWLK/i51HRIfScE2lVhfts2dQTreowLiJJd+UYg/tHKxS470IbzpuKmd0MiD6g==",
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.10.tgz",
+      "integrity": "sha512-umwQU6qPzH+ISTf/eHyJ/QoQnJs3V9Vpjz2OjZXe9MVBZ7prgGafMy7yYeRGnlmDAn87AKTF3Q6weLoMGpeqdQ==",
       "cpu": [
         "arm64"
       ],
@@ -165,9 +178,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.4.9",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.9.tgz",
-      "integrity": "sha512-NS4g/2G9SoQ4ktKtz31pvyc/rmgzlcIDCGU/zWbmHJAqx6gcRj2gj5Q/guXhoWTzCUaQZDIqiCQXHS7BcGYc0w==",
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.10.tgz",
+      "integrity": "sha512-aW/JU5GuyH4uxMrNYpoC2kjaHlyJGLgIa3XkhPEZI0uKhZhJZU8BuEyJmvgzSPQNGozBwWjC972RaNdcJ9KyJg==",
       "cpu": [
         "x64"
       ],
@@ -182,9 +195,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
-      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.5.tgz",
+      "integrity": "sha512-nGsF/4C7uzUj+Nj/4J+Zt0bYQ6bz33Phz8Lb2N80Mti1HjGclTJdXZ+9APC4kLvONbjxN1zfvYNd8FEcbBK/MQ==",
       "cpu": [
         "ppc64"
       ],
@@ -199,9 +212,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
-      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.5.tgz",
+      "integrity": "sha512-Cv781jd0Rfj/paoNrul1/r4G0HLvuFKYh7C9uHZ2Pl8YXstzvCyyeWENTFR9qFnRzNMCjXmsulZuvosDg10Mog==",
       "cpu": [
         "arm"
       ],
@@ -216,9 +229,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
-      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.5.tgz",
+      "integrity": "sha512-Oeghq+XFgh1pUGd1YKs4DDoxzxkoUkvko+T/IVKwlghKLvvjbGFB3ek8VEDBmNvqhwuL0CQS3cExdzpmUyIrgA==",
       "cpu": [
         "arm64"
       ],
@@ -233,9 +246,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
-      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.5.tgz",
+      "integrity": "sha512-nQD7lspbzerlmtNOxYMFAGmhxgzn8Z7m9jgFkh6kpkjsAhZee1w8tJW3ZlW+N9iRePz0oPUDrYrXidCPSImD0Q==",
       "cpu": [
         "x64"
       ],
@@ -250,9 +263,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
-      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.5.tgz",
+      "integrity": "sha512-I+Ya/MgC6rr8oRWGRDF3BXDfP8K1BVUggHqN6VI2lUZLdDi1IM1v2cy0e3lCPbP+pVcK3Tv8cgUhHse1kaNZZw==",
       "cpu": [
         "arm64"
       ],
@@ -267,9 +280,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
-      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.5.tgz",
+      "integrity": "sha512-MCjQUtC8wWJn/pIPM7vQaO69BFgwPD1jriEdqwTCKzWjGgkMbcg+M5HzrOhPhuYe1AJjXlHmD142KQf+jnYj8A==",
       "cpu": [
         "x64"
       ],
@@ -284,9 +297,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.5.tgz",
+      "integrity": "sha512-X6xVS+goSH0UelYXnuf4GHLwpOdc8rgK/zai+dKzBMnncw7BTQIwquOodE7EKvY2UVUetSqyAfyZC1D+oqLQtg==",
       "cpu": [
         "arm64"
       ],
@@ -301,9 +314,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
-      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.5.tgz",
+      "integrity": "sha512-233X1FGo3a8x1ekLB6XT69LfZ83vqz+9z3TSEQCTYfMNY880A97nr81KbPcAMl9rmOFp11wO0dP+eB18KU/Ucg==",
       "cpu": [
         "x64"
       ],
@@ -318,9 +331,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
-      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.5.tgz",
+      "integrity": "sha512-0wkVrYHG4sdCCN/bcwQ7yYMXACkaHc3UFeaEOwSVW6e5RycMageYAFv+JS2bKLwHyeKVUvtoVH+5/RHq0fgeFw==",
       "cpu": [
         "arm"
       ],
@@ -335,9 +348,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
-      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.5.tgz",
+      "integrity": "sha512-euKkilsNOv7x/M1NKsx5znyprbpsRFIzTV6lWziqJch7yWYayfLtZzDxDTl+LSQDJYAjd9TVb/Kt5UKIrj2e4A==",
       "cpu": [
         "arm64"
       ],
@@ -352,9 +365,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
-      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.5.tgz",
+      "integrity": "sha512-hVRQX4+P3MS36NxOy24v/Cdsimy/5HYePw+tmPqnNN1fxV0bPrFWR6TMqwXPwoTM2VzbkA+4lbHWUKDd5ZDA/w==",
       "cpu": [
         "ia32"
       ],
@@ -369,9 +382,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
-      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.5.tgz",
+      "integrity": "sha512-mKqqRuOPALI8nDzhOBmIS0INvZOOFGGg5n1osGIXAx8oersceEbKd4t1ACNTHM3sJBXGFAlEgqM+svzjPot+ZQ==",
       "cpu": [
         "loong64"
       ],
@@ -386,9 +399,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
-      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.5.tgz",
+      "integrity": "sha512-EE/QXH9IyaAj1qeuIV5+/GZkBTipgGO782Ff7Um3vPS9cvLhJJeATy4Ggxikz2inZ46KByamMn6GqtqyVjhenA==",
       "cpu": [
         "mips64el"
       ],
@@ -403,9 +416,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
-      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.5.tgz",
+      "integrity": "sha512-0V2iF1RGxBf1b7/BjurA5jfkl7PtySjom1r6xOK2q9KWw/XCpAdtB6KNMO+9xx69yYfSCRR9FE0TyKfHA2eQMw==",
       "cpu": [
         "ppc64"
       ],
@@ -420,9 +433,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
-      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.5.tgz",
+      "integrity": "sha512-rYxThBx6G9HN6tFNuvB/vykeLi4VDsm5hE5pVwzqbAjZEARQrWu3noZSfbEnPZ/CRXP3271GyFk/49up2W190g==",
       "cpu": [
         "riscv64"
       ],
@@ -437,9 +450,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
-      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.5.tgz",
+      "integrity": "sha512-uEP2q/4qgd8goEUc4QIdU/1P2NmEtZ/zX5u3OpLlCGhJIuBIv0s0wr7TB2nBrd3/A5XIdEkkS5ZLF0ULuvaaYQ==",
       "cpu": [
         "s390x"
       ],
@@ -454,9 +467,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
-      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.5.tgz",
+      "integrity": "sha512-+Gq47Wqq6PLOOZuBzVSII2//9yyHNKZLuwfzCemqexqOQCSz0zy0O26kIzyp9EMNMK+nZ0tFHBZrCeVUuMs/ew==",
       "cpu": [
         "x64"
       ],
@@ -471,9 +484,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.5.tgz",
+      "integrity": "sha512-3F/5EG8VHfN/I+W5cO1/SV2H9Q/5r7vcHabMnBqhHK2lTWOh3F8vixNzo8lqxrlmBtZVFpW8pmITHnq54+Tq4g==",
       "cpu": [
         "arm64"
       ],
@@ -488,9 +501,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.5.tgz",
+      "integrity": "sha512-28t+Sj3CPN8vkMOlZotOmDgilQwVvxWZl7b8rxpn73Tt/gCnvrHxQUMng4uu3itdFvrtba/1nHejvxqz8xgEMA==",
       "cpu": [
         "x64"
       ],
@@ -505,9 +518,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.5.tgz",
+      "integrity": "sha512-Doz/hKtiuVAi9hMsBMpwBANhIZc8l238U2Onko3t2xUp8xtM0ZKdDYHMnm/qPFVthY8KtxkXaocwmMh6VolzMA==",
       "cpu": [
         "arm64"
       ],
@@ -522,9 +535,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.5.tgz",
+      "integrity": "sha512-WfGVaa1oz5A7+ZFPkERIbIhKT4olvGl1tyzTRaB5yoZRLqC0KwaO95FeZtOdQj/oKkjW57KcVF944m62/0GYtA==",
       "cpu": [
         "x64"
       ],
@@ -539,9 +552,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
-      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.5.tgz",
+      "integrity": "sha512-Xh+VRuh6OMh3uJ0JkCjI57l+DVe7VRGBYymen8rFPnTVgATBwA6nmToxM2OwTlSvrnWpPKkrQUj93+K9huYC6A==",
       "cpu": [
         "arm64"
       ],
@@ -556,9 +569,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
-      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.5.tgz",
+      "integrity": "sha512-aC1gpJkkaUADHuAdQfuVTnqVUTLqqUNhAvEwHwVWcnVVZvNlDPGA0UveZsfXJJ9T6k9Po4eHi3c02gbdwO3g6w==",
       "cpu": [
         "x64"
       ],
@@ -573,9 +586,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
-      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.5.tgz",
+      "integrity": "sha512-0UNx2aavV0fk6UpZcwXFLztA2r/k9jTUa7OW7SAea1VYUhkug99MW1uZeXEnPn5+cHOd0n8myQay6TlFnBR07w==",
       "cpu": [
         "arm64"
       ],
@@ -590,9 +603,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
-      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.5.tgz",
+      "integrity": "sha512-5nlJ3AeJWCTSzR7AEqVjT/faWyqKU86kCi1lLmxVqmNR+j4HrYdns+eTGjS/vmrzCIe8inGQckUadvS0+JkKdQ==",
       "cpu": [
         "ia32"
       ],
@@ -607,9 +620,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
-      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.5.tgz",
+      "integrity": "sha512-PWypQR+d4FLfkhBIV+/kHsUELAnMpx1bRvvsn3p+/sAERbnCzFrtDRG2Xw5n+2zPxBK2+iaP+vetsRl4Ti7WgA==",
       "cpu": [
         "x64"
       ],
@@ -1137,12 +1150,12 @@
       "license": "MIT"
     },
     "node_modules/@php-wasm/cli-util": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.14.tgz",
-      "integrity": "sha512-bZG/iTGVOo0BntmQ3geDhOncerjZQQQiVjTgnLrJDGEc1xOMfIES0V+RdeIfiN3D2ttasuQbYNku30QG2lg4gg==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.15.tgz",
+      "integrity": "sha512-RsEmW1pVNeXDGrrQy254jyDGIhwc6U5mmKpbD1iq1KMF1cVTZhtKy5BEtuJlY3Htgd1/zXoGRdfSlHguZguLGg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/util": "3.1.14",
+        "@php-wasm/util": "3.1.15",
         "fast-xml-parser": "^5.5.1",
         "jsonc-parser": "3.3.1"
       },
@@ -1152,15 +1165,15 @@
       }
     },
     "node_modules/@php-wasm/fs-journal": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@php-wasm/fs-journal/-/fs-journal-3.1.14.tgz",
-      "integrity": "sha512-3WKRSMdVTBDDQm6KGZ2IfnRUk5G21Xl00aD2vMN8gZw+hVujd5MZpogjTsTJJivZesxOsUCmGm8SH2nX3ClLog==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/fs-journal/-/fs-journal-3.1.15.tgz",
+      "integrity": "sha512-6WwWAMKIqgUqxr+0JlgdnaaGcghRLneue0MqBBMngEp9hxmU8RtFB4r5hz/6qPps7rHIa1m0TcQZgTyr901WrQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.1.14",
-        "@php-wasm/node": "3.1.14",
-        "@php-wasm/universal": "3.1.14",
-        "@php-wasm/util": "3.1.14",
+        "@php-wasm/logger": "3.1.15",
+        "@php-wasm/node": "3.1.15",
+        "@php-wasm/universal": "3.1.15",
+        "@php-wasm/util": "3.1.15",
         "express": "4.22.0",
         "fast-xml-parser": "^5.5.1",
         "fs-ext-extra-prebuilt": "2.2.7",
@@ -1176,12 +1189,12 @@
       }
     },
     "node_modules/@php-wasm/logger": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.14.tgz",
-      "integrity": "sha512-5Pt/Vljb6XiWMhoQAyDkjn/yZgC3GFrnLi3NONk66OfmcBUAjaoQ6IpYxxrSALeFd2NkUH7IF2l2KBW0FwsuRw==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.15.tgz",
+      "integrity": "sha512-qqMVDo18/JcUKShj5tHaWp9MvaMvzssFBVOyO94GB7QAk84nx3dn5QeqJX45txl7Zw1XoGewWfIitfVG9knUVQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/node-polyfills": "3.1.14"
+        "@php-wasm/node-polyfills": "3.1.15"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1189,24 +1202,24 @@
       }
     },
     "node_modules/@php-wasm/node": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.14.tgz",
-      "integrity": "sha512-ZmkVx9UYTZmDK1P96JlpLUC2AmDaPVrydStlm7ybaYoE8CdbkVVtESK5+c3MxmlyXo2GuQynEihlFtqTZTKTzA==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.15.tgz",
+      "integrity": "sha512-tGrueWDECzL7KQYo0rj/YP6/M7souF5eRM/8Gn3bPHfReKZdnJf2D8R0KqzVFlIrbF7paJWzrGoMO8otaSisbQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/cli-util": "3.1.14",
-        "@php-wasm/logger": "3.1.14",
-        "@php-wasm/node-7-4": "3.1.14",
-        "@php-wasm/node-8-0": "3.1.14",
-        "@php-wasm/node-8-1": "3.1.14",
-        "@php-wasm/node-8-2": "3.1.14",
-        "@php-wasm/node-8-3": "3.1.14",
-        "@php-wasm/node-8-4": "3.1.14",
-        "@php-wasm/node-8-5": "3.1.14",
-        "@php-wasm/node-polyfills": "3.1.14",
-        "@php-wasm/universal": "3.1.14",
-        "@php-wasm/util": "3.1.14",
-        "@wp-playground/common": "3.1.14",
+        "@php-wasm/cli-util": "3.1.15",
+        "@php-wasm/logger": "3.1.15",
+        "@php-wasm/node-7-4": "3.1.15",
+        "@php-wasm/node-8-0": "3.1.15",
+        "@php-wasm/node-8-1": "3.1.15",
+        "@php-wasm/node-8-2": "3.1.15",
+        "@php-wasm/node-8-3": "3.1.15",
+        "@php-wasm/node-8-4": "3.1.15",
+        "@php-wasm/node-8-5": "3.1.15",
+        "@php-wasm/node-polyfills": "3.1.15",
+        "@php-wasm/universal": "3.1.15",
+        "@php-wasm/util": "3.1.15",
+        "@wp-playground/common": "3.1.15",
         "express": "4.22.0",
         "fast-xml-parser": "^5.5.1",
         "fs-ext-extra-prebuilt": "2.2.7",
@@ -1222,12 +1235,12 @@
       }
     },
     "node_modules/@php-wasm/node-7-4": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.14.tgz",
-      "integrity": "sha512-Z35WiUKR2wqHIpfXUBugotht21MBkY5PhaBRwlBa+2OFIedmSbxWicjBqFHt4s0e7nV5wgWbiFzzlJNWusNZWQ==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.15.tgz",
+      "integrity": "sha512-VnhGHF7F98Y7KX+0X8aQA0xvZM6HPEEj1BpwiPQZdc63sXYGmGhtqWZqeL9R9TEfs+8/sz0gk5Vh+wzhxFjypQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.14",
+        "@php-wasm/universal": "3.1.15",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.3"
@@ -1238,12 +1251,12 @@
       }
     },
     "node_modules/@php-wasm/node-8-0": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.14.tgz",
-      "integrity": "sha512-NSBYIjkNxhYHVym3/Rmwsm/UHQLW2Nll8KPneOHd8PewsUt3plrKigV+O6N9klrmhaut1VCLSqIVs0KKTsrgxQ==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.15.tgz",
+      "integrity": "sha512-e+larvOOoo5M3zXTae7aU2P/K5EFTHwTQqd5UjZcuSzIfMbWPvEM8Ykk5QebpRt015UsVVhwamjTWADy3r0qPg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.14",
+        "@php-wasm/universal": "3.1.15",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.3"
@@ -1254,12 +1267,12 @@
       }
     },
     "node_modules/@php-wasm/node-8-1": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.14.tgz",
-      "integrity": "sha512-ykTv64N3rqF57P/Hc743806De9YaUiuI8nT/9ceCVWg9wBJSrN8v5L/Vejw3kP7ys6vlLXj3SzdevhcDYD1GnA==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.15.tgz",
+      "integrity": "sha512-gwvO+W/aOYIhYsogdVDkceesXwVFT0JBZr+FbDitK7C3f9ZnX/4xzMFnN5EQYu3E0jOLH5gvaWUVnOPPI+lrUg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.14",
+        "@php-wasm/universal": "3.1.15",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.3"
@@ -1270,12 +1283,12 @@
       }
     },
     "node_modules/@php-wasm/node-8-2": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.14.tgz",
-      "integrity": "sha512-asStKlXGXpuJmrUcFaodJ3d004D0tEXgN6lZ7Ri8Ilo/1OMRdr7GsIStgZAyxq0k87cyO8AHTTvv6Clk1hy+YA==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.15.tgz",
+      "integrity": "sha512-M5NSfHLdUoymlU9EGIErvDFrVR80DQQY+/ijN/+4giuAJ2q00eH15qoWO61vffPxueZIKMx57aPBIn93J0WSJA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.14",
+        "@php-wasm/universal": "3.1.15",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.3"
@@ -1286,12 +1299,12 @@
       }
     },
     "node_modules/@php-wasm/node-8-3": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.14.tgz",
-      "integrity": "sha512-Qu75uh57XatFU+fFLFHvVodBM96OM4os0uEmeqDrxI6EnHBv735sDkMLggR3GpFd+u+02nz9xJHqJzJMqUnpig==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.15.tgz",
+      "integrity": "sha512-qMdc8joBPKKz1QKy7trlqqP8fW99oWUzt2KlhUUh3I46dkzBZ+7PvacnEubqETD78IWm3sazgO7PqbzQcqCKvQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.14",
+        "@php-wasm/universal": "3.1.15",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.3"
@@ -1302,12 +1315,12 @@
       }
     },
     "node_modules/@php-wasm/node-8-4": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.14.tgz",
-      "integrity": "sha512-UVKNNiZbZKyq40CnWK6vH4I+t2dQwky5B3qMOdF/P7QUCuzUNIxsPmmQ0psnJFarNfH8PTL233bOJNBt/KKbhw==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.15.tgz",
+      "integrity": "sha512-3RkeC98j4Su55eMBIhpT9rqmQyFmD0g/fnTOcVVF4x7VoIH1qImRwtKSA0jal9tPGtyMfdw3TSzJEjkEmU+WSA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.14",
+        "@php-wasm/universal": "3.1.15",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.3"
@@ -1318,12 +1331,12 @@
       }
     },
     "node_modules/@php-wasm/node-8-5": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.14.tgz",
-      "integrity": "sha512-XD5zG67jPqnNcoBZFEum+LT5WsMpq34S2nurPLIhTydgXY0ykByoguj/cHgmCzykHeHSet1KgCZwV8dP2HOACA==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.15.tgz",
+      "integrity": "sha512-aAhql2q38equXpfMEolzev1at0HDIm8Yshf3OB2n5lh/u1GJvXycVE4DAUTnzD+t5Q5Pz76HFxt8x4d4+Ppo3g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.14",
+        "@php-wasm/universal": "3.1.15",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.3"
@@ -1334,19 +1347,19 @@
       }
     },
     "node_modules/@php-wasm/node-polyfills": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-3.1.14.tgz",
-      "integrity": "sha512-2pbxuxpXFL/V/XKOvHQ9tLrRFf8lcfWB9V9ym4NRNw3w2BtfANsnNNBz7CXF1Qg918yUXhfc437ToRBCPqKovQ==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-3.1.15.tgz",
+      "integrity": "sha512-TzFaD7tB4uL3uSt33OAsV9CO0U7wDYHhd79nBuSXRfbWbx9GBvI/bUqANE7sRMSNNCuAoIJ+5hRqoX+Lq0QgaQ==",
       "license": "GPL-2.0-or-later"
     },
     "node_modules/@php-wasm/progress": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.14.tgz",
-      "integrity": "sha512-xbwsdMSHb5njvQGdSfJq3ni9CtAI0FouIc8PDnmig7WXmxgJAtofO/UHz4++/gV+RKX9iQhN27NM5rq9fWt9FQ==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.15.tgz",
+      "integrity": "sha512-9dApeEIQdxcIfvF2KVX1nDlJnfT6pPoKQC3RJKn/L/cmM3q3r+bUmRaCR0oBaSqrB6syp4/+SeTe/yyhUfh7Pw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.1.14",
-        "@php-wasm/node-polyfills": "3.1.14"
+        "@php-wasm/logger": "3.1.15",
+        "@php-wasm/node-polyfills": "3.1.15"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1354,9 +1367,9 @@
       }
     },
     "node_modules/@php-wasm/scopes": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.14.tgz",
-      "integrity": "sha512-0tTFoHLqderimPzWf3cN7VspZ9QHMcrPXVjxg+Nd0RS633W6sXRY3IorElBgT/dEb3li35YsPLuGm7Z3xUTPAw==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.15.tgz",
+      "integrity": "sha512-VLReby1RrbhO8bA1Py9cCE/15G2DcHUwqu5BNjvVIWVnqqzI8wOUkDGwON9CtcfPmC2GDSgwkOxVQDJ2Tmu0YQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=20.10.0",
@@ -1364,26 +1377,26 @@
       }
     },
     "node_modules/@php-wasm/stream-compression": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.14.tgz",
-      "integrity": "sha512-K0euPHWbh/fIefudpuJOmYl5zpQ66uO49VqcE9WUfUs7ndHMn5zaXiuoYkCgnzTjl1hZYZ95z65ns/1nzTKR5g==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.15.tgz",
+      "integrity": "sha512-zJLPpOJHgSWsoWscojgmrkIy6S7tn/D/zwo6iVCQLWZquW4GY0drt/0xgEPpYmsRS+Iz92lfwfxUr+Zpb05rRg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/node-polyfills": "3.1.14",
-        "@php-wasm/util": "3.1.14"
+        "@php-wasm/node-polyfills": "3.1.15",
+        "@php-wasm/util": "3.1.15"
       }
     },
     "node_modules/@php-wasm/universal": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.14.tgz",
-      "integrity": "sha512-VoA+IzHl6knCYd/Bu+7Fw7CEKTNGvcIXxv9uCv+WgwjTajtGdz7fFM9ph3+RJHdVwUOu6Gb3MsYCJ/nNbTTapQ==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.15.tgz",
+      "integrity": "sha512-AIxn8pDdzzXnRTYi4tOfMjyS2kmSrzNcf1exUt3pmNuWQF0ey1Lv9ulImzi6lvuLgRwwlqzfoJtHzii2ITfCfw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.1.14",
-        "@php-wasm/node-polyfills": "3.1.14",
-        "@php-wasm/progress": "3.1.14",
-        "@php-wasm/stream-compression": "3.1.14",
-        "@php-wasm/util": "3.1.14",
+        "@php-wasm/logger": "3.1.15",
+        "@php-wasm/node-polyfills": "3.1.15",
+        "@php-wasm/progress": "3.1.15",
+        "@php-wasm/stream-compression": "3.1.15",
+        "@php-wasm/util": "3.1.15",
         "ini": "4.1.2"
       },
       "engines": {
@@ -1392,34 +1405,34 @@
       }
     },
     "node_modules/@php-wasm/util": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.14.tgz",
-      "integrity": "sha512-bDbnWJWm8JNtdyeKykUYePJOOvSr4A4iaq75RlG0/hBaS2q/Mh5IT04hsyGHZFAp91PFSSDr7sVWI4Dgn0NZww==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.15.tgz",
+      "integrity": "sha512-D0e0Re57fJhoj1ZuDV4iamVc7Dw8EzVj5qicy+u8FHaqX6U4kutNbUZv2Vtezal02ssNnhXG4psFPVpUPhXDTg==",
       "engines": {
         "node": ">=20.10.0",
         "npm": ">=10.2.3"
       }
     },
     "node_modules/@php-wasm/web": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web/-/web-3.1.14.tgz",
-      "integrity": "sha512-dlQt2D6G7AfSZcNsL2BLdAYiWkYpJlczCZS3C3Hc0aPiA9EkkCLJPWPnMDmI/RHGF4UiXbBP/RrT1WaBMn02eA==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web/-/web-3.1.15.tgz",
+      "integrity": "sha512-2Ir/0pGdbKcIyncWWkmSxih+/9NKypGW2BXeaDzepkmUZn/RZr5TMBVvrVNGKo1hlaRxPhkqjIdExS/m1lKgvw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/fs-journal": "3.1.14",
-        "@php-wasm/logger": "3.1.14",
-        "@php-wasm/universal": "3.1.14",
-        "@php-wasm/util": "3.1.14",
-        "@php-wasm/web-7-4": "3.1.14",
-        "@php-wasm/web-8-0": "3.1.14",
-        "@php-wasm/web-8-1": "3.1.14",
-        "@php-wasm/web-8-2": "3.1.14",
-        "@php-wasm/web-8-3": "3.1.14",
-        "@php-wasm/web-8-4": "3.1.14",
-        "@php-wasm/web-8-5": "3.1.14",
-        "@php-wasm/web-service-worker": "3.1.14",
-        "@wp-playground/common": "3.1.14",
-        "@wp-playground/storage": "3.1.14",
+        "@php-wasm/fs-journal": "3.1.15",
+        "@php-wasm/logger": "3.1.15",
+        "@php-wasm/universal": "3.1.15",
+        "@php-wasm/util": "3.1.15",
+        "@php-wasm/web-7-4": "3.1.15",
+        "@php-wasm/web-8-0": "3.1.15",
+        "@php-wasm/web-8-1": "3.1.15",
+        "@php-wasm/web-8-2": "3.1.15",
+        "@php-wasm/web-8-3": "3.1.15",
+        "@php-wasm/web-8-4": "3.1.15",
+        "@php-wasm/web-8-5": "3.1.15",
+        "@php-wasm/web-service-worker": "3.1.15",
+        "@wp-playground/common": "3.1.15",
+        "@wp-playground/storage": "3.1.15",
         "@zip.js/zip.js": "2.7.57",
         "async-lock": "1.4.1",
         "clean-git-ref": "2.0.1",
@@ -1448,12 +1461,12 @@
       }
     },
     "node_modules/@php-wasm/web-7-4": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-7-4/-/web-7-4-3.1.14.tgz",
-      "integrity": "sha512-nqqt/pXg8YNFYATrufk9eCXpkCJbU0/dwKeDaZ0zP75b3Ok9ra7Ixn1ybpoxnUG6mSqKyry4v4GgJYaOXWdt3g==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-7-4/-/web-7-4-3.1.15.tgz",
+      "integrity": "sha512-XjjddWZ3ru6LBYxInhF6YF2rjhiqNr4fCuZ9WzkZQFXGB7IS1AR7OtpQpNRW6tftqcid0LO8MvB8be8Suoc/kw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.14",
+        "@php-wasm/universal": "3.1.15",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0"
       },
@@ -1463,12 +1476,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-0": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-0/-/web-8-0-3.1.14.tgz",
-      "integrity": "sha512-7vtTzIFnTDUHlvGVaT7dUm0TFS84lDZg1lQPpyycZEdjiZrEHB+A5mC4wFJVgRdm6NNWYv92tO4jbTsUcGJmug==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-0/-/web-8-0-3.1.15.tgz",
+      "integrity": "sha512-5/OboMv7CzTYsIyrctRoj4Epu5ETtlryHWvjksVQGW2MdhEB+3/6npHC36o6ZurqTTX20RF+KnPZiMEl5zptZw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.14",
+        "@php-wasm/universal": "3.1.15",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0"
       },
@@ -1478,12 +1491,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-1": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-1/-/web-8-1-3.1.14.tgz",
-      "integrity": "sha512-DU6/fNlQkc+EOy8zzjAw2ThuO93Q6FH9PxhOgvs2KS5zSeQIfgdCB00QKEqMM2Jsonf5xUPfyPGwnu901peEHg==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-1/-/web-8-1-3.1.15.tgz",
+      "integrity": "sha512-1jJVZj42oGrRGaSdrKKVJJUBaUflu9TdcMLxp49CYqIxdp7+6TQTkTwKEFi37TEvMTXaE4Qe2AIIP3FiKU8Xag==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.14",
+        "@php-wasm/universal": "3.1.15",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0"
       },
@@ -1493,12 +1506,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-2": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-2/-/web-8-2-3.1.14.tgz",
-      "integrity": "sha512-TZr+m8KrrhvtjJabC/IzZo/vwsZyHuIB1YVfVOlwus0iANyox7ruVXcpVcrUrpKNfBujeMxX60HzOsvVgEKi3g==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-2/-/web-8-2-3.1.15.tgz",
+      "integrity": "sha512-Y17Ft3+9wWCby8ysllw1WzVQeNzAZnSTA+LPp8Jow2+Q9oq7ZcZQA0q5PyHF5BvEbm9B3j9Thvxmk6FEFCDPuA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.14",
+        "@php-wasm/universal": "3.1.15",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0"
       },
@@ -1508,12 +1521,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-3": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-3/-/web-8-3-3.1.14.tgz",
-      "integrity": "sha512-MQUAc+ls68HIGBQTP+kZAibwCT9iD3eItSOINURPy+42/EnydtQhsA6zE9uydR1K3hH6PeiLLOgEWCEvO9g4zQ==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-3/-/web-8-3-3.1.15.tgz",
+      "integrity": "sha512-YR03dLxxOi4eJkUN6ajjKKFIAmA5QeRYhQ4SZarshW1ZOsLTnQD+/cpNCFfFDDis8cnNkxFGMr7f2M0bXLb42A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.14",
+        "@php-wasm/universal": "3.1.15",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0"
       },
@@ -1523,12 +1536,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-4": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-4/-/web-8-4-3.1.14.tgz",
-      "integrity": "sha512-YlQIGtlXUuKoNPwKfzZO8o4LvNmdr5mSiHHn8avUhooD9j+Pmh4SBGyLQa+CuJNGzzFpQhHx0NZ3G0hzlmbyQQ==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-4/-/web-8-4-3.1.15.tgz",
+      "integrity": "sha512-oyo/1qRTB0e8Yk0Il2Uck4taDXU1PlLPUteUXukzvfHQRpZ+aUSTFClyu9ctohB3/xHyraQjqs5Dtj2GmSv81g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.14",
+        "@php-wasm/universal": "3.1.15",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0"
       },
@@ -1538,12 +1551,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-5": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-5/-/web-8-5-3.1.14.tgz",
-      "integrity": "sha512-P1szrbVtUMrgESA+rgt6jX2dnhK4hxEiE0aEs4ICCL13hspRYoX9HuglOmfiX9+hxIlYruGggpuFa2mgyyt+pw==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-5/-/web-8-5-3.1.15.tgz",
+      "integrity": "sha512-Vt9gsRZ7hHRC40tDPfl52J5FV/jMs7ENOMzKi3BIKu8etMtwiueUwYWSJ0fPiJUUuF1K5VbcwJ6eUAStJHBM/g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.14",
+        "@php-wasm/universal": "3.1.15",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0"
       },
@@ -1553,13 +1566,13 @@
       }
     },
     "node_modules/@php-wasm/web-service-worker": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.14.tgz",
-      "integrity": "sha512-AOnY6uRw1YIZ9pc3AoicSM5nht31OZ36nZVF45rCLs4hofWK7w670O7VUS3v35E2xomc7Xfz/M7+VLnYYPzFog==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.15.tgz",
+      "integrity": "sha512-zfCzD++N7lDgFt8L7esRn9yYD4/aBAEhghnsfsOqKurHTSwRz7DCZGNdTaxy8UlYvuyGRTnBPkGSPwz9VpgKpg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/scopes": "3.1.14",
-        "@php-wasm/universal": "3.1.14",
+        "@php-wasm/scopes": "3.1.15",
+        "@php-wasm/universal": "3.1.15",
         "ini": "4.1.2"
       },
       "engines": {
@@ -1568,13 +1581,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.2"
+        "playwright": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1621,13 +1634,13 @@
       }
     },
     "node_modules/@wp-playground/common": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.14.tgz",
-      "integrity": "sha512-K268d4U9EYVE+DSBd9STlWEmjm3RVnCCNZjtvTf5zICeXWS1s32eJXyhIL5gqr1mWfBcc35MYauE5bH5pZa6Lw==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.15.tgz",
+      "integrity": "sha512-U/8ReVqCh0Ceh0rWMCvTHUmqF9/O6EpvPZEXkq27nTTE7dha08cUYmw/PX61vbLZ9O0RXRqXf036vR03r3gTwg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.14",
-        "@php-wasm/util": "3.1.14",
+        "@php-wasm/universal": "3.1.15",
+        "@php-wasm/util": "3.1.15",
         "ini": "4.1.2"
       },
       "engines": {
@@ -1636,14 +1649,14 @@
       }
     },
     "node_modules/@wp-playground/storage": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.14.tgz",
-      "integrity": "sha512-hhgHKliiwcjr/q8iy2gfCja8jYGgrWmYgvVMPYw9qcLVRqFNdeeMfgDVlSp6pDfvj7knUiGw3Z8ILZbzSc8H1Q==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.15.tgz",
+      "integrity": "sha512-QEaI4pA4O0gPJiYInpoSYMIwTacGyfmW0Onj+HT0Tf8Vw+GWe8Z85nyGZDbZEo0zBLUYOSAIeyfc/vgXKVdLcg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/stream-compression": "3.1.14",
-        "@php-wasm/universal": "3.1.14",
-        "@php-wasm/util": "3.1.14",
+        "@php-wasm/stream-compression": "3.1.15",
+        "@php-wasm/universal": "3.1.15",
+        "@php-wasm/util": "3.1.15",
         "@zip.js/zip.js": "2.7.57",
         "async-lock": "^1.4.1",
         "clean-git-ref": "^2.0.1",
@@ -2201,9 +2214,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
-      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.5.tgz",
+      "integrity": "sha512-zdQoHBjuDqKsvV5OPaWansOwfSQ0Js+Uj9J85TBvj3bFW1JjWTSULMRwdQAc8qMeIScbClxeMK0jlrtB9linhA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2214,32 +2227,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.4",
-        "@esbuild/android-arm": "0.27.4",
-        "@esbuild/android-arm64": "0.27.4",
-        "@esbuild/android-x64": "0.27.4",
-        "@esbuild/darwin-arm64": "0.27.4",
-        "@esbuild/darwin-x64": "0.27.4",
-        "@esbuild/freebsd-arm64": "0.27.4",
-        "@esbuild/freebsd-x64": "0.27.4",
-        "@esbuild/linux-arm": "0.27.4",
-        "@esbuild/linux-arm64": "0.27.4",
-        "@esbuild/linux-ia32": "0.27.4",
-        "@esbuild/linux-loong64": "0.27.4",
-        "@esbuild/linux-mips64el": "0.27.4",
-        "@esbuild/linux-ppc64": "0.27.4",
-        "@esbuild/linux-riscv64": "0.27.4",
-        "@esbuild/linux-s390x": "0.27.4",
-        "@esbuild/linux-x64": "0.27.4",
-        "@esbuild/netbsd-arm64": "0.27.4",
-        "@esbuild/netbsd-x64": "0.27.4",
-        "@esbuild/openbsd-arm64": "0.27.4",
-        "@esbuild/openbsd-x64": "0.27.4",
-        "@esbuild/openharmony-arm64": "0.27.4",
-        "@esbuild/sunos-x64": "0.27.4",
-        "@esbuild/win32-arm64": "0.27.4",
-        "@esbuild/win32-ia32": "0.27.4",
-        "@esbuild/win32-x64": "0.27.4"
+        "@esbuild/aix-ppc64": "0.27.5",
+        "@esbuild/android-arm": "0.27.5",
+        "@esbuild/android-arm64": "0.27.5",
+        "@esbuild/android-x64": "0.27.5",
+        "@esbuild/darwin-arm64": "0.27.5",
+        "@esbuild/darwin-x64": "0.27.5",
+        "@esbuild/freebsd-arm64": "0.27.5",
+        "@esbuild/freebsd-x64": "0.27.5",
+        "@esbuild/linux-arm": "0.27.5",
+        "@esbuild/linux-arm64": "0.27.5",
+        "@esbuild/linux-ia32": "0.27.5",
+        "@esbuild/linux-loong64": "0.27.5",
+        "@esbuild/linux-mips64el": "0.27.5",
+        "@esbuild/linux-ppc64": "0.27.5",
+        "@esbuild/linux-riscv64": "0.27.5",
+        "@esbuild/linux-s390x": "0.27.5",
+        "@esbuild/linux-x64": "0.27.5",
+        "@esbuild/netbsd-arm64": "0.27.5",
+        "@esbuild/netbsd-x64": "0.27.5",
+        "@esbuild/openbsd-arm64": "0.27.5",
+        "@esbuild/openbsd-x64": "0.27.5",
+        "@esbuild/openharmony-arm64": "0.27.5",
+        "@esbuild/sunos-x64": "0.27.5",
+        "@esbuild/win32-arm64": "0.27.5",
+        "@esbuild/win32-ia32": "0.27.5",
+        "@esbuild/win32-x64": "0.27.5"
       }
     },
     "node_modules/escalade": {
@@ -3107,13 +3120,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -3126,9 +3139,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
     "test:e2e:install": "playwright install chromium"
   },
   "dependencies": {
-    "@php-wasm/universal": "^3.1.12",
-    "@php-wasm/web": "^3.1.14",
+    "@php-wasm/stream-compression": "^3.1.15",
+    "@php-wasm/universal": "^3.1.15",
+    "@php-wasm/web": "^3.1.15",
     "fflate": "^0.8.2"
   },
   "devDependencies": {

--- a/scripts/github-proxy-worker.js
+++ b/scripts/github-proxy-worker.js
@@ -455,7 +455,7 @@ function corsHeaders() {
   return {
     "Access-Control-Allow-Origin": "*",
     "Access-Control-Allow-Methods": "GET, OPTIONS",
-    "Access-Control-Allow-Headers": "Content-Type, Accept",
+    "Access-Control-Allow-Headers": "*",
     "Access-Control-Expose-Headers":
       "Content-Disposition, Content-Type, Content-Length, X-Playground-Cors-Proxy",
     "Access-Control-Max-Age": "86400",

--- a/src/blueprint/php/helpers.js
+++ b/src/blueprint/php/helpers.js
@@ -54,11 +54,12 @@ function addModuleExec(fileSpecs = []) {
     // Attach uploaded files to the module via Moodle file storage.
     $ctx = context_module::instance($cmid);
     $fs = get_file_storage();
+    $component = 'mod_' . $moduleInfo->modulename;
     foreach ([${entries}] as $fSpec) {
         if (!file_exists($fSpec['tmppath'])) continue;
         $fileinfo = [
             'contextid' => $ctx->id,
-            'component' => 'mod_' . $moduleInfo->modulename,
+            'component' => $component,
             'filearea'  => $fSpec['filearea'],
             'itemid'    => $fSpec['itemid'],
             'filepath'  => $fSpec['filepath'],
@@ -70,6 +71,58 @@ function addModuleExec(fileSpecs = []) {
         ];
         $fs->create_file_from_pathname($fileinfo, $fSpec['tmppath']);
         @unlink($fSpec['tmppath']);
+
+        // If the file is in the 'package' filearea, extract it to 'content'
+        // and detect the main entry file. This replicates the post-save
+        // processing that modules like exeweb, resource, and scorm perform
+        // when a package ZIP is uploaded through the Moodle form UI.
+        if ($fSpec['filearea'] === 'package') {
+            $storedFile = $fs->get_file(
+                $ctx->id, $component, 'package',
+                $fSpec['itemid'], $fSpec['filepath'], $fSpec['filename']
+            );
+            if ($storedFile) {
+                $packer = get_file_packer('application/zip');
+                $fs->delete_area_files($ctx->id, $component, 'content');
+                $contentsList = $storedFile->extract_to_storage(
+                    $packer, $ctx->id, $component, 'content', $fSpec['itemid'], '/'
+                );
+                if ($contentsList) {
+                    // Find index.html as main entry file (common convention).
+                    $entryNames = ['index.html', 'index.htm'];
+                    $entryPath = '/';
+                    $firstKey = key($contentsList);
+                    if ($firstKey && mb_substr($firstKey, -1) === '/') {
+                        $entryPath = '/' . $firstKey;
+                    }
+                    foreach ($entryNames as $eName) {
+                        $mainFile = $fs->get_file(
+                            $ctx->id, $component, 'content',
+                            $fSpec['itemid'], $entryPath, $eName
+                        );
+                        if ($mainFile) {
+                            file_set_sortorder(
+                                $ctx->id, $component, 'content', $fSpec['itemid'],
+                                $mainFile->get_filepath(), $mainFile->get_filename(), 1
+                            );
+                            // Update entrypath/entryname if the module supports them.
+                            try {
+                                $cols = $DB->get_columns($moduleInfo->modulename);
+                                if (isset($cols['entrypath'])) {
+                                    $DB->set_field($moduleInfo->modulename, 'entrypath',
+                                        $mainFile->get_filepath(), ['id' => $instanceid]);
+                                }
+                                if (isset($cols['entryname'])) {
+                                    $DB->set_field($moduleInfo->modulename, 'entryname',
+                                        $mainFile->get_filename(), ['id' => $instanceid]);
+                                }
+                            } catch (\\Throwable $ignore) {}
+                            break;
+                        }
+                    }
+                }
+            }
+        }
     }`;
   }
 
@@ -97,7 +150,7 @@ try {
     // Copy module-specific fields (e.g. assign grade, submissiondrafts)
     // that type-specific generators set on $moduleInfo.
     $skip = ['modulename','name','intro','introformat','course','section',
-             'visible','cmidnumber','groupmode','groupingid','files','display'];
+             'visible','cmidnumber','groupmode','groupingid','files'];
     foreach (get_object_vars($moduleInfo) as $k => $v) {
         if (!isset($instance->$k) && !in_array($k, $skip)) {
             $instance->$k = $v;
@@ -165,6 +218,7 @@ $created[] = user_create_user($u${i}, true, false);`;
   return `${CLI_HEADER}
 require_once($CFG->dirroot . '/user/lib.php');
 global $CFG;
+$CFG->passwordpolicy = false;
 $created = [];
 ${blocks.join("\n")}
 echo json_encode(['ok' => true, 'created' => $created]);
@@ -308,9 +362,27 @@ export function phpAddModule(mod, fileSpecs = []) {
   const name = escapePhp(mod.name || mod.module);
   const intro = escapePhp(mod.intro || "");
 
-  // When files are present, always use the generic handler (it supports
-  // custom fields AND file attachment in one pass).
-  if (fileSpecs.length > 0) {
+  // Extract module-specific custom fields (e.g. exeorigin, revision)
+  // that should be set on the module instance record.
+  const standardKeys = new Set([
+    "step",
+    "module",
+    "course",
+    "section",
+    "name",
+    "intro",
+    "files",
+  ]);
+  const customFields = {};
+  for (const [k, v] of Object.entries(mod)) {
+    if (!standardKeys.has(k) && v !== undefined && v !== null) {
+      customFields[k] = v;
+    }
+  }
+
+  // When files or custom fields are present, always use the generic handler
+  // (it supports custom fields AND file attachment in one pass).
+  if (fileSpecs.length > 0 || Object.keys(customFields).length > 0) {
     return phpAddGenericModule(
       mod.module,
       course,
@@ -318,6 +390,7 @@ export function phpAddModule(mod, fileSpecs = []) {
       name,
       intro,
       fileSpecs,
+      customFields,
     );
   }
 
@@ -411,7 +484,17 @@ function phpAddGenericModule(
   name,
   intro,
   fileSpecs = [],
+  customFields = {},
 ) {
+  const customLines = Object.entries(customFields)
+    .map(([k, v]) => {
+      if (typeof v === "number" || typeof v === "boolean") {
+        return `$moduleInfo->${escapePhp(k)} = ${typeof v === "boolean" ? (v ? 1 : 0) : v};`;
+      }
+      return `$moduleInfo->${escapePhp(k)} = '${escapePhp(String(v))}';`;
+    })
+    .join("\n");
+
   return `${CLI_HEADER}
 ${ADD_MODULE_SETUP}
 $course = $DB->get_record('course', ['shortname' => '${course}'], '*', MUST_EXIST);
@@ -426,6 +509,7 @@ $moduleInfo->visible = 1;
 $moduleInfo->cmidnumber = '';
 $moduleInfo->groupmode = 0;
 $moduleInfo->groupingid = 0;
+${customLines}
 ${addModuleExec(fileSpecs)}
 `;
 }

--- a/src/blueprint/resolver.js
+++ b/src/blueprint/resolver.js
@@ -1,6 +1,6 @@
 import { parseBlueprint } from "./parser.js";
 import { validateBlueprint } from "./schema.js";
-import { loadBlueprint, saveBlueprint } from "./storage.js";
+import { saveBlueprint } from "./storage.js";
 
 /**
  * Resolve the active blueprint from multiple sources in priority order.
@@ -69,12 +69,9 @@ export async function resolveBlueprint({
     }
   }
 
-  // 3. sessionStorage
-  const stored = loadBlueprint(scopeId);
-  if (stored) {
-    console.log("[blueprint] Resolved from sessionStorage.");
-    return stored;
-  }
+  // 3. sessionStorage blueprints are not reloaded on bare URL navigations —
+  //    the ephemeral runtime should boot clean. Blueprints from ?blueprint=
+  //    params are returned above before reaching this point.
 
   // 4. defaultBlueprintUrl
   if (defaultBlueprintUrl) {

--- a/src/blueprint/steps/filesystem.js
+++ b/src/blueprint/steps/filesystem.js
@@ -1,6 +1,7 @@
 /**
  * Filesystem step handlers: mkdir, rmdir, writeFile, writeFiles, copyFile, moveFile, unzip.
  */
+import { readZipEntries } from "../../../lib/moodle-loader.js";
 import { escapePhp } from "../php/helpers.js";
 
 export function registerFilesystemSteps(register) {
@@ -114,21 +115,15 @@ async function handleUnzip(step, { php, resources }) {
     throw new Error("unzip: 'data' is required.");
   }
   const zipBytes = await resources.resolve(step.data);
+  const entries = await readZipEntries(zipBytes);
 
-  // Use fflate for decompression
-  const { unzipSync } = await import("fflate");
-  const entries = unzipSync(zipBytes);
-
-  for (const [entryPath, entryData] of Object.entries(entries)) {
-    if (entryPath.endsWith("/")) continue; // skip directories
-    const fullPath = `${destination}/${entryPath}`;
-
-    // Ensure parent directory exists
+  const rawPhp = php._php;
+  for (const { path, data } of entries) {
+    const fullPath = `${destination}/${path}`;
     const parentDir = fullPath.substring(0, fullPath.lastIndexOf("/"));
     if (parentDir) {
-      await php.run(`<?php @mkdir('${escapePhp(parentDir)}', 0777, true);`);
+      rawPhp.mkdirTree(parentDir);
     }
-
-    await php.writeFile(fullPath, entryData);
+    rawPhp.writeFile(fullPath, data);
   }
 }

--- a/src/blueprint/steps/moodle-plugins.js
+++ b/src/blueprint/steps/moodle-plugins.js
@@ -5,6 +5,8 @@
  * and runs the Moodle upgrade to register the plugin.
  */
 
+import { readZipEntries } from "../../../lib/moodle-loader.js";
+
 const MOODLE_ROOT = "/www/moodle";
 const DEFAULT_ADDON_PROXY_URL = "https://github-proxy.exelearning.dev/";
 
@@ -80,7 +82,7 @@ async function handleInstallMoodlePlugin(step, context) {
     );
   }
 
-  const targetDir = resolvePluginDir(pluginType, pluginName);
+  const targetDir = resolvePluginDir(pluginType, pluginName, context.webRoot);
   await installPluginFiles(step.url, targetDir, context);
   await runMoodleUpgrade(pluginType, pluginName, targetDir, context);
   context.onPluginInstalled?.(targetDir);
@@ -99,20 +101,21 @@ async function handleInstallTheme(step, context) {
     );
   }
 
-  const targetDir = resolvePluginDir("theme", pluginName);
+  const targetDir = resolvePluginDir("theme", pluginName, context.webRoot);
   await installPluginFiles(step.url, targetDir, context);
   await runMoodleUpgrade("theme", pluginName, targetDir, context);
   context.onPluginInstalled?.(targetDir);
 }
 
-function resolvePluginDir(pluginType, pluginName) {
+function resolvePluginDir(pluginType, pluginName, webRoot) {
   const typeDir = PLUGIN_TYPE_DIRS[pluginType];
   if (!typeDir) {
     throw new Error(
       `Unknown plugin type '${pluginType}'. Known types: ${Object.keys(PLUGIN_TYPE_DIRS).join(", ")}`,
     );
   }
-  return `${MOODLE_ROOT}/${typeDir}/${pluginName}`;
+  const base = webRoot || MOODLE_ROOT;
+  return `${base}/${typeDir}/${pluginName}`;
 }
 
 /**
@@ -186,7 +189,14 @@ async function installViaZipDownload(zipUrl, targetDir, context) {
     );
   }
 
-  const response = await fetch(downloadUrl);
+  // Retry once on 502/503 — Cloudflare CDN or GitHub may return transient
+  // errors on browser reloads (cache revalidation race with the proxy).
+  let response = await fetch(downloadUrl, { cache: "no-store" });
+  if (!response.ok && (response.status === 502 || response.status === 503)) {
+    if (publish) publish("Plugin download failed, retrying…", 0.93);
+    await new Promise((r) => setTimeout(r, 1000));
+    response = await fetch(downloadUrl, { cache: "no-store" });
+  }
   if (!response.ok) {
     throw new Error(
       `Failed to download plugin ZIP from ${downloadUrl}: ${response.status}`,
@@ -196,20 +206,17 @@ async function installViaZipDownload(zipUrl, targetDir, context) {
 
   if (publish) publish(`Extracting plugin to ${targetDir}`, 0.935);
 
-  const { unzipSync } = await import("fflate");
-  const entries = unzipSync(zipBytes);
+  const rawEntries = await readZipEntries(zipBytes);
 
   // GitHub ZIPs have a top-level directory. Find and strip common prefix.
-  const paths = Object.keys(entries).filter((p) => !p.endsWith("/"));
+  const paths = rawEntries.map((e) => e.path);
   const commonPrefix = findCommonPrefix(paths);
 
   const rawPhp = php._php;
   rawPhp.mkdirTree(targetDir);
 
   let fileCount = 0;
-  for (const [entryPath, entryData] of Object.entries(entries)) {
-    if (entryPath.endsWith("/")) continue;
-
+  for (const { path: entryPath, data: entryData } of rawEntries) {
     const relativePath = commonPrefix
       ? entryPath.substring(commonPrefix.length)
       : entryPath;
@@ -235,16 +242,17 @@ async function runMoodleUpgrade(
   pluginType,
   pluginName,
   targetDir,
-  { php, publish },
+  { php, publish, webRoot },
 ) {
   if (publish) publish("Running Moodle upgrade to register plugin.", 0.945);
 
   const component = `${pluginType}_${pluginName}`;
   const safeDir = targetDir.replaceAll("'", "\\'");
 
+  const base = webRoot || MOODLE_ROOT;
   const code = `<?php
 define('CLI_SCRIPT', true);
-require('${MOODLE_ROOT}/config.php');
+require('${base}/config.php');
 require_once($CFG->libdir . '/upgradelib.php');
 require_once($CFG->libdir . '/clilib.php');
 require_once($CFG->libdir . '/adminlib.php');

--- a/src/runtime/bootstrap.js
+++ b/src/runtime/bootstrap.js
@@ -1,3 +1,4 @@
+import { ProgressTracker } from "@php-wasm/progress";
 import { setPhpIniEntries } from "@php-wasm/universal";
 import {
   extractZipEntries,
@@ -1953,6 +1954,25 @@ async function requestRuntimeScript(
   return body;
 }
 
+/**
+ * Creates a ProgressTracker with weighted bootstrap phases.
+ *
+ * The tracker is used as structured phase markers only — manual publish()
+ * calls drive the actual progress UI to avoid double-publishing conflicts.
+ */
+function createBootstrapTracker() {
+  const tracker = new ProgressTracker({ caption: "Bootstrapping Moodle" });
+
+  return {
+    download: tracker.stage(0.4, "Downloading Moodle bundle"),
+    extract: tracker.stage(0.15, "Extracting Moodle bundle"),
+    config: tracker.stage(0.02, "Writing runtime configuration"),
+    install: tracker.stage(0.25, "Installing Moodle"),
+    blueprints: tracker.stage(0.1, "Executing blueprint steps"),
+    finalize: tracker.stage(0.08, "Finalizing"),
+  };
+}
+
 export async function bootstrapMoodle({
   config,
   blueprint,
@@ -2031,6 +2051,8 @@ export async function bootstrapMoodle({
     debug: effectiveDebug,
     debugdisplay: effectiveDebugDisplay,
   };
+  const phases = createBootstrapTracker();
+
   if (shouldTraceRuntimeSelection({ debug, profile })) {
     publish(
       `[runtime-selection][bootstrap:resolved] runtimeId=${resolvedRuntimeId} moodleBranch=${selection.moodleBranch}`,
@@ -2076,6 +2098,7 @@ export async function bootstrapMoodle({
       }
     },
   );
+  phases.download.finish();
   const archiveMs = Math.round(performance.now() - tArchive);
   publish(`Bundle resolved in ${archiveMs}ms.`, 0.45);
 
@@ -2104,6 +2127,7 @@ export async function bootstrapMoodle({
     const zipMs = Math.round(performance.now() - tZip);
     publish(`ZIP extraction completed in ${zipMs}ms.`, 0.56);
   }
+  phases.extract.finish();
 
   const manifestState = buildManifestState(
     archive.manifest,
@@ -2159,6 +2183,7 @@ export async function bootstrapMoodle({
   });
   const prepareMs = Math.round(performance.now() - tPrepare);
   publish(`Runtime preparation completed in ${prepareMs}ms.`, 0.86);
+  phases.config.finish();
 
   // Update php.ini entries if blueprint specifies non-default timezone or debug display
   const iniOverrides = {};
@@ -2337,6 +2362,7 @@ export async function bootstrapMoodle({
       0.89,
     );
   }
+  phases.install.finish();
 
   const tNorm = performance.now();
   publish("Normalizing persisted Moodle configuration defaults.", 0.915);
@@ -2441,6 +2467,7 @@ export async function bootstrapMoodle({
       publish(`Blueprint execution error: ${blueprintError.message}`, 0.95);
     }
   }
+  phases.blueprints.finish();
 
   // Auto-login: create a Moodle session for the admin user so the playground
   // opens directly to the dashboard, just like WordPress Playground does.
@@ -2491,6 +2518,8 @@ export async function bootstrapMoodle({
       /* non-fatal */
     }
   }
+
+  phases.finalize.finish();
 
   return {
     manifest: archive.manifest,

--- a/src/shell/main.js
+++ b/src/shell/main.js
@@ -2,7 +2,6 @@ import {
   clearBlueprint,
   parseBlueprint,
   resolveBlueprint,
-  saveBlueprint,
   validateBlueprint,
 } from "../blueprint/index.js";
 import { loadPlaygroundConfig } from "../shared/config.js";
@@ -364,14 +363,14 @@ async function importPayload(file) {
     );
   }
 
-  activeBlueprint = blueprint;
-  saveBlueprint(scopeId, activeBlueprint);
-  pendingCleanBoot = true;
-  currentPath = activeBlueprint.landingPage || config.landingPath || "/";
-  els.address.value = currentPath;
-  updateBlueprintTextarea();
-  saveState({ importedBlueprintAt: new Date().toISOString() });
-  await updateFrame();
+  // Encode the blueprint into the URL and trigger a full page reload,
+  // the same way version changes work. This ensures a clean WASM runtime
+  // with no stale state from the previous session.
+  const encoded = btoa(unescape(encodeURIComponent(JSON.stringify(blueprint))));
+  const url = new URL(window.location.href);
+  url.searchParams.set("blueprint", encoded);
+  url.searchParams.delete("blueprint-url");
+  window.location.href = url.toString();
 }
 
 function bindShellChannel() {

--- a/tests/e2e/admin-flows.spec.mjs
+++ b/tests/e2e/admin-flows.spec.mjs
@@ -1,15 +1,10 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures.mjs";
 import {
-  captureDiagnostics,
   clickFirstVisible,
-  createDiagnosticsCollector,
   fillFirstVisible,
-  getMoodleFrame,
   navigateWithinPlayground,
-  openPlayground,
   tryFillFirstVisible,
   uniqueSuffix,
-  waitForPlaygroundReady,
 } from "./helpers.mjs";
 
 // This test interacts with Moodle forms inside a 2-level iframe served by a
@@ -18,12 +13,13 @@ import {
 // run locally with: npx playwright test admin-flows
 test("creates a course and a user, then renders an admin system information page", async ({
   page,
+  playground,
+  moodle,
 }, testInfo) => {
   test.skip(
     !!process.env.CI,
     "Nested iframe interaction is unreliable in CI — run locally",
   );
-  const diagnostics = createDiagnosticsCollector(page);
   const suffix = uniqueSuffix(testInfo);
   const courseName = `Playwright Course ${suffix}`;
   // Keep generated identifiers short for readability in Moodle admin tables.
@@ -35,124 +31,117 @@ test("creates a course and a user, then renders an admin system information page
   const userLastName = `User ${suffix}`;
   const userEmail = `${username}@example.com`;
 
-  try {
-    await openPlayground(page);
-    await waitForPlaygroundReady(page);
+  await playground.open({ waitForMoodle: true });
 
-    const moodle = getMoodleFrame(page);
-
-    await test.step("create a course through the Moodle UI", async () => {
-      await navigateWithinPlayground(page, "/course/edit.php?category=1");
-      await fillFirstVisible(
-        [
-          () => moodle.locator("#id_fullname"),
-          () => moodle.locator('input[name="fullname"]'),
-          () => moodle.getByLabel(/Course full name/i),
-        ],
-        courseName,
-      );
-      await fillFirstVisible(
-        [
-          () => moodle.locator("#id_shortname"),
-          () => moodle.locator('input[name="shortname"]'),
-          () => moodle.getByLabel(/Course short name/i),
-        ],
-        courseShortName,
-      );
-      await clickFirstVisible([
-        () =>
-          moodle.getByRole("button", {
-            name: /Save and display|Save changes|Save and return/i,
-          }),
-        () => moodle.locator("#id_saveanddisplay"),
-        () => moodle.locator("#id_savechanges"),
-      ]);
-
-      await expect(
-        moodle.getByRole("heading", { name: courseName }),
-      ).toBeVisible();
-    });
-
-    await test.step("create a user through the Moodle UI", async () => {
-      await navigateWithinPlayground(page, "/user/editadvanced.php?id=-1");
-      await fillFirstVisible(
-        [
-          () => moodle.locator("#id_username"),
-          () => moodle.locator('input[name="username"]'),
-          () => moodle.getByLabel(/^Username$/i),
-        ],
-        username,
-      );
-      if (await moodle.locator('[data-passwordunmask="edit"]').count()) {
-        await moodle.locator('[data-passwordunmask="edit"]').first().click();
-      }
-      const filledPassword = await tryFillFirstVisible(
-        [
-          () => moodle.locator("#id_newpassword"),
-          () => moodle.locator("#id_password"),
-          () => moodle.locator('input[name="newpassword"]'),
-          () => moodle.locator('input[name="password"]'),
-          () => moodle.getByLabel(/New password|Password/i),
-        ],
-        userPassword,
-      );
-      if (!filledPassword) {
-        await clickFirstVisible([
-          () => moodle.locator("#id_createpassword"),
-          () =>
-            moodle.getByRole("checkbox", {
-              name: /Generate password and notify user/i,
-            }),
-        ]);
-      }
-      await fillFirstVisible(
-        [
-          () => moodle.locator("#id_firstname"),
-          () => moodle.locator('input[name="firstname"]'),
-          () => moodle.getByLabel(/First name/i),
-        ],
-        userFirstName,
-      );
-      await fillFirstVisible(
-        [
-          () => moodle.locator("#id_lastname"),
-          () => moodle.locator('input[name="lastname"]'),
-          () => moodle.getByLabel(/Surname|Last name/i),
-        ],
-        userLastName,
-      );
-      await fillFirstVisible(
-        [
-          () => moodle.locator("#id_email"),
-          () => moodle.locator('input[name="email"]'),
-          () => moodle.getByLabel(/Email address/i),
-        ],
-        userEmail,
-      );
-      await clickFirstVisible([
-        () =>
-          moodle.getByRole("button", {
-            name: /Create user|Update profile|Save changes/i,
-          }),
-        () => moodle.locator("#id_submitbutton"),
-      ]);
-
-      await expect(moodle.locator("body")).toContainText(username);
-    });
-
-    await test.step("open an admin system information page", async () => {
-      await navigateWithinPlayground(page, "/admin/environment.php");
-      await expect(
-        moodle.getByRole("heading", {
-          name: /Server environment|Environment|System/i,
+  await test.step("create a course through the Moodle UI", async () => {
+    await navigateWithinPlayground(page, "/course/edit.php?category=1");
+    await fillFirstVisible(
+      [
+        () => moodle.locator("#id_fullname"),
+        () => moodle.locator('input[name="fullname"]'),
+        () => moodle.getByLabel(/Course full name/i),
+      ],
+      courseName,
+    );
+    await fillFirstVisible(
+      [
+        () => moodle.locator("#id_shortname"),
+        () => moodle.locator('input[name="shortname"]'),
+        () => moodle.getByLabel(/Course short name/i),
+      ],
+      courseShortName,
+    );
+    await clickFirstVisible([
+      () =>
+        moodle.getByRole("button", {
+          name: /Save and display|Save changes|Save and return/i,
         }),
-      ).toBeVisible();
-      await expect(
-        moodle.locator("#serverstatus, #otherserverstatus").first(),
-      ).toBeVisible();
-      await expect(moodle.locator("body")).toContainText(/PHP/i);
-    });
-  } finally {
-    await captureDiagnostics(page, testInfo, diagnostics);
-  }
+      () => moodle.locator("#id_saveanddisplay"),
+      () => moodle.locator("#id_savechanges"),
+    ]);
+
+    await expect(
+      moodle.getByRole("heading", { name: courseName }),
+    ).toBeVisible();
+  });
+
+  await test.step("create a user through the Moodle UI", async () => {
+    await navigateWithinPlayground(page, "/user/editadvanced.php?id=-1");
+    await fillFirstVisible(
+      [
+        () => moodle.locator("#id_username"),
+        () => moodle.locator('input[name="username"]'),
+        () => moodle.getByLabel(/^Username$/i),
+      ],
+      username,
+    );
+    if (await moodle.locator('[data-passwordunmask="edit"]').count()) {
+      await moodle.locator('[data-passwordunmask="edit"]').first().click();
+    }
+    const filledPassword = await tryFillFirstVisible(
+      [
+        () => moodle.locator("#id_newpassword"),
+        () => moodle.locator("#id_password"),
+        () => moodle.locator('input[name="newpassword"]'),
+        () => moodle.locator('input[name="password"]'),
+        () => moodle.getByLabel(/New password|Password/i),
+      ],
+      userPassword,
+    );
+    if (!filledPassword) {
+      await clickFirstVisible([
+        () => moodle.locator("#id_createpassword"),
+        () =>
+          moodle.getByRole("checkbox", {
+            name: /Generate password and notify user/i,
+          }),
+      ]);
+    }
+    await fillFirstVisible(
+      [
+        () => moodle.locator("#id_firstname"),
+        () => moodle.locator('input[name="firstname"]'),
+        () => moodle.getByLabel(/First name/i),
+      ],
+      userFirstName,
+    );
+    await fillFirstVisible(
+      [
+        () => moodle.locator("#id_lastname"),
+        () => moodle.locator('input[name="lastname"]'),
+        () => moodle.getByLabel(/Surname|Last name/i),
+      ],
+      userLastName,
+    );
+    await fillFirstVisible(
+      [
+        () => moodle.locator("#id_email"),
+        () => moodle.locator('input[name="email"]'),
+        () => moodle.getByLabel(/Email address/i),
+      ],
+      userEmail,
+    );
+    await clickFirstVisible([
+      () =>
+        moodle.getByRole("button", {
+          name: /Create user|Update profile|Save changes/i,
+        }),
+      () => moodle.locator("#id_submitbutton"),
+    ]);
+
+    await expect(moodle.locator("body")).toContainText(username);
+  });
+
+  await test.step("open an admin system information page", async () => {
+    await navigateWithinPlayground(page, "/admin/environment.php");
+    await expect(
+      moodle.getByRole("heading", {
+        name: /Server environment|Environment|System/i,
+      }),
+    ).toBeVisible();
+    await expect(
+      moodle.locator("#serverstatus, #otherserverstatus").first(),
+    ).toBeVisible();
+    await expect(moodle.locator("body")).toContainText(/PHP/i);
+  });
 });

--- a/tests/e2e/blueprint-courses.spec.mjs
+++ b/tests/e2e/blueprint-courses.spec.mjs
@@ -1,15 +1,7 @@
-import { expect, test } from "@playwright/test";
-import {
-  captureDiagnostics,
-  createDiagnosticsCollector,
-  waitForShellReady,
-} from "./helpers.mjs";
+import { expect, test } from "./fixtures.mjs";
+import { buildBlueprintParam, waitForShellReady } from "./helpers.mjs";
 
 test.describe.configure({ timeout: 180_000 });
-
-function buildBlueprintParam(payload) {
-  return Buffer.from(JSON.stringify(payload)).toString("base64url");
-}
 
 // ---------------------------------------------------------------------------
 // Blueprint: course creation with users, enrollment, and modules
@@ -17,9 +9,7 @@ function buildBlueprintParam(payload) {
 
 test("blueprint creates a course with a user and enrollment", async ({
   page,
-}, testInfo) => {
-  const diagnostics = createDiagnosticsCollector(page);
-
+}) => {
   const bp = buildBlueprintParam({
     landingPage: "/course/view.php?id=2",
     steps: [
@@ -73,29 +63,25 @@ test("blueprint creates a course with a user and enrollment", async ({
     ],
   });
 
-  try {
-    await page.goto(`/?blueprint=${bp}`);
-    await waitForShellReady(page);
+  await page.goto(`/?blueprint=${bp}`);
+  await waitForShellReady(page);
 
-    // Verify the address bar shows the course view
-    const address = await page.locator("#address-input").inputValue();
-    expect(address).toContain("/course/view.php");
+  // Verify the address bar shows the course view
+  const address = await page.locator("#address-input").inputValue();
+  expect(address).toContain("/course/view.php");
 
-    // Verify the blueprint tab contains our custom data
-    await page.locator("#panel-toggle-button").click();
-    await page.locator("#blueprint-tab").click();
-    await expect(page.locator("#blueprint-textarea")).toHaveValue(
-      /E2E Test Course/,
-    );
-    await expect(page.locator("#blueprint-textarea")).toHaveValue(
-      /E2E Assignment/,
-    );
+  // Verify the blueprint tab contains our custom data
+  await page.locator("#panel-toggle-button").click();
+  await page.locator("#blueprint-tab").click();
+  await expect(page.locator("#blueprint-textarea")).toHaveValue(
+    /E2E Test Course/,
+  );
+  await expect(page.locator("#blueprint-textarea")).toHaveValue(
+    /E2E Assignment/,
+  );
 
-    // Verify logs show successful bootstrap
-    await page.locator("#logs-tab").click();
-    const logText = await page.locator("#log-panel").textContent();
-    expect(logText).toContain("Moodle");
-  } finally {
-    await captureDiagnostics(page, testInfo, diagnostics);
-  }
+  // Verify logs show successful bootstrap
+  await page.locator("#logs-tab").click();
+  const logText = await page.locator("#log-panel").textContent();
+  expect(logText).toContain("Moodle");
 });

--- a/tests/e2e/fixtures.mjs
+++ b/tests/e2e/fixtures.mjs
@@ -1,0 +1,51 @@
+import { test as base, expect } from "@playwright/test";
+import {
+  captureDiagnostics,
+  createDiagnosticsCollector,
+  getMoodleFrame,
+  openPlayground,
+  waitForPlaygroundReady,
+  waitForShellReady,
+} from "./helpers.mjs";
+
+export { expect };
+
+export const test = base.extend({
+  /**
+   * Auto fixture: attaches a diagnostics collector and captures diagnostics
+   * on teardown. Eliminates the try/finally pattern in every test.
+   */
+  diagnostics: [
+    async ({ page }, use, testInfo) => {
+      const diagnostics = createDiagnosticsCollector(page);
+      await use(diagnostics);
+      await captureDiagnostics(page, testInfo, diagnostics);
+    },
+    { auto: true },
+  ],
+
+  /**
+   * Provides a playground helper with an open() method.
+   * open() calls openPlayground + waitForShellReady by default.
+   * Pass { waitForMoodle: true } to also wait for Moodle content.
+   */
+  playground: async ({ page }, use) => {
+    await use({
+      open: async (options = {}) => {
+        await openPlayground(page);
+        if (options.waitForMoodle) {
+          await waitForPlaygroundReady(page);
+        } else {
+          await waitForShellReady(page);
+        }
+      },
+    });
+  },
+
+  /**
+   * Provides the Moodle iframe frame locator directly.
+   */
+  moodle: async ({ page }, use) => {
+    await use(getMoodleFrame(page));
+  },
+});

--- a/tests/e2e/helpers.mjs
+++ b/tests/e2e/helpers.mjs
@@ -471,3 +471,7 @@ export async function clickFirstVisible(locatorFactories) {
 export function uniqueSuffix(testInfo) {
   return `${testInfo.project.name}-${Date.now()}`;
 }
+
+export function buildBlueprintParam(payload) {
+  return Buffer.from(JSON.stringify(payload)).toString("base64url");
+}

--- a/tests/e2e/moodle-boot.spec.mjs
+++ b/tests/e2e/moodle-boot.spec.mjs
@@ -1,10 +1,4 @@
-import { expect, test } from "@playwright/test";
-import {
-  captureDiagnostics,
-  createDiagnosticsCollector,
-  openPlayground,
-  waitForShellReady,
-} from "./helpers.mjs";
+import { expect, test } from "./fixtures.mjs";
 
 test.describe.configure({ timeout: 180_000 });
 
@@ -12,41 +6,31 @@ test.describe.configure({ timeout: 180_000 });
 // Moodle runtime boot tests
 // ---------------------------------------------------------------------------
 
-test("Moodle dashboard loads after boot", async ({ page }, testInfo) => {
-  const diagnostics = createDiagnosticsCollector(page);
-  try {
-    await openPlayground(page);
-    await waitForShellReady(page);
+test("Moodle dashboard loads after boot", async ({ page, playground }) => {
+  await playground.open();
 
-    const address = await page.locator("#address-input").inputValue();
-    expect(address).toMatch(/^\//);
-  } finally {
-    await captureDiagnostics(page, testInfo, diagnostics);
-  }
+  const address = await page.locator("#address-input").inputValue();
+  expect(address).toMatch(/^\//);
 });
 
 test("PHP Info tab captures runtime diagnostics", async ({
   page,
+  playground,
   browserName,
-}, testInfo) => {
+}) => {
   test.fixme(
     browserName === "firefox",
     "Temporarily disabled due to Firefox CI runtime readiness flakiness.",
   );
-  const diagnostics = createDiagnosticsCollector(page);
-  try {
-    await openPlayground(page);
-    await waitForShellReady(page);
 
-    await page.locator("#panel-toggle-button").click();
-    await page.locator("#phpinfo-tab").click();
-    await page.locator("#refresh-phpinfo-button").click();
+  await playground.open();
 
-    const phpinfoFrame = page.locator("#phpinfo-frame");
-    await expect(phpinfoFrame).toHaveAttribute("srcdoc", /PHP Version/, {
-      timeout: 30_000,
-    });
-  } finally {
-    await captureDiagnostics(page, testInfo, diagnostics);
-  }
+  await page.locator("#panel-toggle-button").click();
+  await page.locator("#phpinfo-tab").click();
+  await page.locator("#refresh-phpinfo-button").click();
+
+  const phpinfoFrame = page.locator("#phpinfo-frame");
+  await expect(phpinfoFrame).toHaveAttribute("srcdoc", /PHP Version/, {
+    timeout: 30_000,
+  });
 });

--- a/tests/e2e/php-networking.spec.mjs
+++ b/tests/e2e/php-networking.spec.mjs
@@ -4,10 +4,9 @@ import http from "node:http";
 import https from "node:https";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures.mjs";
 import {
-  captureDiagnostics,
-  createDiagnosticsCollector,
+  buildBlueprintParam,
   findMoodleFrame,
   waitForPlaygroundReady,
   waitForRuntimeFrameReady,
@@ -212,10 +211,6 @@ test.afterAll(async () => {
   }
 });
 
-function buildBlueprintParam(payload) {
-  return Buffer.from(JSON.stringify(payload)).toString("base64url");
-}
-
 function buildNetworkingBlueprint(siteName, files) {
   return buildBlueprintParam({
     landingPage: "/my/",
@@ -272,9 +267,9 @@ test.beforeEach(() => {
 test("PHP direct HTTPS to a self-signed local server still fails before proxy fallback", async ({
   page,
   browserName,
-}, testInfo) => {
+}) => {
   test.skip(browserName === "firefox");
-  const diagnostics = createDiagnosticsCollector(page);
+
   const bp = buildNetworkingBlueprint("PHP Local HTTPS Test", [
     {
       path: "/www/moodle/playground-net-local-https.php",
@@ -282,35 +277,31 @@ test("PHP direct HTTPS to a self-signed local server still fails before proxy fa
     },
   ]);
 
-  try {
-    await page.goto(`/?blueprint=${bp}`);
-    await waitForPlaygroundReady(page);
+  await page.goto(`/?blueprint=${bp}`);
+  await waitForPlaygroundReady(page);
 
-    const result = await fetchPhpJson(
-      page,
-      "/playground/main/php83-moodle50/playground-net-local-https.php",
-    );
+  const result = await fetchPhpJson(
+    page,
+    "/playground/main/php83-moodle50/playground-net-local-https.php",
+  );
 
-    expect(result.moodle_playground).toBe(true);
-    expect(result.url).toBe(`${localHttpsBaseUrl}/plain`);
-    expect(result.fgc_ok).toBe(false);
-    expect(result.fgc_error).toMatch(/Failed to open stream: operation failed/);
-    expect(result.fgc_body).toBeNull();
-    expect(result.curl_errno).toBe(35);
-    expect(result.curl_error).toMatch(/SSL_ERROR_SYSCALL|UnknownCa|ASN1/i);
-    expect(result.curl_http_code).toBe(0);
-    expect(result.curl_body).toBeNull();
-  } finally {
-    await captureDiagnostics(page, testInfo, diagnostics);
-  }
+  expect(result.moodle_playground).toBe(true);
+  expect(result.url).toBe(`${localHttpsBaseUrl}/plain`);
+  expect(result.fgc_ok).toBe(false);
+  expect(result.fgc_error).toMatch(/Failed to open stream: operation failed/);
+  expect(result.fgc_body).toBeNull();
+  expect([35, 77]).toContain(result.curl_errno);
+  expect(result.curl_error).toMatch(/SSL_ERROR_SYSCALL|UnknownCa|ASN1|CAfile/i);
+  expect(result.curl_http_code).toBe(0);
+  expect(result.curl_body).toBeNull();
 });
 
 test("PHP can fetch GitHub releases atom feed through the same-origin playground proxy", async ({
   page,
   browserName,
-}, testInfo) => {
+}) => {
   test.skip(browserName === "firefox");
-  const diagnostics = createDiagnosticsCollector(page);
+
   const bp = buildNetworkingBlueprint("PHP Networking Test", [
     {
       path: "/www/moodle/playground-net-github.php",
@@ -319,37 +310,32 @@ test("PHP can fetch GitHub releases atom feed through the same-origin playground
     },
   ]);
 
-  try {
-    await page.goto(
-      `/?blueprint=${bp}&addonProxyUrl=${encodeURIComponent(localAddonProxyBaseUrl)}`,
-    );
-    await waitForPlaygroundReady(page);
+  await page.goto(
+    `/?blueprint=${bp}&addonProxyUrl=${encodeURIComponent(localAddonProxyBaseUrl)}`,
+  );
+  await waitForPlaygroundReady(page);
 
-    const result = await fetchPhpJson(
-      page,
-      "/playground/main/php83-moodle50/playground-net-github.php",
-    );
+  const result = await fetchPhpJson(
+    page,
+    "/playground/main/php83-moodle50/playground-net-github.php",
+  );
 
-    expect(result.moodle_playground).toBe(true);
-    expect(result.url).toContain(
-      "/__playground_proxy__?repo=exelearning%2Fexelearning&atom=releases",
-    );
-    expect(result.fgc_ok).toBe(true);
-    expect(result.fgc_body_prefix).toMatch(/<feed|<\?xml/i);
-    expect(result.curl_errno).toBe(0);
-    expect(result.curl_http_code).toBe(200);
-    expect(result.curl_body_prefix).toMatch(/<feed|<\?xml/i);
-  } finally {
-    await captureDiagnostics(page, testInfo, diagnostics);
-  }
+  expect(result.moodle_playground).toBe(true);
+  expect(result.url).toContain(
+    "/__playground_proxy__?repo=exelearning%2Fexelearning&atom=releases",
+  );
+  expect(result.fgc_ok).toBe(true);
+  expect(result.fgc_body_prefix).toMatch(/<feed|<\?xml/i);
+  expect(result.curl_errno).toBe(0);
+  expect(result.curl_http_code).toBe(200);
+  expect(result.curl_body_prefix).toMatch(/<feed|<\?xml/i);
 });
 
 test("PHP HTTP requests fall back to the configured phpCorsProxyUrl", async ({
   page,
   browserName,
-}, testInfo) => {
+}) => {
   test.skip(browserName === "firefox");
-  const diagnostics = createDiagnosticsCollector(page);
 
   const bp = buildNetworkingBlueprint("PHP Networking Proxy Fallback Test", [
     {
@@ -359,45 +345,39 @@ test("PHP HTTP requests fall back to the configured phpCorsProxyUrl", async ({
     },
   ]);
 
-  try {
-    await page.goto(
-      `/?blueprint=${bp}&phpCorsProxyUrl=${encodeURIComponent(localCorsProxyBaseUrl)}`,
-    );
-    await waitForPlaygroundReady(page);
+  await page.goto(
+    `/?blueprint=${bp}&phpCorsProxyUrl=${encodeURIComponent(localCorsProxyBaseUrl)}`,
+  );
+  await waitForPlaygroundReady(page);
 
-    const result = await fetchPhpJson(
-      page,
-      "/playground/main/php83-moodle50/playground-net-fallback.php",
-    );
+  const result = await fetchPhpJson(
+    page,
+    "/playground/main/php83-moodle50/playground-net-fallback.php",
+  );
 
-    expect(result.moodle_playground).toBe(true);
-    expect(result.url).toBe("http://remote-server.example/plain");
-    expect(result.fgc_ok).toBe(true);
-    expect(result.fgc_body).toBe("proxy-fallback-ok");
-    expect(result.curl_errno).toBe(0);
-    expect(result.curl_http_code).toBe(200);
-    expect(result.curl_body).toBe("proxy-fallback-ok");
-    expect(
-      localCorsProxyHits
-        .filter(
-          ({ target }) => target === "https://remote-server.example/plain",
-        )
-        .map(({ method, target }) => ({ method, target })),
-    ).toEqual([
-      { method: "GET", target: "https://remote-server.example/plain" },
-      { method: "GET", target: "https://remote-server.example/plain" },
-    ]);
-  } finally {
-    await captureDiagnostics(page, testInfo, diagnostics);
-  }
+  expect(result.moodle_playground).toBe(true);
+  expect(result.url).toBe("http://remote-server.example/plain");
+  expect(result.fgc_ok).toBe(true);
+  expect(result.fgc_body).toBe("proxy-fallback-ok");
+  expect(result.curl_errno).toBe(0);
+  expect(result.curl_http_code).toBe(200);
+  expect(result.curl_body).toBe("proxy-fallback-ok");
+  expect(
+    localCorsProxyHits
+      .filter(({ target }) => target === "https://remote-server.example/plain")
+      .map(({ method, target }) => ({ method, target })),
+  ).toEqual([
+    { method: "GET", target: "https://remote-server.example/plain" },
+    { method: "GET", target: "https://remote-server.example/plain" },
+  ]);
 });
 
 test("PHP direct HTTPS works for a CORS-open external URL", async ({
   page,
   browserName,
-}, testInfo) => {
+}) => {
   test.skip(browserName === "firefox");
-  const diagnostics = createDiagnosticsCollector(page);
+
   const bp = buildNetworkingBlueprint("PHP Networking Direct Test", [
     {
       path: "/www/moodle/playground-net-external-https.php",
@@ -406,40 +386,36 @@ test("PHP direct HTTPS works for a CORS-open external URL", async ({
     },
   ]);
 
-  try {
-    await page.goto(`/?blueprint=${bp}`);
-    await waitForPlaygroundReady(page);
+  await page.goto(`/?blueprint=${bp}`);
+  await waitForPlaygroundReady(page);
 
-    const result = await fetchPhpJson(
-      page,
-      "/playground/main/php83-moodle50/playground-net-external-https.php",
-    );
+  const result = await fetchPhpJson(
+    page,
+    "/playground/main/php83-moodle50/playground-net-external-https.php",
+  );
 
-    expect(result.moodle_playground).toBe(true);
-    expect(result.url).toBe(
-      "https://raw.githubusercontent.com/WordPress/wordpress-playground/5e5ba3e0f5b984ceadd5cbe6e661828c14621d25/README.md",
-    );
-    expect(result.fgc_ok).toBe(true);
-    expect(result.fgc_body_prefix).toMatch(
-      /WordPress Playground|PHP\.wasm|Playground/i,
-    );
-    expect(result.curl_errno).toBe(0);
-    expect(result.curl_error).toBe("");
-    expect(result.curl_http_code).toBe(200);
-    expect(result.curl_body_prefix).toMatch(
-      /WordPress Playground|PHP\.wasm|Playground/i,
-    );
-  } finally {
-    await captureDiagnostics(page, testInfo, diagnostics);
-  }
+  expect(result.moodle_playground).toBe(true);
+  expect(result.url).toBe(
+    "https://raw.githubusercontent.com/WordPress/wordpress-playground/5e5ba3e0f5b984ceadd5cbe6e661828c14621d25/README.md",
+  );
+  expect(result.fgc_ok).toBe(true);
+  expect(result.fgc_body_prefix).toMatch(
+    /WordPress Playground|PHP\.wasm|Playground/i,
+  );
+  expect(result.curl_errno).toBe(0);
+  expect(result.curl_error).toBe("");
+  expect(result.curl_http_code).toBe(200);
+  expect(result.curl_body_prefix).toMatch(
+    /WordPress Playground|PHP\.wasm|Playground/i,
+  );
 });
 
 test("PHP direct HTTPS can fetch the eXeLearning GitHub releases feed", async ({
   page,
   browserName,
-}, testInfo) => {
+}) => {
   test.skip(browserName === "firefox");
-  const diagnostics = createDiagnosticsCollector(page);
+
   const bp = buildNetworkingBlueprint("PHP GitHub Feed Direct Test", [
     {
       path: "/www/moodle/playground-net-github-feed-direct.php",
@@ -447,37 +423,33 @@ test("PHP direct HTTPS can fetch the eXeLearning GitHub releases feed", async ({
     },
   ]);
 
-  try {
-    await page.goto(
-      `/?blueprint=${bp}&phpCorsProxyUrl=${encodeURIComponent(localCorsProxyBaseUrl)}`,
-    );
-    await waitForPlaygroundReady(page);
+  await page.goto(
+    `/?blueprint=${bp}&phpCorsProxyUrl=${encodeURIComponent(localCorsProxyBaseUrl)}`,
+  );
+  await waitForPlaygroundReady(page);
 
-    const result = await fetchPhpJson(
-      page,
-      "/playground/main/php83-moodle50/playground-net-github-feed-direct.php",
-    );
+  const result = await fetchPhpJson(
+    page,
+    "/playground/main/php83-moodle50/playground-net-github-feed-direct.php",
+  );
 
-    expect(result.moodle_playground).toBe(true);
-    expect(result.url).toBe(EXELEARNING_RELEASES_ATOM_URL);
-    expect(result.fgc_ok).toBe(true);
-    expect(result.fgc_error).toBeNull();
-    expect(result.fgc_body_prefix).toMatch(/<feed|<\?xml/i);
-    expect(result.curl_errno).toBe(0);
-    expect(result.curl_error).toBe("");
-    expect(result.curl_http_code).toBe(200);
-    expect(result.curl_body_prefix).toMatch(/<feed|<\?xml/i);
-  } finally {
-    await captureDiagnostics(page, testInfo, diagnostics);
-  }
+  expect(result.moodle_playground).toBe(true);
+  expect(result.url).toBe(EXELEARNING_RELEASES_ATOM_URL);
+  expect(result.fgc_ok).toBe(true);
+  expect(result.fgc_error).toBeNull();
+  expect(result.fgc_body_prefix).toMatch(/<feed|<\?xml/i);
+  expect(result.curl_errno).toBe(0);
+  expect(result.curl_error).toBe("");
+  expect(result.curl_http_code).toBe(200);
+  expect(result.curl_body_prefix).toMatch(/<feed|<\?xml/i);
 });
 
 test("PHP direct HTTPS can fetch the eXeLearning GitHub release ZIP asset", async ({
   page,
   browserName,
-}, testInfo) => {
+}) => {
   test.skip(browserName === "firefox");
-  const diagnostics = createDiagnosticsCollector(page);
+
   const bp = buildNetworkingBlueprint("PHP GitHub Asset Direct Test", [
     {
       path: "/www/moodle/playground-net-github-asset-direct.php",
@@ -485,41 +457,36 @@ test("PHP direct HTTPS can fetch the eXeLearning GitHub release ZIP asset", asyn
     },
   ]);
 
-  try {
-    await page.goto(
-      `/?blueprint=${bp}&phpCorsProxyUrl=${encodeURIComponent(localCorsProxyBaseUrl)}`,
-    );
-    await waitForPlaygroundReady(page);
+  await page.goto(
+    `/?blueprint=${bp}&phpCorsProxyUrl=${encodeURIComponent(localCorsProxyBaseUrl)}`,
+  );
+  await waitForPlaygroundReady(page);
 
-    const result = await fetchPhpJson(
-      page,
-      "/playground/main/php83-moodle50/playground-net-github-asset-direct.php",
-    );
+  const result = await fetchPhpJson(
+    page,
+    "/playground/main/php83-moodle50/playground-net-github-asset-direct.php",
+  );
 
-    expect(result.moodle_playground).toBe(true);
-    expect(result.url).toBe(EXELEARNING_RELEASE_ASSET_URL);
-    expect(result.fgc_ok).toBe(true);
-    expect(result.fgc_error).toBeNull();
-    expect(result.fgc_prefix_hex).toBe("504b0304");
-    expect(result.curl_errno).toBe(0);
-    expect(result.curl_error).toBe("");
-    expect([200, 206]).toContain(result.curl_http_code);
-    expect(result.curl_prefix_hex).toBe("504b0304");
-  } finally {
-    await captureDiagnostics(page, testInfo, diagnostics);
-  }
+  expect(result.moodle_playground).toBe(true);
+  expect(result.url).toBe(EXELEARNING_RELEASE_ASSET_URL);
+  expect(result.fgc_ok).toBe(true);
+  expect(result.fgc_error).toBeNull();
+  expect(result.fgc_prefix_hex).toBe("504b0304");
+  expect(result.curl_errno).toBe(0);
+  expect(result.curl_error).toBe("");
+  expect([200, 206]).toContain(result.curl_http_code);
+  expect(result.curl_prefix_hex).toBe("504b0304");
 });
 
 test("Firefox: PHP networking scenarios complete within three runtime boots", async ({
   page,
   browserName,
-}, testInfo) => {
+}) => {
   test.skip(browserName !== "firefox");
   test.fixme(
     browserName === "firefox",
     "Temporarily disabled due to Firefox CI runtime readiness flakiness.",
   );
-  const diagnostics = createDiagnosticsCollector(page);
 
   const defaultBlueprint = buildNetworkingBlueprint(
     "PHP Networking Firefox Default",
@@ -564,118 +531,112 @@ test("Firefox: PHP networking scenarios complete within three runtime boots", as
     ],
   );
 
-  try {
-    await page.goto(`/?blueprint=${defaultBlueprint}`);
-    await waitForRuntimeFrameReady(page);
+  await page.goto(`/?blueprint=${defaultBlueprint}`);
+  await waitForRuntimeFrameReady(page);
 
-    const localHttpsResult = await fetchPhpJson(
-      page,
-      "/playground/main/php83-moodle50/playground-net-local-https.php",
-    );
-    expect(localHttpsResult.moodle_playground).toBe(true);
-    expect(localHttpsResult.url).toBe(`${localHttpsBaseUrl}/plain`);
-    expect(localHttpsResult.fgc_ok).toBe(false);
-    expect(localHttpsResult.fgc_error).toMatch(
-      /Failed to open stream: operation failed/,
-    );
-    expect(localHttpsResult.fgc_body).toBeNull();
-    expect(localHttpsResult.curl_errno).toBe(35);
-    expect(localHttpsResult.curl_error).toMatch(
-      /SSL_ERROR_SYSCALL|UnknownCa|ASN1/i,
-    );
-    expect(localHttpsResult.curl_http_code).toBe(0);
-    expect(localHttpsResult.curl_body).toBeNull();
+  const localHttpsResult = await fetchPhpJson(
+    page,
+    "/playground/main/php83-moodle50/playground-net-local-https.php",
+  );
+  expect(localHttpsResult.moodle_playground).toBe(true);
+  expect(localHttpsResult.url).toBe(`${localHttpsBaseUrl}/plain`);
+  expect(localHttpsResult.fgc_ok).toBe(false);
+  expect(localHttpsResult.fgc_error).toMatch(
+    /Failed to open stream: operation failed/,
+  );
+  expect(localHttpsResult.fgc_body).toBeNull();
+  expect(localHttpsResult.curl_errno).toBe(35);
+  expect(localHttpsResult.curl_error).toMatch(
+    /SSL_ERROR_SYSCALL|UnknownCa|ASN1/i,
+  );
+  expect(localHttpsResult.curl_http_code).toBe(0);
+  expect(localHttpsResult.curl_body).toBeNull();
 
-    const externalResult = await fetchPhpJson(
-      page,
-      "/playground/main/php83-moodle50/playground-net-external-https.php",
-    );
-    expect(externalResult.moodle_playground).toBe(true);
-    expect(externalResult.fgc_ok).toBe(true);
-    expect(externalResult.fgc_body_prefix).toMatch(
-      /WordPress Playground|PHP\.wasm|Playground/i,
-    );
-    expect(externalResult.curl_errno).toBe(0);
-    expect(externalResult.curl_error).toBe("");
-    expect(externalResult.curl_http_code).toBe(200);
-    expect(externalResult.curl_body_prefix).toMatch(
-      /WordPress Playground|PHP\.wasm|Playground/i,
-    );
+  const externalResult = await fetchPhpJson(
+    page,
+    "/playground/main/php83-moodle50/playground-net-external-https.php",
+  );
+  expect(externalResult.moodle_playground).toBe(true);
+  expect(externalResult.fgc_ok).toBe(true);
+  expect(externalResult.fgc_body_prefix).toMatch(
+    /WordPress Playground|PHP\.wasm|Playground/i,
+  );
+  expect(externalResult.curl_errno).toBe(0);
+  expect(externalResult.curl_error).toBe("");
+  expect(externalResult.curl_http_code).toBe(200);
+  expect(externalResult.curl_body_prefix).toMatch(
+    /WordPress Playground|PHP\.wasm|Playground/i,
+  );
 
-    await page.goto(
-      `/?blueprint=${addonProxyBlueprint}&addonProxyUrl=${encodeURIComponent(localAddonProxyBaseUrl)}`,
-    );
-    await waitForRuntimeFrameReady(page);
+  await page.goto(
+    `/?blueprint=${addonProxyBlueprint}&addonProxyUrl=${encodeURIComponent(localAddonProxyBaseUrl)}`,
+  );
+  await waitForRuntimeFrameReady(page);
 
-    const sameOriginProxyResult = await fetchPhpJson(
-      page,
-      "/playground/main/php83-moodle50/playground-net-github.php",
-    );
-    expect(sameOriginProxyResult.moodle_playground).toBe(true);
-    expect(sameOriginProxyResult.url).toContain(
-      "/__playground_proxy__?repo=exelearning%2Fexelearning&atom=releases",
-    );
-    expect(sameOriginProxyResult.fgc_ok).toBe(true);
-    expect(sameOriginProxyResult.fgc_body_prefix).toMatch(/<feed|<\?xml/i);
-    expect(sameOriginProxyResult.curl_errno).toBe(0);
-    expect(sameOriginProxyResult.curl_http_code).toBe(200);
-    expect(sameOriginProxyResult.curl_body_prefix).toMatch(/<feed|<\?xml/i);
+  const sameOriginProxyResult = await fetchPhpJson(
+    page,
+    "/playground/main/php83-moodle50/playground-net-github.php",
+  );
+  expect(sameOriginProxyResult.moodle_playground).toBe(true);
+  expect(sameOriginProxyResult.url).toContain(
+    "/__playground_proxy__?repo=exelearning%2Fexelearning&atom=releases",
+  );
+  expect(sameOriginProxyResult.fgc_ok).toBe(true);
+  expect(sameOriginProxyResult.fgc_body_prefix).toMatch(/<feed|<\?xml/i);
+  expect(sameOriginProxyResult.curl_errno).toBe(0);
+  expect(sameOriginProxyResult.curl_http_code).toBe(200);
+  expect(sameOriginProxyResult.curl_body_prefix).toMatch(/<feed|<\?xml/i);
 
-    await page.goto(
-      `/?blueprint=${phpCorsBlueprint}&phpCorsProxyUrl=${encodeURIComponent(localCorsProxyBaseUrl)}`,
-    );
-    await waitForRuntimeFrameReady(page);
+  await page.goto(
+    `/?blueprint=${phpCorsBlueprint}&phpCorsProxyUrl=${encodeURIComponent(localCorsProxyBaseUrl)}`,
+  );
+  await waitForRuntimeFrameReady(page);
 
-    const fallbackResult = await fetchPhpJson(
-      page,
-      "/playground/main/php83-moodle50/playground-net-fallback.php",
-    );
-    expect(fallbackResult.moodle_playground).toBe(true);
-    expect(fallbackResult.url).toBe("http://remote-server.example/plain");
-    expect(fallbackResult.fgc_ok).toBe(true);
-    expect(fallbackResult.fgc_body).toBe("proxy-fallback-ok");
-    expect(fallbackResult.curl_errno).toBe(0);
-    expect(fallbackResult.curl_http_code).toBe(200);
-    expect(fallbackResult.curl_body).toBe("proxy-fallback-ok");
-    expect(
-      localCorsProxyHits
-        .filter(
-          ({ target }) => target === "https://remote-server.example/plain",
-        )
-        .map(({ method, target }) => ({ method, target })),
-    ).toEqual([
-      { method: "GET", target: "https://remote-server.example/plain" },
-      { method: "GET", target: "https://remote-server.example/plain" },
-    ]);
+  const fallbackResult = await fetchPhpJson(
+    page,
+    "/playground/main/php83-moodle50/playground-net-fallback.php",
+  );
+  expect(fallbackResult.moodle_playground).toBe(true);
+  expect(fallbackResult.url).toBe("http://remote-server.example/plain");
+  expect(fallbackResult.fgc_ok).toBe(true);
+  expect(fallbackResult.fgc_body).toBe("proxy-fallback-ok");
+  expect(fallbackResult.curl_errno).toBe(0);
+  expect(fallbackResult.curl_http_code).toBe(200);
+  expect(fallbackResult.curl_body).toBe("proxy-fallback-ok");
+  expect(
+    localCorsProxyHits
+      .filter(({ target }) => target === "https://remote-server.example/plain")
+      .map(({ method, target }) => ({ method, target })),
+  ).toEqual([
+    { method: "GET", target: "https://remote-server.example/plain" },
+    { method: "GET", target: "https://remote-server.example/plain" },
+  ]);
 
-    const directFeedResult = await fetchPhpJson(
-      page,
-      "/playground/main/php83-moodle50/playground-net-github-feed-direct.php",
-    );
-    expect(directFeedResult.moodle_playground).toBe(true);
-    expect(directFeedResult.url).toBe(EXELEARNING_RELEASES_ATOM_URL);
-    expect(directFeedResult.fgc_ok).toBe(true);
-    expect(directFeedResult.fgc_error).toBeNull();
-    expect(directFeedResult.fgc_body_prefix).toMatch(/<feed|<\?xml/i);
-    expect(directFeedResult.curl_errno).toBe(0);
-    expect(directFeedResult.curl_error).toBe("");
-    expect(directFeedResult.curl_http_code).toBe(200);
-    expect(directFeedResult.curl_body_prefix).toMatch(/<feed|<\?xml/i);
+  const directFeedResult = await fetchPhpJson(
+    page,
+    "/playground/main/php83-moodle50/playground-net-github-feed-direct.php",
+  );
+  expect(directFeedResult.moodle_playground).toBe(true);
+  expect(directFeedResult.url).toBe(EXELEARNING_RELEASES_ATOM_URL);
+  expect(directFeedResult.fgc_ok).toBe(true);
+  expect(directFeedResult.fgc_error).toBeNull();
+  expect(directFeedResult.fgc_body_prefix).toMatch(/<feed|<\?xml/i);
+  expect(directFeedResult.curl_errno).toBe(0);
+  expect(directFeedResult.curl_error).toBe("");
+  expect(directFeedResult.curl_http_code).toBe(200);
+  expect(directFeedResult.curl_body_prefix).toMatch(/<feed|<\?xml/i);
 
-    const directAssetResult = await fetchPhpJson(
-      page,
-      "/playground/main/php83-moodle50/playground-net-github-asset-direct.php",
-    );
-    expect(directAssetResult.moodle_playground).toBe(true);
-    expect(directAssetResult.url).toBe(EXELEARNING_RELEASE_ASSET_URL);
-    expect(directAssetResult.fgc_ok).toBe(true);
-    expect(directAssetResult.fgc_error).toBeNull();
-    expect(directAssetResult.fgc_prefix_hex).toBe("504b0304");
-    expect(directAssetResult.curl_errno).toBe(0);
-    expect(directAssetResult.curl_error).toBe("");
-    expect([200, 206]).toContain(directAssetResult.curl_http_code);
-    expect(directAssetResult.curl_prefix_hex).toBe("504b0304");
-  } finally {
-    await captureDiagnostics(page, testInfo, diagnostics);
-  }
+  const directAssetResult = await fetchPhpJson(
+    page,
+    "/playground/main/php83-moodle50/playground-net-github-asset-direct.php",
+  );
+  expect(directAssetResult.moodle_playground).toBe(true);
+  expect(directAssetResult.url).toBe(EXELEARNING_RELEASE_ASSET_URL);
+  expect(directAssetResult.fgc_ok).toBe(true);
+  expect(directAssetResult.fgc_error).toBeNull();
+  expect(directAssetResult.fgc_prefix_hex).toBe("504b0304");
+  expect(directAssetResult.curl_errno).toBe(0);
+  expect(directAssetResult.curl_error).toBe("");
+  expect([200, 206]).toContain(directAssetResult.curl_http_code);
+  expect(directAssetResult.curl_prefix_hex).toBe("504b0304");
 });

--- a/tests/e2e/shell.spec.mjs
+++ b/tests/e2e/shell.spec.mjs
@@ -1,18 +1,10 @@
-import { expect, test } from "@playwright/test";
-import {
-  captureDiagnostics,
-  createDiagnosticsCollector,
-  openPlayground,
-  waitForShellReady,
-} from "./helpers.mjs";
+import { expect, test } from "./fixtures.mjs";
+import { buildBlueprintParam, waitForShellReady } from "./helpers.mjs";
 
 test.describe.configure({ timeout: 180_000 });
 
-/**
- * Encode a blueprint object as base64url for the ?blueprint= query param.
- */
-function buildBlueprintParam(overrides = {}) {
-  const payload = {
+function buildDefaultBlueprintParam(overrides = {}) {
+  return buildBlueprintParam({
     landingPage: "/my/",
     preferredVersions: { php: "8.3", moodle: "5.0" },
     steps: [
@@ -29,9 +21,7 @@ function buildBlueprintParam(overrides = {}) {
       { step: "setLandingPage", path: "/my/" },
     ],
     ...overrides,
-  };
-
-  return Buffer.from(JSON.stringify(payload)).toString("base64url");
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -40,144 +30,106 @@ function buildBlueprintParam(overrides = {}) {
 
 test("loads the shell and boots the Moodle runtime", async ({
   page,
-}, testInfo) => {
-  const diagnostics = createDiagnosticsCollector(page);
-  try {
-    await openPlayground(page);
-    await waitForShellReady(page);
+  playground,
+}) => {
+  await playground.open();
 
-    const address = await page.locator("#address-input").inputValue();
-    expect(address).toBeTruthy();
-    expect(address.startsWith("/")).toBe(true);
-  } finally {
-    await captureDiagnostics(page, testInfo, diagnostics);
-  }
+  const address = await page.locator("#address-input").inputValue();
+  expect(address).toBeTruthy();
+  expect(address.startsWith("/")).toBe(true);
 });
 
-test("side panel opens and shows tabs", async ({ page }, testInfo) => {
-  const diagnostics = createDiagnosticsCollector(page);
-  try {
-    await openPlayground(page);
-    await waitForShellReady(page);
+test("side panel opens and shows tabs", async ({ page, playground }) => {
+  await playground.open();
 
-    await expect(page.locator("#panel-toggle-button")).toHaveAttribute(
-      "aria-expanded",
-      "false",
-    );
+  await expect(page.locator("#panel-toggle-button")).toHaveAttribute(
+    "aria-expanded",
+    "false",
+  );
 
-    await page.locator("#panel-toggle-button").click();
-    await expect(page.locator("#panel-toggle-button")).toHaveAttribute(
-      "aria-expanded",
-      "true",
-    );
-    await expect(page.locator("#side-panel")).not.toHaveClass(/is-collapsed/);
+  await page.locator("#panel-toggle-button").click();
+  await expect(page.locator("#panel-toggle-button")).toHaveAttribute(
+    "aria-expanded",
+    "true",
+  );
+  await expect(page.locator("#side-panel")).not.toHaveClass(/is-collapsed/);
 
-    await expect(page.locator("#current-moodle-label")).not.toHaveText("-");
-    await expect(page.locator("#current-php-label")).not.toHaveText("-");
-    await expect(page.locator("#current-runtime-label")).not.toHaveText("-");
-  } finally {
-    await captureDiagnostics(page, testInfo, diagnostics);
-  }
+  await expect(page.locator("#current-moodle-label")).not.toHaveText("-");
+  await expect(page.locator("#current-php-label")).not.toHaveText("-");
+  await expect(page.locator("#current-runtime-label")).not.toHaveText("-");
 });
 
-test("logs tab displays runtime log entries", async ({ page }, testInfo) => {
-  const diagnostics = createDiagnosticsCollector(page);
-  try {
-    await openPlayground(page);
-    await waitForShellReady(page);
+test("logs tab displays runtime log entries", async ({ page, playground }) => {
+  await playground.open();
 
-    await page.locator("#panel-toggle-button").click();
-    await page.locator("#logs-tab").click();
-    await expect(page.locator("#log-panel")).toBeVisible();
+  await page.locator("#panel-toggle-button").click();
+  await page.locator("#logs-tab").click();
+  await expect(page.locator("#log-panel")).toBeVisible();
 
-    const logText = await page.locator("#log-panel").textContent();
-    expect(logText.length).toBeGreaterThan(0);
-  } finally {
-    await captureDiagnostics(page, testInfo, diagnostics);
-  }
+  const logText = await page.locator("#log-panel").textContent();
+  expect(logText.length).toBeGreaterThan(0);
 });
 
 test("blueprint tab shows the active blueprint JSON", async ({
   page,
-}, testInfo) => {
-  const diagnostics = createDiagnosticsCollector(page);
-  try {
-    await openPlayground(page);
-    await waitForShellReady(page);
+  playground,
+}) => {
+  await playground.open();
 
-    await page.locator("#panel-toggle-button").click();
-    await page.locator("#blueprint-tab").click();
-    await expect(page.locator("#blueprint-textarea")).toBeVisible();
+  await page.locator("#panel-toggle-button").click();
+  await page.locator("#blueprint-tab").click();
+  await expect(page.locator("#blueprint-textarea")).toBeVisible();
 
-    const blueprintText = await page
-      .locator("#blueprint-textarea")
-      .inputValue();
-    expect(blueprintText).toContain('"steps"');
-    expect(blueprintText).toContain('"installMoodle"');
-  } finally {
-    await captureDiagnostics(page, testInfo, diagnostics);
-  }
+  const blueprintText = await page.locator("#blueprint-textarea").inputValue();
+  expect(blueprintText).toContain('"steps"');
+  expect(blueprintText).toContain('"installMoodle"');
 });
 
 test("settings popover opens and shows version selectors", async ({
   page,
-}, testInfo) => {
-  const diagnostics = createDiagnosticsCollector(page);
-  try {
-    await openPlayground(page);
-    await waitForShellReady(page);
+  playground,
+}) => {
+  await playground.open();
 
-    await page.locator("#settings-button").click();
-    await expect(page.locator("#settings-popover")).toHaveClass(/is-open/);
+  await page.locator("#settings-button").click();
+  await expect(page.locator("#settings-popover")).toHaveClass(/is-open/);
 
-    const moodleOptions = await page
-      .locator("#settings-moodle-version option")
-      .count();
-    expect(moodleOptions).toBeGreaterThan(0);
+  const moodleOptions = await page
+    .locator("#settings-moodle-version option")
+    .count();
+  expect(moodleOptions).toBeGreaterThan(0);
 
-    const phpOptions = await page
-      .locator("#settings-php-version option")
-      .count();
-    expect(phpOptions).toBeGreaterThan(0);
-  } finally {
-    await captureDiagnostics(page, testInfo, diagnostics);
-  }
+  const phpOptions = await page.locator("#settings-php-version option").count();
+  expect(phpOptions).toBeGreaterThan(0);
 });
 
 // ---------------------------------------------------------------------------
 // Blueprint override test
 // ---------------------------------------------------------------------------
 
-test("accepts blueprint via ?blueprint= query param", async ({
-  page,
-}, testInfo) => {
-  const diagnostics = createDiagnosticsCollector(page);
-  try {
-    const bp = buildBlueprintParam({
-      steps: [
-        {
-          step: "installMoodle",
-          options: {
-            adminUser: "admin",
-            adminPass: "password",
-            adminEmail: "admin@example.com",
-            siteName: "E2E Custom Site",
-          },
+test("accepts blueprint via ?blueprint= query param", async ({ page }) => {
+  const bp = buildDefaultBlueprintParam({
+    steps: [
+      {
+        step: "installMoodle",
+        options: {
+          adminUser: "admin",
+          adminPass: "password",
+          adminEmail: "admin@example.com",
+          siteName: "E2E Custom Site",
         },
-        { step: "login", username: "admin" },
-        { step: "setLandingPage", path: "/my/" },
-      ],
-    });
+      },
+      { step: "login", username: "admin" },
+      { step: "setLandingPage", path: "/my/" },
+    ],
+  });
 
-    await page.goto(`/?blueprint=${bp}`);
-    await waitForShellReady(page);
+  await page.goto(`/?blueprint=${bp}`);
+  await waitForShellReady(page);
 
-    await page.locator("#panel-toggle-button").click();
-    await page.locator("#blueprint-tab").click();
-    await expect(page.locator("#blueprint-textarea")).toHaveValue(
-      /E2E Custom Site/,
-    );
-  } finally {
-    await captureDiagnostics(page, testInfo, diagnostics);
-  }
+  await page.locator("#panel-toggle-button").click();
+  await page.locator("#blueprint-tab").click();
+  await expect(page.locator("#blueprint-textarea")).toHaveValue(
+    /E2E Custom Site/,
+  );
 });


### PR DESCRIPTION
## Summary

- **ZIP extraction**: Switch blueprint steps from `fflate` to `@php-wasm/stream-compression`, extract shared `readZipEntries()` helper eliminating duplicated streaming code across 3 files. Use direct MEMFS `mkdirTree()` instead of `php.run(mkdir)` for faster unzip.
- **Blueprint provisioning**: Add package filearea extraction for modules (exeweb/scorm), support custom fields on `addModule`, fix `runMoodleUpgrade` to respect `webRoot` parameter, add retry on transient 502/503 proxy errors.
- **Shell**: Blueprint import now triggers a full page reload for clean WASM state instead of in-place mutation. Remove sessionStorage blueprint reuse on bare URL navigations.
- **E2E tests**: Extract shared fixtures (`diagnostics`, `playground`, `moodle`) and `buildBlueprintParam` helper, removing boilerplate and 3 duplicate function copies across test files.
- **Lint & quality**: Fix all 5 Biome warnings (unused imports/params), update schema version, condense excessive comments, remove dual progress reporting in bootstrap.

## Test plan

- [x] All 310 unit tests passing (`make test`)
- [x] Biome lint clean (`make lint`) — 0 warnings
- [x] All source files pass syntax check (`node --check`)
- [ ] E2E Chromium tests pass (`make test-e2e-chrome`)
- [ ] E2E Firefox tests pass (`make test-e2e-firefox`)
- [ ] CI pipeline passes (lint, build, e2e-chromium, e2e-firefox)