### PR TITLE
Potential fix for code scanning alert no. 1: Double escaping or unescaping

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -385,12 +385,12 @@ function decodeHtmlAttributeEntities(value) {
   return value
     .replace(/&#x([0-9a-f]+);/giu, (_, hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
     .replace(/&#([0-9]+);/gu, (_, dec) => String.fromCodePoint(Number.parseInt(dec, 10)))
-    .replaceAll("&amp;", "&")
     .replaceAll("&quot;", "\"")
     .replaceAll("&#39;", "'")
     .replaceAll("&apos;", "'")
     .replaceAll("&sol;", "/")
-    .replaceAll("&colon;", ":");
+    .replaceAll("&colon;", ":")
+    .replaceAll("&amp;", "&");
 }
 
 function rewriteHtmlAttributeUrl(rawValue, { origin, scopeId, runtimeId }) {


### PR DESCRIPTION
Potential fix for [https://github.com/ateeducacion/moodle-playground/security/code-scanning/1](https://github.com/ateeducacion/moodle-playground/security/code-scanning/1)

In general, to avoid double unescaping when decoding HTML entities, any decoding of the escape character `&` must happen last. Otherwise you risk turning `&amp;something;` into `&something;` and then immediately decoding `&something;` as another entity. For this specific function, `decodeHtmlAttributeEntities`, the fix is to postpone decoding `&amp;` until after all other named entities have been decoded.

The minimal change that preserves existing behavior is to move `.replaceAll("&amp;", "&")` so that it is performed after `.replaceAll("&quot;", "\"")`, `.replaceAll("&#39;", "'")`, `.replaceAll("&apos;", "'")`, `.replaceAll("&sol;", "/")`, and `.replaceAll("&colon;", ":")`. The numeric entity decodes (`&#x...;` and `&#...;`) can stay first, because they do not introduce new leading `&` characters; they replace whole sequences starting with `&` in a single step. With this ordering, an input like `&amp;quot;` will correctly decode to `&quot;` (literal ampersand plus “quot;”), not to a double quote.

Concretely, in `sw.js` around lines 384–393, adjust the method chain in `decodeHtmlAttributeEntities` so that the `&amp;` replacement is the last `.replaceAll(...)` in the chain. No additional imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
