### PR TITLE
Accept drive.usercontent.google.com download URLs in proxy worker

### DIFF
--- a/scripts/github-proxy-worker.js
+++ b/scripts/github-proxy-worker.js
@@ -521,19 +521,29 @@ function isGitHubDirectProxyUrl(url) {
 }
 
 function isGoogleDriveDirectFileUrl(url) {
-  if (url.hostname.toLowerCase() !== "drive.google.com") {
+  const hostname = url.hostname.toLowerCase();
+
+  if (hostname === "drive.google.com") {
+    if (/^\/file\/d\/[^/]+(?:\/|$)/u.test(url.pathname)) {
+      return true;
+    }
+
+    if (
+      (url.pathname === "/uc" || url.pathname === "/open") &&
+      url.searchParams.has("id")
+    ) {
+      return true;
+    }
+
     return false;
   }
 
-  if (/^\/file\/d\/[^/]+(?:\/|$)/u.test(url.pathname)) {
-    return true;
-  }
+  if (hostname === "drive.usercontent.google.com") {
+    if (url.pathname === "/download" && url.searchParams.has("id")) {
+      return true;
+    }
 
-  if (
-    (url.pathname === "/uc" || url.pathname === "/open") &&
-    url.searchParams.has("id")
-  ) {
-    return true;
+    return false;
   }
 
   return false;
@@ -541,6 +551,10 @@ function isGoogleDriveDirectFileUrl(url) {
 
 function normalizeSupportedGenericProxyUrl(url) {
   if (!isGoogleDriveDirectFileUrl(url)) {
+    return url;
+  }
+
+  if (url.hostname.toLowerCase() === "drive.usercontent.google.com") {
     return url;
   }
 


### PR DESCRIPTION
## Summary
- The generic proxy mode in `scripts/github-proxy-worker.js` only accepted `drive.google.com` URLs, so a Drive link that had already been resolved/redirected to `https://drive.usercontent.google.com/download?id=...&export=download&confirm=...` returned `400 Bad Request`.
- `isGoogleDriveDirectFileUrl()` now also matches `drive.usercontent.google.com/download?id=...`.
- `normalizeSupportedGenericProxyUrl()` leaves usercontent URLs untouched so the `confirm`/`uuid` tokens that Drive requires for binary downloads are not stripped.

## Test plan
- [x] Deploy the worker and `GET /?url=https%3A%2F%2Fdrive.usercontent.google.com%2Fdownload%3Fid%3D<FILE_ID>%26export%3Ddownload%26confirm%3Dt` — should stream the file (not 400).
- [x] Existing `drive.google.com/file/d/<id>/view` and `drive.google.com/uc?id=<id>` URLs still work (regression check).
- [x] Non-Drive generic URLs (ZIPs, GitHub raw, FacturaScripts) still proxy as before.