### PR TITLE
feat(github-proxy): support omeka.org and dev.omeka.org URLs

### DIFF
--- a/scripts/github-proxy-worker.js
+++ b/scripts/github-proxy-worker.js
@@ -4,7 +4,8 @@
 //
 // 1. Generic proxy mode (legacy): ?url={full_url}
 //    Proxies supported direct URLs with CORS headers. This includes ZIP downloads,
-//    GitHub-hosted text/binary resources, and FacturaScripts plugin pages.
+//    GitHub-hosted text/binary resources, FacturaScripts plugin pages, and
+//    omeka.org / dev.omeka.org resources (plugin/module pages and downloads).
 //
 // 2. GitHub proxy mode: ?repo={owner/repo}[&branch=...][&pr=...][&commit=...][&release=...][&asset=...][&atom=...]
 //    Builds the correct GitHub URL from semantic parameters and proxies the response.
@@ -498,7 +499,8 @@ function isSupportedGenericProxyUrl(url) {
     looksLikeZipUrl(url) ||
     isFacturaScriptsPluginPage(url) ||
     isGitHubDirectProxyUrl(url) ||
-    isGoogleDriveDirectFileUrl(url)
+    isGoogleDriveDirectFileUrl(url) ||
+    isOmekaOrgResourceUrl(url)
   );
 }
 
@@ -700,6 +702,11 @@ function isFacturaScriptsPluginPage(url) {
     url.hostname.toLowerCase() === "facturascripts.com" &&
     /^\/plugins\/[^/]+\/?$/u.test(url.pathname)
   );
+}
+
+function isOmekaOrgResourceUrl(url) {
+  const hostname = url.hostname.toLowerCase();
+  return hostname === "omeka.org" || hostname === "dev.omeka.org";
 }
 
 function buildZipFilename(url) {
@@ -1045,7 +1052,7 @@ function landingPageHtml(origin) {
         <span class="method">GET</span>
         <span class="endpoint-name">URL Proxy</span>
       </div>
-      <div class="endpoint-desc">Proxy supported ZIP, GitHub resource, or Google Drive file URLs with CORS headers.</div>
+      <div class="endpoint-desc">Proxy supported ZIP, GitHub resource, Google Drive, or omeka.org / dev.omeka.org URLs with CORS headers.</div>
       <div class="endpoint-desc">Drive accepts direct <code>/uc?id=...</code> links and shared <code>/file/d/{id}/view</code> links.</div>
       <div class="url-box">${base}/?url=<span class="param">{full_url}</span></div>
     </div>

--- a/tests/shared/github-proxy-worker.test.js
+++ b/tests/shared/github-proxy-worker.test.js
@@ -235,6 +235,62 @@ describe("github-proxy-worker generic ?url= mode", () => {
     );
   });
 
+  it("proxies omeka.org plugin/module pages", async () => {
+    let upstreamRequest;
+    global.fetch = async (url, init = {}) => {
+      upstreamRequest = { url, init };
+      return new Response("<html>module page</html>", {
+        status: 200,
+        headers: { "Content-Type": "text/html; charset=utf-8" },
+      });
+    };
+
+    const response = await worker.fetch(
+      new Request(
+        "https://proxy.example/?url=https://omeka.org/s/modules/ContactUs/",
+      ),
+      {},
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(upstreamRequest.url, "https://omeka.org/s/modules/ContactUs/");
+    assert.equal(
+      upstreamRequest.init.headers.get("User-Agent"),
+      "github-proxy-worker",
+    );
+    assert.equal(response.headers.get("X-Playground-Cors-Proxy"), "true");
+    assert.equal(await response.text(), "<html>module page</html>");
+  });
+
+  it("proxies dev.omeka.org resources", async () => {
+    let upstreamRequest;
+    global.fetch = async (url, init = {}) => {
+      upstreamRequest = { url, init };
+      return new Response(new Uint8Array([0x50, 0x4b, 0x03, 0x04]), {
+        status: 200,
+        headers: { "Content-Type": "application/zip" },
+      });
+    };
+
+    const response = await worker.fetch(
+      new Request(
+        "https://proxy.example/?url=https://dev.omeka.org/files/plugins/ContactUs-2.0.0.zip",
+      ),
+      {},
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(
+      upstreamRequest.url,
+      "https://dev.omeka.org/files/plugins/ContactUs-2.0.0.zip",
+    );
+    assert.equal(response.headers.get("X-Playground-Cors-Proxy"), "true");
+    assert.deepEqual(
+      Array.from(new Uint8Array(await response.arrayBuffer())),
+      [0x50, 0x4b, 0x03, 0x04],
+    );
+  });
+
   it("still rejects unrelated direct URLs", async () => {
     global.fetch = async () => {
       throw new Error("should not fetch upstream");


### PR DESCRIPTION
## Summary

- Extends the `?url=` generic proxy mode in `scripts/github-proxy-worker.js` to allow resources hosted on `omeka.org` and `dev.omeka.org` (plugin/module/theme pages and direct downloads from the official Omeka site).
- Adds a small `isOmekaOrgResourceUrl()` helper next to the existing host checks (FacturaScripts, GitHub, Google Drive) and wires it into `isSupportedGenericProxyUrl()`.
- Updates the landing-page docs and the file header comment to mention the new supported hosts.
- Adds unit tests covering both an `omeka.org` HTML page and a `dev.omeka.org` ZIP download.

## Test plan

- [x] `make test` — 329 tests across 72 suites pass, including the two new cases (`proxies omeka.org plugin/module pages`, `proxies dev.omeka.org resources`).
- [x] `make lint` — clean (only the pre-existing biome version-info notice).
- [ ] Manual smoke: fetch an omeka.org module page / zip via the deployed worker.