### PR TITLE
build(deps): bump @php-wasm/* to 3.1.30 and fix ICU data resolution

### DIFF
--- a/esbuild.worker.mjs
+++ b/esbuild.worker.mjs
@@ -1,6 +1,25 @@
 #!/usr/bin/env node
 
+import { createRequire } from "node:module";
+import { dirname } from "node:path";
 import { build } from "esbuild";
+
+const require = createRequire(import.meta.url);
+
+// @php-wasm/web 3.1.22+ references the ICU data file via the source-layout
+// path `../intl/shared/icu.dat`, but the published tarball ships the file at
+// `./shared/icu.dat` (no sibling `intl` package exists on npm). Without a
+// resolver hook, esbuild fails with "Could not resolve ../intl/shared/icu.dat"
+// when bundling the worker. See WordPress/wordpress-playground#2776.
+const phpWasmWebDir = dirname(require.resolve("@php-wasm/web/package.json"));
+const phpWasmIcuDataPlugin = {
+  name: "php-wasm-icu-data",
+  setup(b) {
+    b.onResolve({ filter: /(^|\/)intl\/shared\/icu\.dat$/ }, () => ({
+      path: `${phpWasmWebDir}/shared/icu.dat`,
+    }));
+  },
+};
 
 await Promise.all([
   // Bundle the PHP worker (Web Worker — uses @php-wasm dependencies)
@@ -21,6 +40,7 @@ await Promise.all([
     banner: {
       js: `const __APP_ROOT__ = new URL("../", import.meta.url).href;`,
     },
+    plugins: [phpWasmIcuDataPlugin],
     loader: {
       ".wasm": "file",
       ".so": "file",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,9 @@
     "": {
       "name": "moodle-playground",
       "dependencies": {
-        "@php-wasm/stream-compression": "^3.1.27",
-        "@php-wasm/universal": "^3.1.15",
-        "@php-wasm/web": "^3.1.21",
+        "@php-wasm/stream-compression": "^3.1.30",
+        "@php-wasm/universal": "^3.1.30",
+        "@php-wasm/web": "^3.1.30",
         "fflate": "^0.8.2"
       },
       "devDependencies": {
@@ -624,18 +624,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/@octokit/app": {
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/@octokit/app/-/app-14.1.0.tgz",
@@ -1149,39 +1137,15 @@
       "integrity": "sha512-S8u2cJzklBC0FgTwWVLaM8tMrDuDMVE4xiTK4EYXM9GntyvrdbSoxqDQa+Fh57CCNApyIpyeqPhhFEmHPfrXgw==",
       "license": "MIT"
     },
-    "node_modules/@php-wasm/cli-util": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.21.tgz",
-      "integrity": "sha512-LQ/c+vtkLmmPtPoQ/6Nh22lERNzaQmMeE38UGzCvf6PhIj0IoASvA4HthIdrdLegMbp0iG4abfkzTfGkhQzHvg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/util": "3.1.21",
-        "fast-xml-parser": "^5.5.1",
-        "jsonc-parser": "3.3.1"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
     "node_modules/@php-wasm/fs-journal": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@php-wasm/fs-journal/-/fs-journal-3.1.21.tgz",
-      "integrity": "sha512-dKuhka28t3OJxTUWItaox35S5njPppyFM/nTH4O+/5ZuKF9A2X7KwishFFO/Od2Sg1cvcIw5H9Ubj1+VJmC5iA==",
+      "version": "3.1.30",
+      "resolved": "https://registry.npmjs.org/@php-wasm/fs-journal/-/fs-journal-3.1.30.tgz",
+      "integrity": "sha512-yU6/p4o9jNMw55BeFslDBi8QpixRyeffpPav65VVXvV9kjK5d8I3VeKfs8K+rC4BI7vk2DfVbWcgDcIJIHbs/w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.1.21",
-        "@php-wasm/node": "3.1.21",
-        "@php-wasm/universal": "3.1.21",
-        "@php-wasm/util": "3.1.21",
-        "express": "4.22.0",
-        "fast-xml-parser": "^5.5.1",
-        "fs-ext-extra-prebuilt": "2.2.7",
-        "ini": "4.1.2",
-        "jsonc-parser": "3.3.1",
-        "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.0",
-        "yargs": "17.7.2"
+        "@php-wasm/logger": "3.1.30",
+        "@php-wasm/universal": "3.1.30",
+        "@php-wasm/util": "3.1.30"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1189,183 +1153,22 @@
       }
     },
     "node_modules/@php-wasm/logger": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.21.tgz",
-      "integrity": "sha512-ykuQcn2k7anSKOrkC46WHTKiC3/oh08RbHGiAMPnZymzG3fCHJbc1/LdH8CmkZdyNJqHt6nhAaYf7Ll8glG5Dg==",
+      "version": "3.1.30",
+      "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.30.tgz",
+      "integrity": "sha512-Du0Ux1pSLmwE5pj2RZLbbmhFhDPhGpdnQ1cbliK9QhjyzybgCXDy1yudp9ZSAmAxOYglwEk9Z65isMZoCPRcoA==",
       "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/node": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.21.tgz",
-      "integrity": "sha512-KAUbGH8ITHabpSxYlR3zV+dq3ml1QN1TGcdLXMdLrbonKUO36g0TPZr1/ddtf05QBgFiyx7JHIiB1ljvFqMLSQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/cli-util": "3.1.21",
-        "@php-wasm/logger": "3.1.21",
-        "@php-wasm/node-5-2": "3.1.21",
-        "@php-wasm/node-7-4": "3.1.21",
-        "@php-wasm/node-8-0": "3.1.21",
-        "@php-wasm/node-8-1": "3.1.21",
-        "@php-wasm/node-8-2": "3.1.21",
-        "@php-wasm/node-8-3": "3.1.21",
-        "@php-wasm/node-8-4": "3.1.21",
-        "@php-wasm/node-8-5": "3.1.21",
-        "@php-wasm/universal": "3.1.21",
-        "@php-wasm/util": "3.1.21",
-        "@wp-playground/common": "3.1.21",
-        "express": "4.22.0",
-        "fast-xml-parser": "^5.5.1",
-        "fs-ext-extra-prebuilt": "2.2.7",
-        "ini": "4.1.2",
-        "jsonc-parser": "3.3.1",
-        "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.0",
-        "yargs": "17.7.2"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/node-5-2": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-5-2/-/node-5-2-3.1.21.tgz",
-      "integrity": "sha512-l06b+B+NVyUxP9/mfyUSkjbNt4/BFy/YUzfob0teFByFUbcps1dKNqE5B042IERf+Laz9kuoS8ly9+VbFqVDkA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/universal": "3.1.21",
-        "ini": "4.1.2",
-        "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.0"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/node-7-4": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.21.tgz",
-      "integrity": "sha512-n9CRZRl0QI6/Q46W2HldKpAlVqZbyjvyvK2Ph2p6kktpCCAJsJ9JqTUjGSh3iuHgT+8DYBlxw1kMineqLLwNgQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/universal": "3.1.21",
-        "ini": "4.1.2",
-        "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.0"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/node-8-0": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.21.tgz",
-      "integrity": "sha512-dF2G6fcEYDm1yfoR5PWqasImYWPmRf76SLWx3WSXbhrunwDLVDgSuj4d17BmlA5fK/DkUnHHFf4QxwQWqyrUqQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/universal": "3.1.21",
-        "ini": "4.1.2",
-        "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.0"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/node-8-1": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.21.tgz",
-      "integrity": "sha512-SYIBDst+g8CNYw8t4VZ9yiv6GdmKX3NOIAqQ1tFo3fmAOc6VgK9qpQcmCmpwmMIxrHg6BcijvV7qTgJmZ93MmQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/universal": "3.1.21",
-        "ini": "4.1.2",
-        "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.0"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/node-8-2": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.21.tgz",
-      "integrity": "sha512-pB/fFHVtFiRTuXHCVa6ev6vSXwUq7075CLaGye04CpKi+CgsMhX54Qb9UOJNg5kbOp3fxSPnpYTB9ZwfUYnruw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/universal": "3.1.21",
-        "ini": "4.1.2",
-        "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.0"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/node-8-3": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.21.tgz",
-      "integrity": "sha512-RKFVIaul0rgf2aal6QoulOPTF9JUbNd7d0p+p5FJrntUhbjdaW9rICOOmgbwUl1hXiq2HDmRaGX1ZpxCsbVXGQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/universal": "3.1.21",
-        "ini": "4.1.2",
-        "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.0"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/node-8-4": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.21.tgz",
-      "integrity": "sha512-ZI5Pd0T2KqL8XfAX3eCULPbeLM0YmkbPbwye5siS6NXPW1lO0oHyJ91eKfRFLttCdzrkWndW/x1uimKVJFqEqg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/universal": "3.1.21",
-        "ini": "4.1.2",
-        "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.0"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/node-8-5": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.21.tgz",
-      "integrity": "sha512-i01P6zf+EWnVBRudPfokP4Z4Q1N4dy12mjDRfioANv0YqRCcyFgCc6ngJKN4/e0Ew+qhbkjTBkoRpscm4+RewA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/universal": "3.1.21",
-        "ini": "4.1.2",
-        "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.0"
-      },
       "engines": {
         "node": ">=20.10.0",
         "npm": ">=10.2.3"
       }
     },
     "node_modules/@php-wasm/progress": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.21.tgz",
-      "integrity": "sha512-fF7HCeXXptWGNSr8d3Tlyjelax8AnvpyZGWUtwNYI27428oIXhGEwsphlAHMfPfc5YEFz9BQEhHoTU7z/SRlbg==",
+      "version": "3.1.30",
+      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.30.tgz",
+      "integrity": "sha512-7ulbtY1A2deHyPd8GlLkgN776pBfEt35iiUbFxorHY9Oz3tBjpZSqEqRXzH3SHImp5POVvT9PSmAlAFSYdAKyA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.1.21"
+        "@php-wasm/logger": "3.1.30"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1373,9 +1176,9 @@
       }
     },
     "node_modules/@php-wasm/scopes": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.21.tgz",
-      "integrity": "sha512-BTECa1MsKv/RJxOaP+M/4MjilZpnYvYKTB2Kng8hrmYBA6LjuGnP1UY8yiCCUHsxnFxfRm6pW+c8Duy+ZTpVpw==",
+      "version": "3.1.30",
+      "resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.30.tgz",
+      "integrity": "sha512-EmYkNEcoK1R2dOqGloh3RNfAiMLSRzDOGyBfWWeKteooxzxsxAiwHPxjgVlGqb5zAWQVoB9FEJSIUgGRjjQSPg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=20.10.0",
@@ -1383,33 +1186,24 @@
       }
     },
     "node_modules/@php-wasm/stream-compression": {
-      "version": "3.1.27",
-      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.27.tgz",
-      "integrity": "sha512-cfOv/h9+vXgXdkp8t3ZN8MqrwDt3oLDuT+XHe8dCksT0egeYrPxTcrdoT8Y5bnt3Kinx4ycB3jXTB6qxAUI2Hw==",
+      "version": "3.1.30",
+      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.30.tgz",
+      "integrity": "sha512-yJ+4GvXRjO/bcZlBDsCUijYByff3aipdyi018MzqbTENF68nK6WOnSm+bBhDpvpZ4ZZ2yTTgDzpwdw5PJAVS0A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/util": "3.1.27"
-      }
-    },
-    "node_modules/@php-wasm/stream-compression/node_modules/@php-wasm/util": {
-      "version": "3.1.27",
-      "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.27.tgz",
-      "integrity": "sha512-/CHgMDamPY+SeR7Ov3y147EB/1b2yuLZEceIB2CDnkAuPCu1wdPJ/3oNt9gupAubd0Iuabw30xmlnweT0+U9RQ==",
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
+        "@php-wasm/util": "3.1.30"
       }
     },
     "node_modules/@php-wasm/universal": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.21.tgz",
-      "integrity": "sha512-JuaLJvGE2jCmLY+GYkz2yFpxjTrb4QzqXodKo3IDYe+hO9nhmPhBg5oootftPfMMKlYdyIfOT1jv3AUy6ihb+Q==",
+      "version": "3.1.30",
+      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.30.tgz",
+      "integrity": "sha512-6P5OrBEjE24X4IcDDSD6mJSdQuB94eQ8q5Wp3YzHjO7yjSd4TOqWmlrFZTjbGJfz7fH7ZbR8g5UmlZ8e/AZPEg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.1.21",
-        "@php-wasm/progress": "3.1.21",
-        "@php-wasm/stream-compression": "3.1.21",
-        "@php-wasm/util": "3.1.21",
+        "@php-wasm/logger": "3.1.30",
+        "@php-wasm/progress": "3.1.30",
+        "@php-wasm/stream-compression": "3.1.30",
+        "@php-wasm/util": "3.1.30",
         "ini": "4.1.2"
       },
       "engines": {
@@ -1417,66 +1211,37 @@
         "npm": ">=10.2.3"
       }
     },
-    "node_modules/@php-wasm/universal/node_modules/@php-wasm/stream-compression": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.21.tgz",
-      "integrity": "sha512-VB+M15HL0krTo2yK9xswWzxby+K+gAHMtYhg7NhL7fhFIv/dKRkCv/dYAazwGNXP4/T7RxlPpchRpeFi+7ndjA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/util": "3.1.21"
-      }
-    },
     "node_modules/@php-wasm/util": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.21.tgz",
-      "integrity": "sha512-D2JYnqKJv5n7qArvczEPa2aX/vlVbdOBZ+MJJKUHAgzqun8wRT7kJXfW0XQ2C9EYvW9mFQ4gm7sYbpiEHUB8+g==",
+      "version": "3.1.30",
+      "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.30.tgz",
+      "integrity": "sha512-Ak2vRZIviWn3KrBcLNhhAWN9qdhRCNdtvZJDBjOHm4yajqYraSFl9tDqyu6vz2KJgcsVfsZpS+BOR9hLvR2nMw==",
       "engines": {
         "node": ">=20.10.0",
         "npm": ">=10.2.3"
       }
     },
     "node_modules/@php-wasm/web": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web/-/web-3.1.21.tgz",
-      "integrity": "sha512-B/MPMknkcJ2FDtyrQWxu9JUyyNQ1gwNTqbo2WcqDzMngfXr4NUO0wMuNEd3ybgGylyAcGdFO8+v3sq+DqEcVOw==",
+      "version": "3.1.30",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web/-/web-3.1.30.tgz",
+      "integrity": "sha512-Bk98/9vs5CGLUfe7TkLVYLWF/WBhAtBMdr7FaUOmid9erLO0Ts5Rw0zSdmICzjBAhdnk7PZIY+65NYKD5KTK+w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/fs-journal": "3.1.21",
-        "@php-wasm/logger": "3.1.21",
-        "@php-wasm/universal": "3.1.21",
-        "@php-wasm/util": "3.1.21",
-        "@php-wasm/web-5-2": "3.1.21",
-        "@php-wasm/web-7-4": "3.1.21",
-        "@php-wasm/web-8-0": "3.1.21",
-        "@php-wasm/web-8-1": "3.1.21",
-        "@php-wasm/web-8-2": "3.1.21",
-        "@php-wasm/web-8-3": "3.1.21",
-        "@php-wasm/web-8-4": "3.1.21",
-        "@php-wasm/web-8-5": "3.1.21",
-        "@php-wasm/web-service-worker": "3.1.21",
-        "@wp-playground/common": "3.1.21",
-        "@wp-playground/storage": "3.1.21",
-        "@zip.js/zip.js": "2.7.57",
-        "async-lock": "1.4.1",
-        "clean-git-ref": "2.0.1",
-        "crc-32": "1.2.2",
-        "diff3": "0.0.4",
-        "express": "4.22.0",
-        "fast-xml-parser": "^5.5.1",
-        "fs-ext-extra-prebuilt": "2.2.7",
-        "ignore": "5.3.2",
-        "ini": "4.1.2",
-        "jsonc-parser": "3.3.1",
-        "minimisted": "2.0.1",
-        "octokit": "3.1.2",
-        "pako": "1.0.10",
-        "pify": "2.3.0",
-        "readable-stream": "3.6.2",
-        "sha.js": "2.4.12",
-        "simple-get": "4.0.1",
-        "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.0",
-        "yargs": "17.7.2"
+        "@php-wasm/fs-journal": "3.1.30",
+        "@php-wasm/logger": "3.1.30",
+        "@php-wasm/universal": "3.1.30",
+        "@php-wasm/util": "3.1.30",
+        "@php-wasm/web-5-2": "3.1.30",
+        "@php-wasm/web-7-4": "3.1.30",
+        "@php-wasm/web-8-0": "3.1.30",
+        "@php-wasm/web-8-1": "3.1.30",
+        "@php-wasm/web-8-2": "3.1.30",
+        "@php-wasm/web-8-3": "3.1.30",
+        "@php-wasm/web-8-4": "3.1.30",
+        "@php-wasm/web-8-5": "3.1.30",
+        "@php-wasm/web-service-worker": "3.1.30",
+        "@wp-playground/common": "3.1.30",
+        "@wp-playground/storage": "3.1.30",
+        "wasm-feature-detect": "1.8.0"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1484,13 +1249,12 @@
       }
     },
     "node_modules/@php-wasm/web-5-2": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-5-2/-/web-5-2-3.1.21.tgz",
-      "integrity": "sha512-V543kkVN7Dkd4TavQnfuIIeDZQgdEZ2f+VvbpzjPQPk1CUR5yXMmaCH9C9Wi1Fi5YWsoiXebPUecoyP6Q/oPPA==",
+      "version": "3.1.30",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-5-2/-/web-5-2-3.1.30.tgz",
+      "integrity": "sha512-gi5CEFu6KM+5DCoYkoDgo/tjhIQjudbtAc6X80bxXgmHlMkg5S540d+iiIouDYgrrW2rLMFp1yTdKMURrGoRag==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.21",
-        "ini": "4.1.2",
+        "@php-wasm/universal": "3.1.30",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1499,13 +1263,12 @@
       }
     },
     "node_modules/@php-wasm/web-7-4": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-7-4/-/web-7-4-3.1.21.tgz",
-      "integrity": "sha512-9WnrqDFCNi9wcw8u1iBeZPw4l4I975W4KUxafMa5rgpy1WYlTLQE4te27w4xqCpdnPazm4odZwqyL0mO4vAoeA==",
+      "version": "3.1.30",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-7-4/-/web-7-4-3.1.30.tgz",
+      "integrity": "sha512-sjWlB8XtJHgmCo3kn6sMtVA/Fx/KR3bPhtSQpgyRgOs1PMSmNvF+LjlLajadHvFcDCLG+LNYYOBffnnPfCc2uQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.21",
-        "ini": "4.1.2",
+        "@php-wasm/universal": "3.1.30",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1514,13 +1277,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-0": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-0/-/web-8-0-3.1.21.tgz",
-      "integrity": "sha512-qymM5NJ4OOd1Lqm6uxZ99e7eUIjTgh4JtDY9LM9zgvF+Mnbt9DnMrSUK3IkE0tMRXIllT1WGrzkUuc9wF1sS1A==",
+      "version": "3.1.30",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-0/-/web-8-0-3.1.30.tgz",
+      "integrity": "sha512-xlOdlEspYH6AhUeiq0yDJwO4VsY+XyV6RnM1rOqxmhLMMYijUe7NItWzk6ouvIm/ulLEp5Bv5HOnXolBAw0nrA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.21",
-        "ini": "4.1.2",
+        "@php-wasm/universal": "3.1.30",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1529,13 +1291,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-1": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-1/-/web-8-1-3.1.21.tgz",
-      "integrity": "sha512-wOAVby6iLPaKbu20hJo+8VgrQXjz34XriesqdhVYRw1nAffSR/PdlaFA1PzcPQE9605XBXQ9W21b1ihozbEcQQ==",
+      "version": "3.1.30",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-1/-/web-8-1-3.1.30.tgz",
+      "integrity": "sha512-oFz6hcWc+HXJnsvGqWD+XsFT7iNhNdUqvZsM5HdmdkkA73yfqA/gkfTtcEzhQ91D9wGeEPVzFL4A9+iODC/exQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.21",
-        "ini": "4.1.2",
+        "@php-wasm/universal": "3.1.30",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1544,13 +1305,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-2": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-2/-/web-8-2-3.1.21.tgz",
-      "integrity": "sha512-4KYZmD6Nx/jrwHrcUJabvIhodXcptHeVReGauUE2I/0pf2CowDSZi9fcTOd2PXXXsDP0yRSHZGWMSEOx1tbJJw==",
+      "version": "3.1.30",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-2/-/web-8-2-3.1.30.tgz",
+      "integrity": "sha512-6ueKnvOQa/z3y2kC3EUHA4vGhZ6LAwTZPuHd/m6lAy0OaXT6g1PlBz8dc6HjMLBfIMlm/37n6U9EnkY/hRIq4g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.21",
-        "ini": "4.1.2",
+        "@php-wasm/universal": "3.1.30",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1559,13 +1319,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-3": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-3/-/web-8-3-3.1.21.tgz",
-      "integrity": "sha512-6l31DKBK1mDRQYo4zwoTfxgL2FRNKAoMKwf9oRy+aY2e54q0JMyYkIqi+w9XIdghS/0ayS4n7hRHBslBcH5MOg==",
+      "version": "3.1.30",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-3/-/web-8-3-3.1.30.tgz",
+      "integrity": "sha512-ICE7t51Yhx0b9dJ48a3pJTZXQ/XuTjuNBTvUylcg2Jmfq/+yxmaJ01G5EWX841TGpsJfPJNYOOT4kK0tPR/I+w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.21",
-        "ini": "4.1.2",
+        "@php-wasm/universal": "3.1.30",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1574,13 +1333,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-4": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-4/-/web-8-4-3.1.21.tgz",
-      "integrity": "sha512-5MylNmgHWxyA3G+uuWF2zdM3bGBeudFPF6RdgO7upohF1mUVUvpJLNNpBv6M96vWGTxhVUaVd/ZsJtpvWnKiLw==",
+      "version": "3.1.30",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-4/-/web-8-4-3.1.30.tgz",
+      "integrity": "sha512-rAa0uYY6AB10x4TJKRTAnI+xqDd3QIUJE/6HIvPo3ImU9WhsN+H8A2D1wHJpkNJ5C0SQHCnouwRpJTkyHj3H5Q==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.21",
-        "ini": "4.1.2",
+        "@php-wasm/universal": "3.1.30",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1589,13 +1347,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-5": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-5/-/web-8-5-3.1.21.tgz",
-      "integrity": "sha512-npcBU6GB5rdqi/qOeDxIduuQ1OZqrKZS0sCTH3FuHqVAsQUceRoV8+MRniePtWQqUuTcUsy2hnisqzaRO3x13A==",
+      "version": "3.1.30",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-5/-/web-8-5-3.1.30.tgz",
+      "integrity": "sha512-2Znk5Lrpo1xLhPez3Hs2HU69HMrs+cnEVQHCEa/wMC8/tkAhivF4yp8UJbyp4Al1cc0YycII/QQXyN8cBh5xOQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.21",
-        "ini": "4.1.2",
+        "@php-wasm/universal": "3.1.30",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1604,14 +1361,13 @@
       }
     },
     "node_modules/@php-wasm/web-service-worker": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.21.tgz",
-      "integrity": "sha512-ZLxbCfw+t3VKkZtVj7kUE3hNJ3PVFU47pakUcpvfDq9+yAOQggx3IPLH5/YokWHu3pm+G9eCIRuHcMZuLa5J/w==",
+      "version": "3.1.30",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.30.tgz",
+      "integrity": "sha512-IPnRTr1TPU/m7rw20ZwOntXAuykWahybakYMjzKQjSSOA7MV3dSbbEXADAw03SKGSLivzTehXXveY4/zXSk0lQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/scopes": "3.1.21",
-        "@php-wasm/universal": "3.1.21",
-        "ini": "4.1.2"
+        "@php-wasm/scopes": "3.1.30",
+        "@php-wasm/universal": "3.1.30"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1663,23 +1419,22 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
+      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
       }
     },
     "node_modules/@wp-playground/common": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.21.tgz",
-      "integrity": "sha512-NEM8gwpksjiGohLuikvKo2+qOKE7LlatUEQBe3MqzMOpJtItxnCBBFTo21mH9/0ZzuHCn7udFdVwWoF5ZjbBMQ==",
+      "version": "3.1.30",
+      "resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.30.tgz",
+      "integrity": "sha512-tyqGMP+jyYy8pNhyg3G52y1v0I5q7z5rRopei8lp9Bd7OKCycXH52OzfMjQAy8OSAb2JPYbk0Tk3FEeqD7FYMg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.21",
-        "@php-wasm/util": "3.1.21",
-        "ini": "4.1.2"
+        "@php-wasm/universal": "3.1.30",
+        "@php-wasm/util": "3.1.30"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1687,52 +1442,18 @@
       }
     },
     "node_modules/@wp-playground/storage": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.21.tgz",
-      "integrity": "sha512-6Is8Pjx+WpWlVPE/7Oxks19sK4wiaeFbFnGNcw1ICT6i0ssbZIULWq1kwkshHM2czop/PKM2SyxjhiSMd++EMw==",
+      "version": "3.1.30",
+      "resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.30.tgz",
+      "integrity": "sha512-ePj9/BshpYpNdPrV8QkT4nEqLN/XUcJYwqhWOEG+6EJac84WJdOfBxkQoJow/N+HC2RnvEPvclvurzXsCWZI8g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/stream-compression": "3.1.21",
-        "@php-wasm/universal": "3.1.21",
-        "@php-wasm/util": "3.1.21",
+        "@php-wasm/stream-compression": "3.1.30",
+        "@php-wasm/universal": "3.1.30",
+        "@php-wasm/util": "3.1.30",
         "@zip.js/zip.js": "2.7.57",
-        "async-lock": "^1.4.1",
-        "clean-git-ref": "^2.0.1",
-        "crc-32": "^1.2.0",
-        "diff3": "0.0.3",
-        "ignore": "^5.1.4",
-        "ini": "4.1.2",
-        "minimisted": "^2.0.0",
+        "isomorphic-git": "1.37.6",
         "octokit": "3.1.2",
-        "pako": "^1.0.10",
-        "pify": "^4.0.1",
-        "readable-stream": "^3.4.0",
-        "sha.js": "^2.4.9",
-        "simple-get": "^4.0.1"
-      }
-    },
-    "node_modules/@wp-playground/storage/node_modules/@php-wasm/stream-compression": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.21.tgz",
-      "integrity": "sha512-VB+M15HL0krTo2yK9xswWzxby+K+gAHMtYhg7NhL7fhFIv/dKRkCv/dYAazwGNXP4/T7RxlPpchRpeFi+7ndjA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/util": "3.1.21"
-      }
-    },
-    "node_modules/@wp-playground/storage/node_modules/diff3": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
-      "integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
-      "license": "MIT"
-    },
-    "node_modules/@wp-playground/storage/node_modules/pify": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
+        "pako": "^1.0.10"
       }
     },
     "node_modules/@zip.js/zip.js": {
@@ -1746,17 +1467,16 @@
         "node": ">=16.5.0"
       }
     },
-    "node_modules/accepts": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "license": "MIT",
       "dependencies": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
+        "event-target-shim": "^5.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=6.5"
       }
     },
     "node_modules/aggregate-error": {
@@ -1776,6 +1496,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1785,6 +1506,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -1795,12 +1517,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "license": "MIT"
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -1830,6 +1546,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/basic-auth": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -1856,45 +1592,6 @@
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
       "license": "Apache-2.0"
     },
-    "node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "~1.2.0",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "on-finished": "~2.4.1",
-        "qs": "~6.15.1",
-        "raw-body": "~2.5.3",
-        "type-is": "~1.6.18",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/bottleneck": {
       "version": "2.19.5",
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
@@ -1907,20 +1604,35 @@
       "integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==",
       "license": "MIT"
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/call-bind": {
       "version": "1.0.9",
@@ -2018,6 +1730,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -2032,6 +1745,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2044,6 +1758,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/concurrently": {
@@ -2071,42 +1786,6 @@
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
     },
-    "node_modules/content-disposition": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/cookie-signature": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
-      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
-      "license": "MIT"
-    },
     "node_modules/corser": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
@@ -2127,15 +1806,6 @@
       },
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
       }
     },
     "node_modules/decompress-response": {
@@ -2170,35 +1840,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/deprecation": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "license": "ISC"
     },
-    "node_modules/destroy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
     "node_modules/diff3": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.4.tgz",
-      "integrity": "sha512-f1rQ7jXDn/3i37hdwRk9ohqcvLRH3+gEIgmA6qEM280WUOh7cOr3GXV8Jm5sPwUs46Nzl48SE8YNLGJoaLuodg==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
+      "integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
       "license": "MIT"
     },
     "node_modules/dunder-proto": {
@@ -2224,26 +1875,12 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT"
-    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/encodeurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -2321,24 +1958,19 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
-    "node_modules/escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT"
-    },
-    "node_modules/etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=6"
       }
     },
     "node_modules/eventemitter3": {
@@ -2348,87 +1980,13 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/express": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
-      "integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "license": "MIT",
-      "dependencies": {
-        "accepts": "~1.3.8",
-        "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
-        "content-disposition": "~0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "~0.7.1",
-        "cookie-signature": "~1.0.6",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "~1.3.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.0",
-        "merge-descriptors": "1.0.3",
-        "methods": "~1.1.2",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "~0.1.12",
-        "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.2.1",
-        "send": "~0.19.0",
-        "serve-static": "~1.16.2",
-        "setprototypeof": "1.2.0",
-        "statuses": "~2.0.1",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
-      },
       "engines": {
-        "node": ">= 0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/fast-xml-builder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
-      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.5.0",
-        "xml-naming": "^0.1.0"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
-      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
+        "node": ">=0.8.x"
       }
     },
     "node_modules/fflate": {
@@ -2436,24 +1994,6 @@
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
       "license": "MIT"
-    },
-    "node_modules/finalhandler": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
-      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "~2.0.2",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
@@ -2491,37 +2031,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/forwarded": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/fs-ext-extra-prebuilt": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/fs-ext-extra-prebuilt/-/fs-ext-extra-prebuilt-2.2.7.tgz",
-      "integrity": "sha512-Q7rayYRBDIvDF01HWOwSSjoaP+05N1g+o3BXL1Zf8Frw2JkjSmi4EtvCBITuW30l6hB2m2TW1pehdh8wyU/+gw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "nan": "^2.24.0"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -2550,6 +2059,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -2688,26 +2198,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/http-proxy": {
       "version": "1.18.1",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
@@ -2751,17 +2241,25 @@
         "node": ">=12"
       }
     },
-    "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -2796,15 +2294,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -2821,6 +2310,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2847,11 +2337,30 @@
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "license": "MIT"
     },
-    "node_modules/jsonc-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
-      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-      "license": "MIT"
+    "node_modules/isomorphic-git": {
+      "version": "1.37.6",
+      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.37.6.tgz",
+      "integrity": "sha512-qr1NFCPsVTZ6YGqTXw0CzamnsHyH9QQ1OTEfeXIweSljRUMzuHFCJdUn0wc6OcjtTDns6knxjPb7N6LmJeftOA==",
+      "license": "MIT",
+      "dependencies": {
+        "async-lock": "^1.4.1",
+        "clean-git-ref": "^2.0.1",
+        "crc-32": "^1.2.0",
+        "diff3": "0.0.3",
+        "ignore": "^5.1.4",
+        "minimisted": "^2.0.0",
+        "pako": "^1.0.10",
+        "pify": "^4.0.1",
+        "readable-stream": "^4.0.0",
+        "sha.js": "^2.4.12",
+        "simple-get": "^4.0.1"
+      },
+      "bin": {
+        "isogit": "cli.cjs"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",
@@ -2874,12 +2383,6 @@
         "node": ">=12",
         "npm": ">=6"
       }
-    },
-    "node_modules/jsonwebtoken/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/jwa": {
       "version": "2.0.1",
@@ -2963,64 +2466,17 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/merge-descriptors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-response": {
@@ -3054,30 +2510,16 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
-    },
-    "node_modules/nan": {
-      "version": "2.26.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
-      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
-      "license": "MIT"
-    },
-    "node_modules/negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3107,18 +2549,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/on-finished": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3139,48 +2569,18 @@
       }
     },
     "node_modules/pako": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
-      "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "license": "(MIT AND Zlib)"
     },
-    "node_modules/parseurl": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/path-to-regexp": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-      "license": "MIT"
-    },
     "node_modules/pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=6"
       }
     },
     "node_modules/playwright": {
@@ -3247,13 +2647,6 @@
         }
       }
     },
-    "node_modules/portfinder/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -3263,23 +2656,20 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/proxy-addr": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
       "license": "MIT",
-      "dependencies": {
-        "forwarded": "0.2.0",
-        "ipaddr.js": "1.9.1"
-      },
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/qs": {
       "version": "6.14.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
       "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -3291,48 +2681,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/raw-body": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
-      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
       "license": "MIT",
       "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3379,6 +2748,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/secure-compare": {
@@ -3389,60 +2759,15 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/send": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
-      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.1",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "~2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "~2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/serve-static": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
-      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
-      "license": "MIT",
-      "dependencies": {
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "~0.19.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/set-function-length": {
@@ -3461,12 +2786,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/setprototypeof": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC"
     },
     "node_modules/sha.js": {
       "version": "2.4.12",
@@ -3505,6 +2824,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3524,6 +2844,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3540,6 +2861,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -3558,6 +2880,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -3618,15 +2941,6 @@
         "simple-concat": "^1.0.0"
       }
     },
-    "node_modules/statuses": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -3640,6 +2954,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -3654,6 +2969,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -3661,18 +2977,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "8.1.1",
@@ -3704,15 +3008,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/toidentifier": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -3729,19 +3024,6 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
-    },
-    "node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "license": "MIT",
-      "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
@@ -3791,45 +3073,12 @@
       "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
       "license": "ISC"
     },
-    "node_modules/unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/url-join": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
       "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
-    },
-    "node_modules/utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/vary": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/wasm-feature-detect": {
       "version": "1.8.0",
@@ -3889,6 +3138,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -3908,46 +3158,11 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
-    "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/xml-naming": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -3957,6 +3172,7 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -3975,6 +3191,7 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "test:e2e:install": "playwright install chromium"
   },
   "dependencies": {
-    "@php-wasm/stream-compression": "^3.1.27",
-    "@php-wasm/universal": "^3.1.15",
-    "@php-wasm/web": "^3.1.21",
+    "@php-wasm/stream-compression": "^3.1.30",
+    "@php-wasm/universal": "^3.1.30",
+    "@php-wasm/web": "^3.1.30",
     "fflate": "^0.8.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Adds an esbuild resolver plugin that redirects `../intl/shared/icu.dat` (referenced by `@php-wasm/web` 3.1.22+) to the actual location `@php-wasm/web/shared/icu.dat` shipped in the published tarball. There is no sibling `@php-wasm/intl` package on npm; the broken relative path comes from the source-layout import and is documented as a bundler-config requirement in WordPress/wordpress-playground#2776.
- Bumps `@php-wasm/web`, `@php-wasm/universal`, and `@php-wasm/stream-compression` together to `^3.1.30`. They must move in lockstep — bumping web and universal independently causes esbuild to bundle two copies of `@php-wasm/universal`, splitting `loadedRuntimes` across registries and surfacing as `Runtime with id 1 not found` in `popLoadedRuntime` when `new PHP(runtimeId)` runs after `loadWebRuntime`.

## Failures this replaces / closes
- Closes #82 — Dependabot bump of `@php-wasm/web` to 3.1.30. Build failed with `[ERROR] Could not resolve "../intl/shared/icu.dat"`.
- Closes #84 — Dependabot bump of `@php-wasm/universal` to 3.1.30 (would surface the runtime-registry mismatch if merged alone).
- Closes #85 — Dependabot bump of `@php-wasm/stream-compression` to 3.1.30 (rolled together for consistency).

## Test plan
- [x] `make lint` passes
- [x] `npm run build:worker` produces `dist/php-worker.bundle.js` and `sw.bundle.js` with the new package versions
- [x] `make test` — 327 unit tests pass
- [ ] CI e2e