### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete string escaping or encoding

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -470,8 +470,12 @@ function rewriteHtmlDocument(html, scope) {
   // scoped runtime and hit the static dev server (405 Method Not Allowed).
   // Moodle JSON-escapes forward slashes in its inline JS config, so we must
   // match both escaped (http:\/\/host) and unescaped (http://host) forms.
-  const jsonEscapedOrigin = origin.replace(/\//gu, "\\/");
-  const jsonEscapedBase = scopedBase.replace(/\//gu, "\\/");
+  const jsonEscapedOrigin = origin
+    .replace(/\\/gu, "\\\\")
+    .replace(/\//gu, "\\/");
+  const jsonEscapedBase = scopedBase
+    .replace(/\\/gu, "\\\\")
+    .replace(/\//gu, "\\/");
   // Match JSON-escaped form: "wwwroot":"http:\/\/localhost:8080"
   result = result.replaceAll(
     `"wwwroot":"${jsonEscapedOrigin}"`,


### PR DESCRIPTION
Potential fix for [https://github.com/ateeducacion/moodle-playground/security/code-scanning/3](https://github.com/ateeducacion/moodle-playground/security/code-scanning/3)

In general, when implementing custom JSON-like escaping, you must first escape the escape character (`\`) itself before escaping other characters such as `/`. This avoids cases where an input containing `\` followed by a character you later escape leads to the backslash being interpreted as escaping the escape sequence, breaking the encoding.

The best minimal fix here is to ensure that both `origin` and `scopedBase` have their backslashes escaped before the forward slashes are JSON-escaped. This can be done by applying `.replace(/\\/gu, "\\\\")` first, followed by `.replace(/\//gu, "\\/")`. That yields a proper JSON-safe representation of these strings with respect to `\` and `/`, and preserves the current functionality and usage pattern. Concretely, in `sw.js` inside `rewriteHtmlDocument`, adjust the definitions of `jsonEscapedOrigin` and `jsonEscapedBase` around lines 473–474 to add an initial backslash-escaping step, without changing other logic in the function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
