### PR TITLE
fix: query sqlite_temp_master in fetch_columns() for temporary tables

### DIFF
--- a/.agents/references/sqlite-upstream-workflow.md
+++ b/.agents/references/sqlite-upstream-workflow.md
@@ -27,10 +27,12 @@ In `ateeducacion/moodle`:
 - `sqlite3_pdo_moodle_database.php` — DML driver (queries, connections, column introspection)
 - `sqlite_sql_generator.php` — DDL generator (CREATE TABLE, ALTER TABLE emulation, temp tables)
 
-In `ateeducacion/moodle-playground` (patches applied at build time):
+In `ateeducacion/moodle-playground` (independent copies, applied at build time):
 
 - `patches/shared/lib/dml/sqlite3_pdo_moodle_database.php`
 - `patches/shared/lib/ddl/sqlite_sql_generator.php`
+
+**CRITICAL**: moodle-playground maintains its **own independent copies** of the SQLite driver files in `patches/shared/`. It does NOT pull from `ateeducacion/moodle`. The build pipeline (`scripts/patch-moodle-source.sh`) clones official Moodle from `github.com/moodle/moodle` and overlays these local patches. Any fix applied to `ateeducacion/moodle` must ALSO be applied to the patch files in this repository, otherwise the playground will keep using the old buggy version.
 
 ## When you find a SQLite bug
 
@@ -67,9 +69,9 @@ git checkout origin/<branch> -B <branch>
 git push origin <branch>
 ```
 
-### 4. Update the playground patches
+### 4. Update the playground patches (MANDATORY)
 
-If the fix also affects the WASM build, update the corresponding patch file in this repository:
+The fix **must also** be applied to the local patch files in this repository, since the playground build uses these copies, not the upstream fork:
 
 ```bash
 # Copy the fixed file to the patches directory

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -308,14 +308,20 @@ Defaults currently seeded:
 ## SQLite driver bugs (upstream)
 
 If the error originates from the DML/DDL layer (`sqlite3_pdo_moodle_database.php` or
-`sqlite_sql_generator.php`), it is a driver bug that must be fixed upstream in the
-[ateeducacion/moodle](https://github.com/ateeducacion/moodle) repository.
+`sqlite_sql_generator.php`), it is a driver bug that must be fixed in **two places**:
+
+1. The upstream fork [ateeducacion/moodle](https://github.com/ateeducacion/moodle) (3 maintained branches for Moodle tracker PRs)
+2. The **local patch copies** in this repository under `patches/shared/lib/dml/` and `patches/shared/lib/ddl/`
+
+This repository maintains its own independent copies of the SQLite driver files.
+The build pipeline clones official Moodle and overlays these local patches — it does
+NOT pull from the `ateeducacion/moodle` fork. Fixing only the fork will NOT fix the playground.
 
 **Workflow:**
 
 1. Reproduce and fix on the `mdl-88218-workbench` branch using `make up` (local PHP + SQLite)
-2. Replicate the fix to all three maintained branches (`MDL-88218-sqlite-500`, `MDL-88218-sqlite-501`, `MDL-88218-Add-experimental-SQLite-support-for-Moodle-WASM-environments`)
-3. Update the patch in `patches/shared/lib/dml/` or `patches/shared/lib/ddl/` if it affects the WASM build
+2. Replicate the fix to all three maintained upstream branches
+3. **Also** apply the fix to `patches/shared/lib/dml/` or `patches/shared/lib/ddl/` in this repo
 4. Trigger a manual rebuild via [GitHub Actions](https://github.com/ateeducacion/moodle-playground/actions/workflows/ci.yml) (Run workflow → select `main`)
 
 See [`.agents/references/sqlite-upstream-workflow.md`](https://github.com/ateeducacion/moodle-playground/blob/main/.agents/references/sqlite-upstream-workflow.md) for the full procedure.

--- a/patches/shared/lib/dml/sqlite3_pdo_moodle_database.php
+++ b/patches/shared/lib/dml/sqlite3_pdo_moodle_database.php
@@ -308,7 +308,9 @@ class sqlite3_pdo_moodle_database extends pdo_moodle_database {
     protected function fetch_columns(string $table): array {
         $structure = array();
 
-        $sql = 'SELECT sql FROM sqlite_master WHERE type="table" AND tbl_name="' . $this->prefix . $table . '"';
+        $sql = 'SELECT sql FROM sqlite_master WHERE type="table" AND tbl_name="' . $this->prefix . $table . '"'
+             . ' UNION ALL '
+             . 'SELECT sql FROM sqlite_temp_master WHERE type="table" AND tbl_name="' . $this->prefix . $table . '"';
         if ($this->debug) {
             $this->debug_query($sql);
         }


### PR DESCRIPTION
## Summary

Fix `fetch_columns()` in the local SQLite DML patch to query both `sqlite_master` and `sqlite_temp_master`. Temporary tables in SQLite are stored in `sqlite_temp_master`, so querying only `sqlite_master` caused `ddltablenotexist` errors for temporary tables like `backup_ids_temp` during activity duplication.

Also clarifies in documentation that this repository maintains **independent copies** of the SQLite driver patches in `patches/shared/` — the build pipeline does NOT pull from `ateeducacion/moodle`. Fixes must be applied in both places.

Fixes #48

## Changes

- `patches/shared/lib/dml/sqlite3_pdo_moodle_database.php` — add `UNION ALL sqlite_temp_master` to `fetch_columns()`
- `.agents/references/sqlite-upstream-workflow.md` — clarify independent patch copies, make step 4 mandatory
- `docs/TROUBLESHOOTING.md` — explain dual-fix requirement (upstream fork + local patches)

## Related

The same fix was already applied to the three upstream branches in [ateeducacion/moodle](https://github.com/ateeducacion/moodle):
- Moodle 5.0: https://github.com/ateeducacion/moodle/pull/3
- Moodle 5.1: https://github.com/ateeducacion/moodle/pull/2
- Moodle main: https://github.com/ateeducacion/moodle/pull/1

## Test plan

- [ ] Rebuild playground bundles (manual dispatch or merge to main)
- [ ] Open a course, turn editing on, duplicate an activity
- [ ] Verify no `ddltablenotexist` error
- [ ] Verify MkDocs builds cleanly (`mkdocs build --strict`)