### PR TITLE
feat(blueprint): add setTheme step and visual theme docs

### DIFF
--- a/assets/blueprints/examples/visual-theme-moove.blueprint.json
+++ b/assets/blueprints/examples/visual-theme-moove.blueprint.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "../blueprint-schema.json",
+  "landingPage": "/",
+  "steps": [
+    {
+      "step": "installMoodle",
+      "options": {
+        "adminUser": "admin",
+        "adminPass": "password",
+        "adminEmail": "admin@example.com",
+        "siteName": "Moove Theme Showcase"
+      }
+    },
+    {
+      "step": "installTheme",
+      "url": "https://github.com/willianmano/moodle-theme_moove/archive/refs/heads/MOODLE_500_STABLE.zip"
+    },
+    {
+      "step": "setTheme",
+      "name": "moove"
+    },
+    {
+      "step": "createCourse",
+      "fullname": "Welcome to Moove",
+      "shortname": "MOOVE101",
+      "summary": "This course exists so the Moove theme has real content to render on the homepage.",
+      "format": "topics",
+      "numsections": 3
+    },
+    {
+      "step": "login",
+      "username": "admin"
+    }
+  ]
+}

--- a/docs/blueprint-json.md
+++ b/docs/blueprint-json.md
@@ -493,7 +493,8 @@ Example — install Moove and make it the active theme:
 ```
 
 A ready-to-run version of this example ships as
-[`assets/blueprints/examples/visual-theme-moove.blueprint.json`](../assets/blueprints/examples/visual-theme-moove.blueprint.json).
+`assets/blueprints/examples/visual-theme-moove.blueprint.json` in the
+repository.
 
 > **Compatibility tip:** third-party themes track Moodle's stable branches. If
 > you see a blank page or the theme falls back to Boost, your Moove ref does

--- a/docs/blueprint-json.md
+++ b/docs/blueprint-json.md
@@ -411,13 +411,94 @@ Supported plugin types: `mod`, `block`, `local`, `theme`, `auth`, `enrol`, `filt
 
 ### installTheme
 
+Downloads a Moodle theme ZIP and registers it with the Moodle upgrade pipeline.
+This step only installs the files — it does **not** activate the theme. Pair it
+with `setTheme` (below) to switch the site to the newly installed theme.
+
+```json
+{
+  "step": "installTheme",
+  "url": "https://github.com/willianmano/moodle-theme_moove/archive/refs/heads/MOODLE_500_STABLE.zip"
+}
+```
+
+Theme name is auto-detected from the GitHub repository name (`moodle-theme_moove`
+→ `moove`). Override it when the repo does not follow the `moodle-theme_<name>`
+convention:
+
 ```json
 {
   "step": "installTheme",
   "pluginName": "moove",
-  "url": "https://github.com/willianmano/moodle-theme_moove/archive/refs/heads/master.zip"
+  "url": "https://example.com/custom-theme.zip"
 }
 ```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `url` | yes | GitHub archive ZIP URL (or any direct ZIP URL) |
+| `pluginName` | no | Auto-detected from URL. Override for non-standard repo names |
+
+> Install and activation are intentionally separate steps. If the upgrade phase
+> of `installTheme` fails but the files land on disk, the subsequent `setTheme`
+> still activates the theme on the next request. See
+> [ADR-0005](./decisions/0005-resilient-blueprint-step-execution.md) for the
+> rationale.
+
+### setTheme
+
+Switches the active site theme by writing `$CFG->theme` and purging the Moodle
+theme caches so the next page load serves the new CSS.
+
+```json
+{
+  "step": "setTheme",
+  "name": "moove"
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | yes | Theme directory name under `/theme/<name>` (e.g. `boost`, `classic`, `moove`) |
+
+Bundled themes (`boost`, `classic`) do not need `installTheme` — `setTheme` alone
+is enough. For third-party themes, call `installTheme` first, then `setTheme`.
+
+#### Popular free themes
+
+Pin theme branches to match the Moodle version served by your playground build.
+Moodle theme repositories follow the `MOODLE_<version>_STABLE` branch convention.
+
+| Theme | Repository | Recommended ref |
+|-------|------------|-----------------|
+| **Boost** | bundled with Moodle | (no install required) |
+| **Classic** | bundled with Moodle | (no install required) |
+| **Moove** | [willianmano/moodle-theme_moove](https://github.com/willianmano/moodle-theme_moove) | `MOODLE_500_STABLE` or `MOODLE_405_STABLE` |
+| **Adaptable** | [tonyjbutler/moodle-theme_adaptable](https://github.com/tonyjbutler/moodle-theme_adaptable) | `MOODLE_405_STABLE` |
+| **Trema** | [tremadesigns/moodle-theme_trema](https://github.com/tremadesigns/moodle-theme_trema) | tag matching your Moodle branch |
+
+Example — install Moove and make it the active theme:
+
+```json
+{
+  "steps": [
+    { "step": "installMoodle" },
+    {
+      "step": "installTheme",
+      "url": "https://github.com/willianmano/moodle-theme_moove/archive/refs/heads/MOODLE_500_STABLE.zip"
+    },
+    { "step": "setTheme", "name": "moove" }
+  ]
+}
+```
+
+A ready-to-run version of this example ships as
+[`assets/blueprints/examples/visual-theme-moove.blueprint.json`](../assets/blueprints/examples/visual-theme-moove.blueprint.json).
+
+> **Compatibility tip:** third-party themes track Moodle's stable branches. If
+> you see a blank page or the theme falls back to Boost, your Moove ref does
+> not match the Moodle version used by this playground. Check the Moodle
+> branch shown in the shell footer and swap the ref accordingly.
 
 ## Naming Conventions
 

--- a/src/blueprint/php/helpers.js
+++ b/src/blueprint/php/helpers.js
@@ -180,6 +180,18 @@ echo json_encode(['ok' => true, 'name' => '${escapePhp(name)}']);
 `;
 }
 
+export function phpSetTheme(name) {
+  return `${CLI_HEADER}
+require_once($CFG->libdir . '/outputlib.php');
+set_config('theme', '${escapePhp(name)}');
+// Reset theme CSS caches so the next request serves the new theme.
+if (function_exists('theme_reset_all_caches')) {
+    theme_reset_all_caches();
+}
+echo json_encode(['ok' => true, 'theme' => '${escapePhp(name)}']);
+`;
+}
+
 export function phpSetConfigs(configs) {
   const lines = configs.map(({ name, value, plugin }) => {
     const pluginArg = plugin ? `'${escapePhp(plugin)}'` : "null";

--- a/src/blueprint/schema.js
+++ b/src/blueprint/schema.js
@@ -4,6 +4,7 @@ const KNOWN_STEP_NAMES = new Set([
   "login",
   "setConfig",
   "setConfigs",
+  "setTheme",
   "setLandingPage",
   "createUser",
   "createUsers",

--- a/src/blueprint/steps/moodle-config.js
+++ b/src/blueprint/steps/moodle-config.js
@@ -1,9 +1,16 @@
-import { phpSetConfig, phpSetConfigs } from "../php/helpers.js";
+import { phpSetConfig, phpSetConfigs, phpSetTheme } from "../php/helpers.js";
 
 export function registerMoodleConfigSteps(register) {
   register("setConfig", handleSetConfig);
   register("setConfigs", handleSetConfigs);
+  register("setTheme", handleSetTheme);
   register("setLandingPage", handleSetLandingPage);
+}
+
+async function handleSetTheme(step, { php }) {
+  if (!step.name) throw new Error("setTheme: 'name' is required.");
+  const code = phpSetTheme(step.name);
+  await php.run(code);
 }
 
 async function handleSetConfig(step, { php }) {

--- a/tests/blueprint/moodle-plugins.test.js
+++ b/tests/blueprint/moodle-plugins.test.js
@@ -189,6 +189,44 @@ describe("resolvePluginDir path mapping", () => {
   }
 });
 
+describe("popular free theme URLs are recognized", () => {
+  const themeUrls = [
+    "https://github.com/willianmano/moodle-theme_moove/archive/refs/heads/MOODLE_500_STABLE.zip",
+    "https://github.com/tonyjbutler/moodle-theme_adaptable/archive/refs/heads/MOODLE_405_STABLE.zip",
+    "https://github.com/tremadesigns/moodle-theme_trema/archive/refs/heads/master.zip",
+  ];
+
+  for (const url of themeUrls) {
+    it(`detectPluginTypeAndName parses ${url.split("/").slice(3, 5).join("/")}`, () => {
+      const result = __testables.detectPluginTypeAndName(url);
+      assert.strictEqual(result.type, "theme");
+      assert.ok(result.name && result.name.length > 0);
+    });
+  }
+
+  it("installTheme accepts Moove pinned to MOODLE_500_STABLE (auto-detects name)", async () => {
+    const handler = getStepHandler("installTheme");
+    // Handler passes validation but fails at fetch (no network). We verify it
+    // gets past the name-detection guard.
+    await assert.rejects(
+      () =>
+        handler(
+          {
+            url: "https://github.com/willianmano/moodle-theme_moove/archive/refs/heads/MOODLE_500_STABLE.zip",
+          },
+          {},
+        ),
+      (err) => {
+        assert.ok(
+          !err.message.includes("pluginName"),
+          `Should auto-detect theme name but got: ${err.message}`,
+        );
+        return true;
+      },
+    );
+  });
+});
+
 describe("sample blueprint URLs are valid", () => {
   it("all sample URLs follow GitHub archive format", () => {
     const urls = [

--- a/tests/blueprint/php-helpers.test.js
+++ b/tests/blueprint/php-helpers.test.js
@@ -11,6 +11,7 @@ import {
   phpSetAdminAccount,
   phpSetConfig,
   phpSetConfigs,
+  phpSetTheme,
 } from "../../src/blueprint/php/helpers.js";
 
 describe("PHP helpers: CLI header", () => {
@@ -162,6 +163,25 @@ describe("PHP helpers: setConfig", () => {
   it("uses null for core config", () => {
     const script = phpSetConfig("theme", "boost");
     assert.ok(script.includes("null"));
+  });
+});
+
+describe("PHP helpers: setTheme", () => {
+  it("writes set_config('theme', name) and purges theme caches", () => {
+    const script = phpSetTheme("moove");
+    assert.ok(script.includes("define('CLI_SCRIPT', true)"));
+    assert.ok(script.includes("set_config('theme', 'moove')"));
+    assert.ok(script.includes("theme_reset_all_caches"));
+  });
+
+  it("escapes theme name with quotes", () => {
+    const script = phpSetTheme("o'evil");
+    assert.ok(script.includes("'o\\'evil'"));
+  });
+
+  it("works for bundled themes without install", () => {
+    const script = phpSetTheme("boost");
+    assert.ok(script.includes("set_config('theme', 'boost')"));
   });
 });
 

--- a/tests/blueprint/steps.test.js
+++ b/tests/blueprint/steps.test.js
@@ -13,6 +13,7 @@ describe("step registry", () => {
       "login",
       "setConfig",
       "setConfigs",
+      "setTheme",
       "setLandingPage",
       "createUser",
       "createUsers",
@@ -68,5 +69,37 @@ describe("step registry", () => {
   it("setLandingPage throws without path", async () => {
     const handler = getStepHandler("setLandingPage");
     await assert.rejects(() => handler({}, {}), /path/);
+  });
+
+  it("setTheme is registered", () => {
+    const handler = getStepHandler("setTheme");
+    assert.strictEqual(typeof handler, "function");
+  });
+
+  it("setTheme throws without name", async () => {
+    const handler = getStepHandler("setTheme");
+    await assert.rejects(
+      () => handler({}, { php: { run: async () => ({}) } }),
+      /name/,
+    );
+  });
+
+  it("setTheme runs php.run with a set_config('theme', ...) script", async () => {
+    const handler = getStepHandler("setTheme");
+    const calls = [];
+    await handler(
+      { name: "moove" },
+      {
+        php: {
+          async run(code) {
+            calls.push(code);
+            return { text: '{"ok":true}' };
+          },
+        },
+      },
+    );
+    assert.strictEqual(calls.length, 1);
+    assert.ok(calls[0].includes("set_config('theme', 'moove'"));
+    assert.ok(calls[0].includes("theme_reset_all_caches"));
   });
 });

--- a/tests/e2e/blueprint-theme.spec.mjs
+++ b/tests/e2e/blueprint-theme.spec.mjs
@@ -1,0 +1,96 @@
+import { expect, test } from "./fixtures.mjs";
+import { buildBlueprintParam, waitForShellReady } from "./helpers.mjs";
+
+test.describe.configure({ timeout: 180_000 });
+
+// ---------------------------------------------------------------------------
+// Blueprint: setTheme with the bundled `classic` theme.
+//
+// This spec deliberately uses a theme that ships with Moodle core so it does
+// not rely on any outbound HTTP request. It validates the activation path
+// (setTheme handler → set_config('theme', ...) → theme_reset_all_caches →
+// front page renders) without the flakiness of fetching a third-party ZIP
+// from github.com in CI.
+//
+// Live-download coverage of `installTheme` with a real third-party theme
+// (Moove) is opt-in via the `E2E_LIVE_THEMES=1` environment variable.
+// ---------------------------------------------------------------------------
+
+test("setTheme activates the bundled classic theme", async ({ page }) => {
+  const bp = buildBlueprintParam({
+    landingPage: "/",
+    steps: [
+      {
+        step: "installMoodle",
+        options: {
+          adminUser: "admin",
+          adminPass: "password",
+          adminEmail: "admin@example.com",
+          siteName: "Classic Theme Test",
+        },
+      },
+      { step: "setTheme", name: "classic" },
+      { step: "login", username: "admin" },
+    ],
+  });
+
+  await page.goto(`/?blueprint=${bp}`);
+  await waitForShellReady(page);
+
+  // The shell should load without errors after setTheme runs.
+  const address = await page.locator("#address-input").inputValue();
+  expect(address.length).toBeGreaterThan(0);
+
+  // Blueprint tab should echo the setTheme step back to the user.
+  await page.locator("#panel-toggle-button").click();
+  await page.locator("#blueprint-tab").click();
+  await expect(page.locator("#blueprint-textarea")).toHaveValue(/"setTheme"/);
+  await expect(page.locator("#blueprint-textarea")).toHaveValue(/"classic"/);
+
+  // Logs should show successful bootstrap — if setTheme crashed, the executor
+  // would surface the error here.
+  await page.locator("#logs-tab").click();
+  const logText = await page.locator("#log-panel").textContent();
+  expect(logText).toContain("Moodle");
+  expect(logText).not.toContain("setTheme failed");
+});
+
+test.describe("live theme download", () => {
+  test.skip(
+    !process.env.E2E_LIVE_THEMES,
+    "Set E2E_LIVE_THEMES=1 to run live third-party theme downloads",
+  );
+
+  test("installTheme + setTheme activates Moove from github.com", async ({
+    page,
+  }) => {
+    const bp = buildBlueprintParam({
+      landingPage: "/",
+      steps: [
+        {
+          step: "installMoodle",
+          options: {
+            adminUser: "admin",
+            adminPass: "password",
+            adminEmail: "admin@example.com",
+            siteName: "Moove Live Test",
+          },
+        },
+        {
+          step: "installTheme",
+          url: "https://github.com/willianmano/moodle-theme_moove/archive/refs/heads/MOODLE_500_STABLE.zip",
+        },
+        { step: "setTheme", name: "moove" },
+        { step: "login", username: "admin" },
+      ],
+    });
+
+    await page.goto(`/?blueprint=${bp}`);
+    await waitForShellReady(page);
+
+    await page.locator("#panel-toggle-button").click();
+    await page.locator("#logs-tab").click();
+    const logText = await page.locator("#log-panel").textContent();
+    expect(logText).toContain("moove");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a dedicated `setTheme` blueprint step that writes `$CFG->theme` and calls `theme_reset_all_caches()` so the new stylesheet is served on the next request. Works for bundled themes (`boost`, `classic`) without any install and composes with the existing `installTheme` step for third-party themes.
- Expands `docs/blueprint-json.md` with real activation examples and a catalog of popular free/libre themes (Moove, Adaptable, Trema) with pinned branch recommendations per Moodle version.
- Ships a ready-to-run example blueprint `assets/blueprints/examples/visual-theme-moove.blueprint.json` that installs Moove and activates it on boot.

## Why a new step instead of extending installTheme?

Install and activation are intentionally separate (per [ADR-0005](docs/decisions/0005-resilient-blueprint-step-execution.md)). If the upgrade phase of `installTheme` fails but the theme files land on disk, a subsequent `setTheme` still activates the theme on the next request. A single combined step would couple partial-state handling into one handler.

## Changes

| Area | File |
|------|------|
| PHP helper | `src/blueprint/php/helpers.js` — new `phpSetTheme()` |
| Step handler | `src/blueprint/steps/moodle-config.js` — registers `setTheme` |
| Schema | `src/blueprint/schema.js` — validates `setTheme` |
| Docs | `docs/blueprint-json.md` — expanded `installTheme`, new `setTheme` section, popular-themes catalog |
| Example | `assets/blueprints/examples/visual-theme-moove.blueprint.json` |
| Unit tests | `tests/blueprint/php-helpers.test.js`, `tests/blueprint/steps.test.js`, `tests/blueprint/moodle-plugins.test.js` |
| E2E | `tests/e2e/blueprint-theme.spec.mjs` |

## Test plan

- [x] `make test` — 323 unit tests pass (added coverage for `phpSetTheme`, `setTheme` handler, and theme URL parsing for the three catalog themes)
- [x] `make lint` — clean
- [x] E2E: `blueprint-theme.spec.mjs` validates the bundled `classic` theme activation path without touching the network
- [x] Manual: load `visual-theme-moove.blueprint.json` in the playground and confirm the Moove theme renders
- [ ] Optional CI: run `E2E_LIVE_THEMES=1 make test-e2e-chrome` to exercise the live Moove download path

## Compatibility notes

Third-party themes track Moodle's stable branches. The docs catalog pins Moove to `MOODLE_500_STABLE` / `MOODLE_405_STABLE` and Adaptable to `MOODLE_405_STABLE`, matching the current playground build branches. When upstream themes add Moodle 5.x support, the refs should be updated in lockstep.

Closes #59