### PR TITLE
docs: migrate documentation site from MkDocs to Zensical

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,11 +103,11 @@ jobs:
         run: make prepare-all JOBS=2
 
       - name: Install docs dependencies
-        run: python -m pip install -r requirements-docs.txt
+        run: python -m pip install --default-timeout=120 -r requirements-docs.txt
 
       - name: Assemble site artifact
         run: |
-          rm -rf dist-site
+          rm -rf dist-site site
           mkdir -p dist-site/docs
           rsync -a ./ ./dist-site/ \
             --exclude ".git/" \
@@ -120,7 +120,9 @@ jobs:
             --exclude "site/" \
             --exclude "tests/" \
             --exclude "patches/"
-          mkdocs build --strict --site-dir dist-site/docs
+          zensical build --clean
+          rsync -a --delete site/ dist-site/docs/
+          rm -rf site
           touch dist-site/.nojekyll
 
       - name: Upload site artifact

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src=".github/screenshot.png" alt="Moodle Playground" width="600">
 </p>
 
-[Live demo](https://ateeducacion.github.io/moodle-playground/) · [Documentation](docs/) · [Blueprints](docs/blueprint-json.md)
+[Live demo](https://moodle-playground.com/) · [Documentation](https://moodle-playground.com/docs/) · [Blueprints](https://moodle-playground.com/docs/blueprint-json/)
 
 > Run a full Moodle site in the browser — no server required.
 
@@ -14,7 +14,7 @@ Moodle Playground runs [Moodle](https://moodle.org) entirely in the browser usin
 
 ### Try it online
 
-Open the [live demo](https://ateeducacion.github.io/moodle-playground/) — no install needed.
+Open the [live demo](https://moodle-playground.com/) — no install needed.
 
 ### Run it locally
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,11 +1,19 @@
 # Getting started
 
+This page gets you from a fresh clone to a running Moodle Playground instance and your first blueprint. If you just want to try it, use the hosted version at <https://moodle-playground.com> — no install needed.
+
 ## Requirements
 
-- Node.js 18+
-- npm
-- Python 3 for Moodle build helpers and docs
-- Git
+| Tool     | Version | Why |
+|----------|---------|-----|
+| Node.js  | **18+** | Runs the shell bundler and Playwright tests. |
+| npm      | bundled | Package management. |
+| Python 3 | 3.12+   | Moodle build helpers and docs (Zensical). |
+| PHP      | 8.3     | Only needed when (re)generating install snapshots. |
+| Git      | any     | Cloning and submodule fetches. |
+
+!!! tip
+    The hosted site does not need any of the above — all these requirements are only for **local development** or **contributing**.
 
 ## Local setup
 
@@ -17,19 +25,30 @@ npm install
 
 ## Building the runtime
 
-```bash
-# Install deps and build the worker bundle
-make prepare
+=== "Default build"
 
-# Build the default Moodle bundle (ZIP + install snapshot)
-make bundle
+    Build the shell bundle, the default Moodle ZIP and its install snapshot:
 
-# Build all Moodle bundles (parallelizable via JOBS=...)
-make bundle-all JOBS=2
+    ```bash
+    make prepare
+    make bundle
+    ```
 
-# Build just the PHP worker bundle
-npm run build:worker
-```
+=== "All Moodle branches"
+
+    Build every supported Moodle branch in parallel:
+
+    ```bash
+    make prepare-all JOBS=2
+    ```
+
+=== "Just the PHP worker"
+
+    Useful after editing `php-worker.js` / `src/runtime/php-*.js`:
+
+    ```bash
+    npm run build:worker
+    ```
 
 ## Running locally
 
@@ -37,11 +56,14 @@ npm run build:worker
 make serve
 ```
 
-This starts a local HTTP server at [http://localhost:8080](http://localhost:8080).
+This starts a static HTTP server at <http://localhost:8080>.
+
+!!! info "Why a local HTTP server?"
+    The playground uses a **service worker** to intercept requests and route them to the PHP runtime. Service workers only register on `https://` or `http://localhost`, so opening `index.html` straight from the filesystem will not work.
 
 ## Validation commands
 
-Quick syntax checks for the main runtime files:
+Quick syntax checks across the runtime files:
 
 ```bash
 node --check sw.js
@@ -49,55 +71,108 @@ node --check php-worker.js
 node --check src/runtime/bootstrap.js
 node --check src/runtime/php-loader.js
 node --check src/runtime/php-compat.js
+node --check src/runtime/crash-recovery.js
 node --check src/shell/main.js
 node --check src/remote/main.js
 node --check src/blueprint/index.js
 ```
 
-Run the blueprint unit tests:
+Blueprint unit tests:
 
 ```bash
 npm run test:blueprint
 ```
 
-## Building the documentation
+Full lint + unit tests (same as CI):
 
 ```bash
-python3 -m venv .venv
-source .venv/bin/activate
-pip install -r requirements-docs.txt
-mkdocs serve
+make lint
+make test
 ```
 
-Preview at [http://127.0.0.1:8000](http://127.0.0.1:8000).
+## Building the documentation
 
-## Configuration
+The docs site is built with [Zensical](https://zensical.org/), a Rust-backed static site generator that consumes the same `mkdocs.yml` as Material for MkDocs.
 
-The playground supports URL parameters to select Moodle and PHP versions:
+=== "With a local venv"
 
-| Parameter | Example | Description |
-|-----------|---------|-------------|
-| `moodle`  | `?moodle=4.4` | Moodle version |
-| `php`     | `?php=8.3` | PHP version |
-| `blueprint` | `?blueprint=<json-or-base64>` | Inline blueprint (JSON, base64, or data-URL) |
-| `blueprint-url` | `?blueprint-url=<url>` | URL to a remote blueprint file |
+    ```bash
+    python3.12 -m venv .venv
+    source .venv/bin/activate
+    pip install -r requirements-docs.txt
+    zensical serve
+    ```
 
-These can also be set via the Settings panel in the UI.
+=== "With Docker (no Python install)"
 
-## Blueprints
+    ```bash
+    docker run --rm -it -p 8000:8000 \
+      -v "$PWD":/docs -w /docs \
+      python:3.12-slim \
+      sh -c "pip install --default-timeout=120 -r requirements-docs.txt && zensical serve -a 0.0.0.0:8000"
+    ```
 
-Blueprints are step-based JSON files that configure and provision a playground instance at boot. They can create users, categories, courses, enrolments, course modules, and more.
+Preview at <http://localhost:8000>. The dev server auto-reloads on every edit.
 
-```json
+!!! warning "Python 3.10+ required"
+    Zensical's current releases target Python 3.10+. Older interpreters will resolve to a placeholder package on PyPI that has no CLI. If `zensical --version` errors out, double-check your interpreter.
+
+## Configuration via URL parameters
+
+The playground accepts URL parameters to select Moodle and PHP versions, or to load a blueprint at boot:
+
+| Parameter       | Example                                  | Description |
+|-----------------|------------------------------------------|-------------|
+| `moodle`        | `?moodle=4.4`                            | Moodle branch to load. |
+| `php`           | `?php=8.3`                               | PHP version to boot. |
+| `blueprint`     | `?blueprint=<json-or-base64>`            | Inline blueprint (JSON, base64, or `data:` URL). |
+| `blueprint-url` | `?blueprint-url=/path/to/blueprint.json` | Load a remote or local blueprint file. |
+
+These parameters are also exposed as controls in the Settings panel of the UI.
+
+## First blueprint
+
+Blueprints are small JSON files that **describe how a playground instance should look at boot**. They run as a sequence of steps — install Moodle, create a user, create a course, enrol the user, and so on.
+
+A minimal example:
+
+```json title="demo.blueprint.json" linenums="1"
 {
   "steps": [
-    { "step": "installMoodle", "options": { "siteName": "My Moodle" } },
-    { "step": "login", "username": "admin" },
-    { "step": "createCourse", "fullname": "Demo", "shortname": "DEMO1", "category": "Miscellaneous" }
+    {
+      "step": "installMoodle",
+      "options": { "siteName": "My Moodle" }
+    },
+    {
+      "step": "login",
+      "username": "admin"
+    },
+    {
+      "step": "createCourse",
+      "fullname": "Demo",
+      "shortname": "DEMO1",
+      "category": "Miscellaneous"
+    }
   ]
 }
 ```
 
-See the [Blueprint reference](blueprint-json.md) for the full format and all step types.
+Load it directly via URL:
 
-The default blueprint is at `assets/blueprints/default.blueprint.json`. Example blueprints are in `assets/blueprints/examples/`.
+```
+http://localhost:8080/?blueprint-url=/path/to/demo.blueprint.json
+```
+
+### Where blueprints live
+
+| Path                                    | Purpose |
+|-----------------------------------------|---------|
+| `assets/blueprints/default.blueprint.json` | The default blueprint loaded when no URL override is given. |
+| `assets/blueprints/examples/`              | Example blueprints shipped with the project. |
+
+## Next steps
+
+- :material-code-braces: Read the full [Blueprint reference](blueprint-json.md)
+- :material-image-multiple: Browse the [Blueprint gallery](blueprint-gallery.md)
+- :material-sitemap: Understand the [Architecture](architecture.md)
+- :material-hammer-wrench: Set up a [development environment](development.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,69 +4,155 @@
   <img src="../ogimage.png" alt="Moodle Playground" width="600">
 </p>
 
-Moodle running entirely in your browser using WebAssembly. No server required.
+**Moodle running entirely in your browser, via WebAssembly.** No server, no installation, no data leaves your machine.
+
+[![Open the playground](https://img.shields.io/badge/Open-moodle--playground.com-f5923a?style=for-the-badge)](https://moodle-playground.com)
+[![GitHub](https://img.shields.io/badge/source-GitHub-181717?style=for-the-badge&logo=github)](https://github.com/ateeducacion/moodle-playground)
+[![License GPL](https://img.shields.io/badge/license-GPLv3-blue?style=for-the-badge)](https://github.com/ateeducacion/moodle-playground/blob/main/LICENSE)
 
 ## What is this?
 
-Moodle Playground lets you run a full Moodle LMS instance in your browser for learning, testing, and prototyping course experiences. Everything runs locally — no installation, no server, no data leaves your machine.
+Moodle Playground lets you run a **full Moodle LMS instance in your browser** for learning, testing, and prototyping course experiences. Perfect for:
 
-The runtime is **fully ephemeral**: all state lives in memory and is lost when you close the tab.
+- :material-school: **Teachers** evaluating new activities without touching a production server
+- :material-puzzle: **Plugin developers** testing changes before pushing to a live site
+- :material-book-open: **Trainers** giving workshops where every attendee gets a disposable Moodle
+- :material-flask: **Researchers** reproducing a specific Moodle version in an isolated environment
 
-Default credentials: username `admin`, password `password`.
+The runtime is **fully ephemeral**: everything lives in memory and resets when you close the tab.
+
+!!! tip "Default credentials"
+    Username `admin`, password `password`. Override them via a blueprint if needed.
 
 ## How it works
 
-The project follows a layered architecture:
+The project is a layered architecture with clear boundaries:
 
-1. **Shell UI** (`index.html` + `src/shell/main.js`) — toolbar, URL bar, iframe host, runtime logs
-2. **Runtime host** (`remote.html` + `src/remote/main.js`) — registers the service worker and hosts the playground iframe
-3. **Request routing** (`sw.js` + `php-worker.js`) — intercepts requests and routes them to the PHP runtime
-4. **PHP/Moodle runtime** (`src/runtime/*`) — boots Moodle via `@php-wasm/web` and serves HTTP requests through a bridge
-5. **Generated assets** (`assets/moodle/`) — prebuilt ZIP bundle with Moodle core (extracted into writable MEMFS at runtime)
+``` { .text .no-copy }
+┌─────────────────────────────────────────────────────────┐
+│  Shell UI  (index.html · src/shell/main.js)             │
+│     toolbar · URL bar · iframe host · runtime logs      │
+├─────────────────────────────────────────────────────────┤
+│  Runtime host  (remote.html · src/remote/main.js)       │
+│     registers the service worker                        │
+├─────────────────────────────────────────────────────────┤
+│  Request routing  (sw.js · php-worker.js)               │
+│     intercepts HTTP requests, routes to PHP runtime     │
+├─────────────────────────────────────────────────────────┤
+│  PHP / Moodle runtime  (src/runtime/*)                  │
+│     boots Moodle via @php-wasm/web                      │
+├─────────────────────────────────────────────────────────┤
+│  Generated assets  (assets/moodle/)                     │
+│     prebuilt ZIP bundle (extracted into MEMFS at boot)  │
+└─────────────────────────────────────────────────────────┘
+```
+
+See the [Architecture overview](architecture.md) for the full picture.
 
 ## Quick start
 
-```bash
-# Clone the repo
-git clone https://github.com/ateeducacion/moodle-playground.git
-cd moodle-playground
+=== "Use it right now"
 
-# Install and build
-npm install
-make prepare
-make bundle
+    Nothing to install — just open the hosted instance:
 
-# Start the dev server
-make serve
-```
+    <https://moodle-playground.com>
 
-Then open [http://localhost:8080](http://localhost:8080) in your browser.
+=== "Run it locally"
+
+    ```bash
+    # Clone
+    git clone https://github.com/ateeducacion/moodle-playground.git
+    cd moodle-playground
+
+    # Install and build
+    npm install
+    make prepare
+    make bundle
+
+    # Start the dev server
+    make serve
+    ```
+
+    Then open <http://localhost:8080>.
+
+=== "Quick blueprint demo"
+
+    Provision a site with a custom name and a demo course in one go:
+
+    ```
+    https://moodle-playground.com/?blueprint-url=/assets/blueprints/examples/demo-course.blueprint.json
+    ```
+
+    See the [Blueprint gallery](blueprint-gallery.md) for more.
 
 ## Features
 
-- Full Moodle 4.4 / 5.0 running in WebAssembly
-- PHP 8.1 to 8.5 support (version depends on Moodle branch; default: 8.3)
-- SQLite database via [experimental PDO driver patch](https://moodle.atlassian.net/browse/MDL-88218) (in-memory, no persistence needed)
-- Pre-built install snapshot for fast boot (~3s vs ~8s full install)
-- Step-based blueprint system for provisioning users, courses, enrolments, modules, and more
-- Works on GitHub Pages with subpath support
+<div class="grid cards" markdown>
 
-## Project links
+- :material-language-php: **PHP 8.1 → 8.5**
 
-- [GitHub repository](https://github.com/ateeducacion/moodle-playground)
-- [Getting started](getting-started.md)
-- [Architecture](architecture.md)
-- [Blueprint reference](blueprint-json.md)
-- [Plugin install notes for this branch](plugin-install-branch-notes.md)
+    Version depends on the Moodle branch; default `8.3`.
+
+- :material-school: **Moodle 4.4 / 5.0**
+
+    Multiple upstream branches built at the same time.
+
+- :material-database: **SQLite via PDO**
+
+    Experimental driver patch — see [MDL-88218](https://moodle.atlassian.net/browse/MDL-88218).
+
+- :material-rocket-launch: **Fast boot**
+
+    Pre-built install snapshot boots in ~3 s vs ~8 s for a full install.
+
+- :material-view-list: **Blueprints**
+
+    Step-based JSON to provision users, courses, enrolments, modules, and more.
+
+- :material-github: **Works on GitHub Pages**
+
+    Subpath-aware; deployable as a static site.
+
+</div>
+
+## Where to go next
+
+<div class="grid cards" markdown>
+
+- :material-rocket-launch: **[Getting started](getting-started.md)**
+
+    Local setup, build commands, and a first blueprint.
+
+- :material-code-braces: **[Blueprint reference](blueprint-json.md)**
+
+    The complete JSON schema for blueprint files.
+
+- :material-image-multiple: **[Blueprint gallery](blueprint-gallery.md)**
+
+    Ready-to-use blueprint examples for courses, users, plugins.
+
+- :material-sitemap: **[Architecture](architecture.md)**
+
+    How the shell, service worker and PHP-WASM runtime fit together.
+
+- :material-lightbulb-on: **[Troubleshooting](TROUBLESHOOTING.md)**
+
+    Common failure modes and how to fix them.
+
+- :material-alert-circle: **[Known issues](KNOWN-ISSUES.md)**
+
+    Upstream bugs and limitations we are tracking.
+
+</div>
 
 ## CI/CD and GitHub Actions
 
-The project includes a reusable GitHub Action for generating live PR previews of Moodle Playground:
+The project includes a reusable GitHub Action for live PR previews:
 
-- [**action-moodle-playground-pr-preview**](https://github.com/ateeducacion/action-moodle-playground-pr-preview) — Deploys a temporary Moodle Playground instance for each pull request, allowing reviewers to test changes in the browser before merging.
+- [**action-moodle-playground-pr-preview**](https://github.com/ateeducacion/action-moodle-playground-pr-preview) — Deploys a temporary Moodle Playground instance for each pull request so reviewers can test changes in the browser before merging.
 
-The main CI/CD pipeline (`.github/workflows/ci.yml`) handles linting, unit tests, E2E tests (Chromium + Firefox), and deployment to GitHub Pages on push to `main`.
+The main CI/CD pipeline (`.github/workflows/ci.yml`) handles linting, unit tests, Playwright E2E (Chromium + Firefox), and deployment to GitHub Pages on push to `main`.
 
 ---
 
-Made with ❤️ by [Área de Tecnología Educativa](https://www3.gobiernodecanarias.org/medusa/ecoescuela/ate/)
+Made with :material-heart:{ .heart } by [Área de Tecnología Educativa](https://www3.gobiernodecanarias.org/medusa/ecoescuela/ate/)

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -16,6 +16,39 @@
   --md-accent-fg-color--transparent: rgba(224, 112, 16, 0.1);
 }
 
+/* Zensical paints .md-header with --md-default-bg-color--light, so
+   overriding --md-primary-fg-color isn't enough to colour the navbar.
+   Force the header (and the search input it hosts) to use the brand
+   orange with white foreground text. */
+.md-header,
+.md-header[data-md-state="shadow"] {
+  background-color: var(--md-primary-fg-color);
+  color: #fff;
+}
+
+.md-header .md-header__title,
+.md-header .md-header__button,
+.md-header .md-header__topic,
+.md-header .md-source,
+.md-header .md-source__fact,
+.md-header .md-source__repository {
+  color: #fff;
+}
+
+.md-header .md-search__input {
+  background-color: rgba(255, 255, 255, 0.18);
+  color: #fff;
+}
+
+.md-header .md-search__input::placeholder {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.md-header .md-search__input + .md-search__icon,
+.md-header .md-search__icon[for="__search"] {
+  color: #fff;
+}
+
 /* Make the sidebar nav slightly tighter so deeper hierarchies fit */
 .md-nav--primary .md-nav__link {
   padding-top: 0.35rem;

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,8 +1,42 @@
-/* Match the navbar orange from the main app (--color-orange-soft: #f5923a) */
+/* ------------------------------------------------------------------
+   Moodle Playground — docs theme overrides
+
+   Keep the orange navbar in sync with the main app
+   (--color-orange-soft: #f5923a)
+------------------------------------------------------------------- */
+
 :root,
 [data-md-color-scheme="default"],
 [data-md-color-scheme="slate"] {
-  --md-primary-fg-color: #f5923a;
-  --md-primary-fg-color--light: #f9a85e;
-  --md-primary-fg-color--dark: #e07010;
+  --md-primary-fg-color:        #f5923a;
+  --md-primary-fg-color--light:  #f9a85e;
+  --md-primary-fg-color--dark:   #e07010;
+
+  --md-accent-fg-color:         #e07010;
+  --md-accent-fg-color--transparent: rgba(224, 112, 16, 0.1);
+}
+
+/* Make the sidebar nav slightly tighter so deeper hierarchies fit */
+.md-nav--primary .md-nav__link {
+  padding-top: 0.35rem;
+  padding-bottom: 0.35rem;
+}
+
+/* Nicer feature grid on the index page */
+.md-typeset .grid.cards > :is(ul, ol) > li,
+.md-typeset .grid > .card {
+  border-radius: 0.5rem;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.md-typeset .grid.cards > :is(ul, ol) > li:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08);
+  border-color: var(--md-primary-fg-color);
+}
+
+/* Code blocks: slightly rounder corners and a bit more contrast */
+.md-typeset pre > code,
+.md-typeset .highlight pre {
+  border-radius: 0.5rem;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,34 +1,107 @@
-site_name: Moodle Playground Documentation
-site_description: Contributor and user documentation for Moodle Playground.
+site_name: Moodle Playground
+site_description: Moodle running entirely in your browser via WebAssembly — contributor and user documentation.
 site_url: https://ateeducacion.github.io/moodle-playground/docs/
 repo_url: https://github.com/ateeducacion/moodle-playground
+repo_name: ateeducacion/moodle-playground
 edit_uri: edit/main/docs/
 docs_dir: docs
 site_dir: site
+
 theme:
   name: material
+  language: en
+  features:
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - navigation.instant
+    - navigation.tracking
+    - navigation.indexes
+    - toc.follow
+    - search.suggest
+    - search.highlight
+    - search.share
+    - content.code.copy
+    - content.code.annotate
+    - content.tabs.link
+    - content.action.edit
   palette:
-    - scheme: default
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
-    - scheme: slate
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
       toggle:
         icon: material/brightness-4
         name: Switch to light mode
+  icon:
+    repo: fontawesome/brands/github
+    logo: material/school
+
 extra_css:
   - stylesheets/extra.css
+
 nav:
   - Home: index.md
-  - Getting started: getting-started.md
-  - Architecture: architecture.md
-  - Blueprint reference: blueprint-json.md
-  - Blueprint gallery: blueprint-gallery.md
-  - Development: development.md
-  - Troubleshooting: TROUBLESHOOTING.md
-  - Known issues: KNOWN-ISSUES.md
+  - User guide:
+      - Getting started: getting-started.md
+      - Troubleshooting: TROUBLESHOOTING.md
+      - Known issues: KNOWN-ISSUES.md
+  - Blueprints:
+      - Blueprint reference: blueprint-json.md
+      - Blueprint gallery: blueprint-gallery.md
+  - Architecture:
+      - Overview: architecture.md
+      - Implementation status: implementation-status.md
+      - Moodle WASM plan: moodle-wasm-plan.md
+      - Plugin install notes: plugin-install-branch-notes.md
+      - SQLite WASM migration: sqlite-wasm-migration-notes.md
+  - Development:
+      - Contributing: development.md
+  - Decision records:
+      - "ADR 0001 — SW-level scoped static asset caching": decisions/0001-sw-level-scoped-static-asset-caching.md
+      - "ADR 0002 — Plugin auto-detection from GitHub URLs": decisions/0002-plugin-auto-detection-from-github-urls.md
+      - "ADR 0003 — Direct DB inserts for course modules": decisions/0003-direct-db-inserts-for-course-modules.md
+      - "ADR 0004 — OPcache tuning and runtime UX defaults": decisions/0004-opcache-tuning-and-runtime-ux-defaults.md
+      - "ADR 0005 — Resilient blueprint step execution": decisions/0005-resilient-blueprint-step-execution.md
+  - Research:
+      - PHP process manager evaluation: research/php-process-manager-evaluation.md
+
 markdown_extensions:
+  - abbr
   - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
   - tables
   - toc:
       permalink: true
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.keys
+  - pymdownx.mark
+  - pymdownx.caret
+  - pymdownx.tilde
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/ateeducacion/moodle-playground
+    - icon: fontawesome/solid/globe
+      link: https://moodle-playground.com

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,2 +1,1 @@
-mkdocs==1.6.1
-mkdocs-material==9.7.5
+zensical


### PR DESCRIPTION
Closes #61

## Summary

Swap the docs toolchain from **MkDocs + mkdocs-material** to **[Zensical](https://zensical.org/)** (Rust-backed, Material-for-MkDocs-compatible), restructure the navigation into a left sidebar with grouped sections, and polish the two most-visited pages (`index.md`, `getting-started.md`).

The orange top bar is preserved. All existing pages stay.

## What changed

### Toolchain

- `requirements-docs.txt` → just \`zensical\` (pins Python 3.10+).
- \`.github/workflows/ci.yml\`:
    - \`pip install -r requirements-docs.txt\` now installs Zensical.
    - \`mkdocs build --strict --site-dir dist-site/docs\` replaced by \`zensical build --clean\` + an \`rsync\` into \`dist-site/docs/\` (Zensical's build command does not expose \`--site-dir\` yet, so we use its default \`site/\` and move the output).

### Theme

- `mkdocs.yml` expanded to the full Material feature set:
    - Left sidebar navigation (**no** top tabs) with \`navigation.sections\` + \`navigation.expand\`, plus \`navigation.top\`, \`navigation.instant\`, \`navigation.tracking\`, \`navigation.indexes\`, \`toc.follow\`.
    - Search: \`search.suggest\`, \`search.highlight\`, \`search.share\`.
    - Code blocks: \`content.code.copy\`, \`content.code.annotate\`.
    - Content tabs: \`content.tabs.link\`.
    - Edit-on-GitHub button.
- Full \`pymdownx\` extension set: details, superfences, highlight (with anchors + line spans), inlinehilite, snippets, tabbed, tasklist (custom checkboxes), emoji, keys, mark, caret, tilde. Plus \`admonition\`, \`attr_list\`, \`def_list\`, \`footnotes\`, \`md_in_html\`, \`tables\`, \`toc\`.
- Dark/light palette toggle with automatic OS detection.

### Orange top bar (preserved)

\`docs/stylesheets/extra.css\` keeps \`--md-primary-fg-color: #f5923a\` but also:

- Defines matching light/dark variants (\`#f9a85e\`, \`#e07010\`).
- Matching accent color so links pick up the same orange.
- Slightly rounder code blocks and sidebar tightening.
- Hover effect on the feature grid cards on the home page.

### Navigation structure

Flat list → grouped sidebar:

- **User guide** — Getting started · Troubleshooting · Known issues
- **Blueprints** — Blueprint reference · Blueprint gallery
- **Architecture** — Overview · Implementation status · Moodle WASM plan · Plugin install notes · SQLite WASM migration
- **Development** — Contributing
- **Decision records** — ADRs 0001 → 0005
- **Research** — PHP process manager evaluation

Every page from \`docs/\` is surfaced — nothing hidden, nothing dropped.

### Content upgrades

**\`docs/index.md\`**

- Hero with live badges (hosted site, GitHub, license).
- *Use cases* bulleted list (teachers, plugin devs, trainers, researchers).
- ASCII diagram of the layered runtime.
- Tabbed quick-start (\"Use it now\" vs \"Run it locally\" vs \"Quick blueprint demo\").
- Feature grid cards with icons.
- Navigation grid into the rest of the docs.

**\`docs/getting-started.md\`**

- Requirements table.
- Tabbed build commands (default / all branches / just the PHP worker).
- \`!!! info\` admonition explaining why a local HTTP server is required (service worker constraint).
- A dedicated *Building the documentation* section with both a venv recipe and a Docker one-liner.
- \`!!! warning\` about Zensical's Python 3.10+ requirement.
- A *first blueprint* walkthrough with a labelled code block (\`title=\"demo.blueprint.json\" linenums=\"1\"\`).
- Where-blueprints-live table.

## Validation

Built locally with \`docker run python:3.12-slim\` → \`pip install zensical\` → \`zensical build --clean\`. Result:

- 18 pages compiled, nothing missing from the nav.
- Build finished in **0.23 s**.
- Output \`site/\` contains \`404.html\`, every top-level page, \`decisions/\`, \`research/\`, and the Material asset bundle.
- YAML syntax on \`mkdocs.yml\` and \`.github/workflows/ci.yml\` validated.

## Out of scope

- Content rewrites on the deep ADRs / research pages. They still ship as-is.
- Upstream Moodle version bumps.
- Runtime code changes.

## Test plan

- [ ] CI \`build\` job turns green on the \`docs/zensical-migration\` branch.
- [ ] Netlify PR preview shows the new docs under \`dist-site/docs/\`.
- [ ] Visit \`/docs/\` on the preview — orange top bar, left sidebar with grouped sections, dark/light toggle, code copy buttons.
- [ ] Spot-check every nav link resolves.
- [ ] After merge, confirm Pages deploy and <https://ateeducacion.github.io/moodle-playground/docs/> loads.