### PR TITLE
Improve documentation: PHP versions, SQLite refs, navbar

### DIFF
--- a/docs/KNOWN-ISSUES.md
+++ b/docs/KNOWN-ISSUES.md
@@ -33,7 +33,7 @@ Status:
 
 - mostly resolved (migrated to `@php-wasm/web`)
 
-The `@php-wasm/web` PHP 8.3 runtime includes most previously-missing extensions
+The `@php-wasm/web` PHP runtime (8.1–8.5) includes most previously-missing extensions
 (`curl`, `gd`, `fileinfo`, `xmlreader`, `xmlwriter`) built into the WASM binary.
 
 **sodium is NOT available** in the WASM binary. The OpenSSL fallback patch in

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -330,7 +330,7 @@ If failure happens:
 
 ## Extension reality in this repo
 
-The `@php-wasm/web` PHP 8.3 runtime includes all required extensions built into the WASM binary:
+The `@php-wasm/web` PHP runtime (available for versions 8.1–8.5, default 8.3) includes all required extensions built into the WASM binary:
 
 - `dom`, `iconv`, `intl`, `libxml`, `simplexml`, `xml`, `zip`, `mbstring`, `openssl`,
   `sqlite3`, `pdo_sqlite`, `phar`, `curl`, `gd`, `fileinfo`, `xmlreader`, `xmlwriter`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@ index.html
 
 The PHP runtime is provided by WordPress Playground's `@php-wasm/web` and `@php-wasm/universal` packages. The compatibility wrapper in `src/runtime/php-compat.js` maps the WP Playground API to the interface expected by the rest of the codebase.
 
-The PHP 8.3 WASM binary includes all required extensions built-in: `sqlite3`, `pdo_sqlite`, `dom`, `simplexml`, `xml`, `mbstring`, `openssl`, `intl`, `iconv`, `zlib`, `zip`, `phar`, `curl`, `gd`, `fileinfo`, `xmlreader`, `xmlwriter`.
+The PHP WASM binary (available for versions 8.1 through 8.5, default 8.3) includes all required extensions built-in: `sqlite3`, `pdo_sqlite`, `dom`, `simplexml`, `xml`, `mbstring`, `openssl`, `intl`, `iconv`, `zlib`, `zip`, `phar`, `curl`, `gd`, `fileinfo`, `xmlreader`, `xmlwriter`.
 
 !!! note
     `sodium` is **not** available in the WASM binary. The OpenSSL fallback patch handles all encryption needs.

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,8 +45,8 @@ Then open [http://localhost:8080](http://localhost:8080) in your browser.
 ## Features
 
 - Full Moodle 4.4 / 5.0 running in WebAssembly
-- PHP 8.3 with all required extensions built-in
-- SQLite database (in-memory, no persistence needed)
+- PHP 8.1 to 8.5 support (version depends on Moodle branch; default: 8.3)
+- SQLite database via [experimental PDO driver patch](https://moodle.atlassian.net/browse/MDL-88218) (in-memory, no persistence needed)
 - Pre-built install snapshot for fast boot (~3s vs ~8s full install)
 - Step-based blueprint system for provisioning users, courses, enrolments, modules, and more
 - Works on GitHub Pages with subpath support
@@ -58,6 +58,14 @@ Then open [http://localhost:8080](http://localhost:8080) in your browser.
 - [Architecture](architecture.md)
 - [Blueprint reference](blueprint-json.md)
 - [Plugin install notes for this branch](plugin-install-branch-notes.md)
+
+## CI/CD and GitHub Actions
+
+The project includes a reusable GitHub Action for generating live PR previews of Moodle Playground:
+
+- [**action-moodle-playground-pr-preview**](https://github.com/ateeducacion/action-moodle-playground-pr-preview) — Deploys a temporary Moodle Playground instance for each pull request, allowing reviewers to test changes in the browser before merging.
+
+The main CI/CD pipeline (`.github/workflows/ci.yml`) handles linting, unit tests, E2E tests (Chromium + Firefox), and deployment to GitHub Pages on push to `main`.
 
 ---
 

--- a/docs/sqlite-wasm-migration-notes.md
+++ b/docs/sqlite-wasm-migration-notes.md
@@ -2,6 +2,9 @@
 
 This document records the repo-local changes made to run Moodle in WebAssembly PHP with an in-memory SQLite database (MEMFS-backed file) instead of the previous PGlite/PDO-PGlite path.
 
+!!! info "Upstream SQLite support"
+    Moodle is tracking native SQLite support in [MDL-88218](https://moodle.atlassian.net/browse/MDL-88218). This project uses an experimental PDO driver patch that restores and maintains SQLite compatibility independently.
+
 > **Runtime update (March 2025)**: The PHP runtime was migrated from `seanmorris/php-wasm` (v0.0.9-alpha-32) to WordPress Playground's `@php-wasm/web` + `@php-wasm/universal` (v3.1.11). This replaced 14 vendored packages and a manual extension-loading pipeline with two npm packages. The compatibility wrapper in `src/runtime/php-compat.js` maps the WP Playground API to the interface expected by the existing codebase. All PHP extensions (including previously-missing `curl`, `gd`, `fileinfo`, `sodium`) are now built into the WASM binary.
 
 > **In-memory refactor (March 2026)**: The runtime is now explicitly ephemeral. The SQLite database file lives in Emscripten MEMFS (JavaScript heap) with no durable storage. SQLite pragmas are tuned for in-memory operation (`journal_mode=MEMORY`, `synchronous=OFF`, `temp_store=MEMORY`, `cache_size=-8000`, `locking_mode=EXCLUSIVE`). Moodle caching is fully enabled (file-based caches write to MEMFS). Debug mode defaults to disabled for performance, but the initial level can be seeded at boot and later changed from Moodle administration. All state is lost when the browser tab closes.

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
               <path d="M6 9h6M6 12h4" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
               <path d="M11 1v3.5a1 1 0 0 0 1 1h3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" fill="none"/>
             </svg>
-            <span class="icon-button__label">Docs</span>
+            <span class="icon-button__label">Documentation</span>
           </a>
           <button type="button" id="panel-toggle-button" class="icon-button" aria-label="Toggle sidebar panel" aria-expanded="false" title="Toggle sidebar">
             <svg width="18" height="16" viewBox="0 0 18 16" fill="none" aria-hidden="true" focusable="false">

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Moodle Playground Docs
+site_name: Moodle Playground Documentation
 site_description: Contributor and user documentation for Moodle Playground.
 site_url: https://ateeducacion.github.io/moodle-playground/docs/
 repo_url: https://github.com/ateeducacion/moodle-playground

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -256,6 +256,7 @@ button.danger:hover {
   width: auto;
   padding: 0 12px;
   gap: var(--space-xs);
+  text-decoration: none;
 }
 
 .browser-toolbar .icon-button__label {


### PR DESCRIPTION
## Summary

- Rename site title to **Moodle Playground Documentation** (mkdocs.yml + navbar label)
- Remove underline from the Documentation link in the toolbar
- Update PHP version references from "PHP 8.3" to the full supported range (8.1–8.5) across all docs
- Add link to [MDL-88218](https://moodle.atlassian.net/browse/MDL-88218) (upstream SQLite support tracking) in the SQLite migration notes and the index page
- Add CI/CD section in index.md with reference to [action-moodle-playground-pr-preview](https://github.com/ateeducacion/action-moodle-playground-pr-preview)

## Files changed

| File | Change |
|------|--------|
| `mkdocs.yml` | Site name → "Moodle Playground Documentation" |
| `index.html` | Navbar label "Docs" → "Documentation" |
| `src/styles/app.css` | `text-decoration: none` on toolbar link |
| `docs/index.md` | PHP range, SQLite link, CI/CD section |
| `docs/architecture.md` | PHP range |
| `docs/KNOWN-ISSUES.md` | PHP range |
| `docs/TROUBLESHOOTING.md` | PHP range |
| `docs/sqlite-wasm-migration-notes.md` | MDL-88218 admonition |

## Test plan

- [x] Unit tests pass (313/313)
- [x] Biome lint passes
- [ ] Verify navbar renders "Documentation" without underline
- [ ] Verify mkdocs builds successfully
- [ ] Verify MDL-88218 and GitHub Action links render correctly in docs