### PR TITLE
fix(runtime): disable curl_security_helper so plugins can reach external APIs

### DIFF
--- a/src/runtime/bootstrap.js
+++ b/src/runtime/bootstrap.js
@@ -741,6 +741,23 @@ try {
     $CFG->debug = ${normalizedDebug};
     $CFG->debugdeveloper = (${normalizedDebug} >= 32767);
 
+    // Disable Moodle's curl_security_helper. It calls gethostbynamel() on
+    // every outbound URL and treats unresolved hosts as "blocked", returning
+    // the literal body "The URL is blocked." before the request leaves PHP.
+    // The WASM SAPI has no DNS resolver, so this rejects every external
+    // hostname (e.g. plugin API clients hitting public REST endpoints).
+    // Clearing both blocked hosts and allowed ports makes
+    // core\\files\\curl_security_helper::is_enabled() return false, which
+    // skips the host_is_blocked() DNS check entirely. Direct fetch still
+    // goes through tcpOverFetch + phpCorsProxyUrl, where real network
+    // policy lives.
+    set_config('curlsecurityblockedhosts', '');
+    set_config('curlsecurityallowedport', '');
+    $CFG->curlsecurityblockedhosts = '';
+    $CFG->curlsecurityallowedport = '';
+    $result['set']['curlsecurityblockedhosts'] = '';
+    $result['set']['curlsecurityallowedport'] = '';
+
     $pluginDefaults = [
         'moodlecourse' => [
             'hiddensections' => '1',


### PR DESCRIPTION
## Summary

Moodle's `\core\files\curl_security_helper` validates every URL by calling `gethostbynamel($host)` and treats an unresolved host as **"blocked"**. The `@php-wasm` SAPI has no DNS resolver inside PHP — DNS happens at the `tcpOverFetch`/`fetch` layer — so this check rejects every external hostname before the request ever leaves PHP.

The user-visible symptom is that any Moodle plugin instantiating `new \curl()` to call a public REST API ends up with `http=0`, `len=19`, body `The URL is blocked.`. The recently added `dev.omeka.org` proxy allowlist (#87) doesn't help because the request is short-circuited at the Moodle layer.

This PR clears `curlsecurityblockedhosts` and `curlsecurityallowedport` unconditionally during the config normalizer pass, which makes `curl_security_helper::is_enabled()` return false and skips `host_is_blocked()` entirely. Real network policy continues to live in the browser-side proxy chain (`tcpOverFetch` + `phpCorsProxyUrl`).

## Repro before the fix

1. Boot the playground with the [`repository_omeka`](https://github.com/ateeducacion/moodle-repository_omeka) blueprint preconfigured against `https://dev.omeka.org/omeka-s-sandbox`.
2. Open the file picker (`/user/files.php` → Omeka Sandbox).
3. `repository_ajax.php` returns HTTP 500 with:
   ```
   Omeka-S API error: …/api/item_sets?page=1&per_page=20 -> invalid JSON (http=0, len=19, body=The URL is blocked.)
   ```

After the fix the picker lists item sets from the Omeka sandbox.

## Why not pass `ignoresecurity` per plugin?

It works, but every Moodle plugin that does HTTP from the WASM runtime would need that workaround. Disabling the helper at the runtime level is a one-line fix that benefits all plugins and matches how the playground already overrides other Moodle defaults that are nonsensical in WASM (e.g. snapshot-driven `allversionshash`, `adminsetuppending`).

## Test plan

- [ ] Boot a fresh playground, open `/admin/settings.php?section=httpsecurity` and confirm both blocked-hosts and allowed-ports are empty.
- [ ] Install any plugin that fetches via `new \curl()` (e.g. `repository_omeka` against `dev.omeka.org`) and confirm the call succeeds.
- [ ] Existing `tests/e2e/php-networking.spec.mjs` still passes (it uses raw `curl_init()` so isn't affected, but we shouldn't have regressed it).