### PR TITLE
fix(runtime): pass through PHP responses on non-zero exit when CGI body exists

### DIFF
--- a/src/runtime/php-compat.js
+++ b/src/runtime/php-compat.js
@@ -111,13 +111,25 @@ function getMimeType(path) {
 
 /**
  * Convert a PHPResponse to a native Response object.
+ *
+ * Optional `extraHeaders` (object of name → string) are appended after the
+ * PHP-emitted headers — used to surface diagnostic metadata (exit code,
+ * stderr) when the underlying script exited non-zero but still produced a
+ * well-formed CGI response.
  */
-function phpResponseToResponse(phpResponse) {
+function phpResponseToResponse(phpResponse, extraHeaders) {
   const headers = new Headers();
   if (phpResponse.headers) {
     for (const [key, values] of Object.entries(phpResponse.headers)) {
       for (const value of values) {
         headers.append(key, value);
+      }
+    }
+  }
+  if (extraHeaders) {
+    for (const [key, value] of Object.entries(extraHeaders)) {
+      if (value !== undefined && value !== null && value !== "") {
+        headers.set(key, value);
       }
     }
   }
@@ -127,6 +139,93 @@ function phpResponseToResponse(phpResponse) {
     headers,
   });
 }
+
+/**
+ * Encode a string for safe transport in an HTTP header value.
+ * Uses base64 so arbitrary bytes (newlines, non-ASCII) survive the header
+ * grammar that browsers and Service Workers enforce.
+ */
+function encodeHeaderValue(value) {
+  const bytes = new TextEncoder().encode(String(value));
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  if (typeof btoa === "function") {
+    return btoa(binary);
+  }
+  // Node fallback for tests.
+  return Buffer.from(binary, "binary").toString("base64");
+}
+
+/**
+ * Decide whether a PHPResponse that accompanied a non-zero exit code still
+ * represents a real, browser-deliverable HTTP response (e.g. Moodle's
+ * `repository_ajax.php` emitting a JSON error and exiting with code 1).
+ *
+ * The discriminator is intentionally conservative: only pass through when
+ *   1. PHP wrote at least one CGI header (so the response has a real
+ *      Content-Type) AND
+ *   2. the body bytes are non-empty.
+ *
+ * If either is missing, the response is treated as a true failure (segfault,
+ * fatal parse error before output, etc.) and the diagnostic wrapper still
+ * runs in `php-worker.js`.
+ */
+export function shouldPassThroughFailedPhpResponse(phpResponse) {
+  if (!phpResponse || typeof phpResponse !== "object") {
+    return false;
+  }
+  const headers = phpResponse.headers;
+  if (!headers || typeof headers !== "object") {
+    return false;
+  }
+  let hasHeader = false;
+  for (const key of Object.keys(headers)) {
+    const values = headers[key];
+    if (Array.isArray(values) ? values.length > 0 : Boolean(values)) {
+      hasHeader = true;
+      break;
+    }
+  }
+  if (!hasHeader) {
+    return false;
+  }
+  const bytes = phpResponse.bytes;
+  if (
+    !bytes ||
+    typeof bytes.byteLength !== "number" ||
+    bytes.byteLength === 0
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * True when an error thrown by `@php-wasm/universal` represents a PHP script
+ * that ran to completion but exited non-zero. Such errors carry the parsed
+ * `PHPResponse` on `.response` and `"request"` on `.source`.
+ */
+function isPhpExecutionFailure(error) {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  if (error.name === "PHPExecutionFailureError") {
+    return true;
+  }
+  if (error.source === "request" && error.response) {
+    return true;
+  }
+  return false;
+}
+
+export const __testing = {
+  encodeHeaderValue,
+  isPhpExecutionFailure,
+  phpResponseToResponse,
+  shouldPassThroughFailedPhpResponse,
+};
 
 /**
  * Wraps a WordPress Playground PHP instance with the compatibility API
@@ -260,14 +359,50 @@ export function wrapPhpInstance(
         // Non-fatal — directory might not exist yet during early boot.
       }
 
-      const phpResponse = await php.run({
-        scriptPath,
-        method: req.method || "GET",
-        headers: mergedHeaders,
-        body: req.body,
-        $_SERVER: serverVars,
-        relativeUri: urlPath,
-      });
+      // @php-wasm/universal throws `PHPExecutionFailureError` whenever the
+      // PHP process exits with a non-zero status — even when the script
+      // legitimately wrote a full CGI response first (Moodle's AJAX error
+      // handlers do this; e.g. repository_ajax.php prints a JSON error
+      // payload then calls die() / exits 1).  Without this guard the
+      // worker treated those responses as crashes and overwrote them with
+      // an HTML diagnostic page, producing "Unexpected token '<'" errors
+      // in any browser code that expected JSON.
+      //
+      // Catch that specific failure, and if the attached PHPResponse looks
+      // like a real CGI response (headers + body), deliver it untouched.
+      // Stderr is preserved via console.warn and a custom response header
+      // so debuggability isn't lost.
+      let phpResponse;
+      let nonZeroExitCode = 0;
+      let nonZeroExitErrors = "";
+      try {
+        phpResponse = await php.run({
+          scriptPath,
+          method: req.method || "GET",
+          headers: mergedHeaders,
+          body: req.body,
+          $_SERVER: serverVars,
+          relativeUri: urlPath,
+        });
+      } catch (error) {
+        if (
+          isPhpExecutionFailure(error) &&
+          shouldPassThroughFailedPhpResponse(error.response)
+        ) {
+          phpResponse = error.response;
+          nonZeroExitCode = Number(phpResponse.exitCode) || 1;
+          nonZeroExitErrors = String(phpResponse.errors || "");
+          if (typeof console !== "undefined" && console.warn) {
+            console.warn(
+              `[playground] PHP exited ${nonZeroExitCode} for ${urlPath} but emitted a CGI response; passing it through.${
+                nonZeroExitErrors ? `\nstderr: ${nonZeroExitErrors}` : ""
+              }`,
+            );
+          }
+        } else {
+          throw error;
+        }
+      }
 
       // Remember cookies from Set-Cookie headers (case-insensitive lookup —
       // WP Playground may return "set-cookie" or "Set-Cookie" depending on version)
@@ -295,7 +430,18 @@ export function wrapPhpInstance(
         }
       }
 
-      const response = phpResponseToResponse(phpResponse);
+      let extraHeaders;
+      if (nonZeroExitCode !== 0) {
+        extraHeaders = {
+          "x-playground-php-exit-code": String(nonZeroExitCode),
+        };
+        if (nonZeroExitErrors) {
+          extraHeaders["x-playground-php-stderr"] =
+            encodeHeaderValue(nonZeroExitErrors);
+        }
+      }
+
+      const response = phpResponseToResponse(phpResponse, extraHeaders);
 
       if (syncFs) {
         await syncFs();

--- a/tests/runtime/php-compat-passthrough.test.js
+++ b/tests/runtime/php-compat-passthrough.test.js
@@ -1,0 +1,211 @@
+/**
+ * Tests for the non-zero-exit pass-through helpers in php-compat.js.
+ *
+ * Background:
+ *   When `php.run({ scriptPath, ... })` finishes with a non-zero exit code,
+ *   `@php-wasm/universal` throws a `PHPExecutionFailureError` even if the
+ *   PHP script already wrote a fully-formed CGI response (headers + body).
+ *   This is what Moodle's AJAX error paths do — for example
+ *   `repository_ajax.php` catches a `moodle_exception`, prints a JSON error
+ *   payload, then exits 1.
+ *
+ *   Before this fix the worker mis-treated those responses as crashes and
+ *   replaced them with an HTML diagnostic page, producing
+ *   `SyntaxError: Unexpected token '<'` in any client expecting JSON.
+ *
+ *   These tests exercise the discriminator (`shouldPassThroughFailedPhpResponse`)
+ *   and the error-shape detector (`isPhpExecutionFailure`) used by
+ *   `wrapPhpInstance().request()` to choose between pass-through and the
+ *   existing diagnostic wrapper.
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { __testing } from "../../src/runtime/php-compat.js";
+
+const {
+  encodeHeaderValue,
+  isPhpExecutionFailure,
+  phpResponseToResponse,
+  shouldPassThroughFailedPhpResponse,
+} = __testing;
+
+function makePhpResponse({
+  status = 200,
+  headers = { "content-type": ["application/json; charset=utf-8"] },
+  body = "",
+  exitCode = 0,
+  errors = "",
+} = {}) {
+  return {
+    httpStatusCode: status,
+    headers,
+    bytes: new TextEncoder().encode(body),
+    exitCode,
+    errors,
+  };
+}
+
+describe("shouldPassThroughFailedPhpResponse", () => {
+  it("passes through a real Moodle JSON-AJAX error response (exit 1 with headers and body)", () => {
+    const resp = makePhpResponse({
+      status: 200,
+      headers: { "content-type": ["application/json; charset=utf-8"] },
+      body: JSON.stringify({
+        error: "Omeka-S API error: Bad request",
+        errorcode: "repositoryomeka_apierror",
+        stacktrace: null,
+        debuginfo: null,
+        reproductionlink: null,
+      }),
+      exitCode: 1,
+      errors: "",
+    });
+    assert.strictEqual(shouldPassThroughFailedPhpResponse(resp), true);
+  });
+
+  it("does not pass through when body is empty (true crash / segfault style)", () => {
+    const resp = makePhpResponse({
+      status: 200,
+      headers: { "content-type": ["text/html; charset=utf-8"] },
+      body: "",
+      exitCode: 1,
+    });
+    assert.strictEqual(shouldPassThroughFailedPhpResponse(resp), false);
+  });
+
+  it("does not pass through when there are no CGI headers", () => {
+    const resp = makePhpResponse({
+      status: 200,
+      headers: {},
+      body: "anything",
+      exitCode: 1,
+    });
+    assert.strictEqual(shouldPassThroughFailedPhpResponse(resp), false);
+  });
+
+  it("does not pass through for null/undefined responses", () => {
+    assert.strictEqual(shouldPassThroughFailedPhpResponse(null), false);
+    assert.strictEqual(shouldPassThroughFailedPhpResponse(undefined), false);
+    assert.strictEqual(shouldPassThroughFailedPhpResponse({}), false);
+  });
+
+  it("treats a single string header value the same as a one-element array", () => {
+    const resp = {
+      httpStatusCode: 500,
+      headers: { "content-type": "application/json; charset=utf-8" },
+      bytes: new TextEncoder().encode('{"error":"x"}'),
+      exitCode: 1,
+      errors: "",
+    };
+    assert.strictEqual(shouldPassThroughFailedPhpResponse(resp), true);
+  });
+});
+
+describe("isPhpExecutionFailure", () => {
+  it("recognises the named error from @php-wasm/universal", () => {
+    const err = new Error("PHP.run() failed with exit code 1.");
+    err.name = "PHPExecutionFailureError";
+    err.response = makePhpResponse();
+    err.source = "request";
+    assert.strictEqual(isPhpExecutionFailure(err), true);
+  });
+
+  it("falls back to the source/response shape when name is unavailable", () => {
+    const err = new Error("PHP.run() failed with exit code 1.");
+    err.response = makePhpResponse();
+    err.source = "request";
+    assert.strictEqual(isPhpExecutionFailure(err), true);
+  });
+
+  it("ignores unrelated errors", () => {
+    assert.strictEqual(isPhpExecutionFailure(new Error("boom")), false);
+    assert.strictEqual(isPhpExecutionFailure(null), false);
+    assert.strictEqual(isPhpExecutionFailure("string"), false);
+  });
+});
+
+describe("phpResponseToResponse", () => {
+  it("baseline: exit 0 → Response carries PHP headers and body untouched", async () => {
+    const phpResponse = makePhpResponse({
+      status: 200,
+      headers: { "content-type": ["application/json; charset=utf-8"] },
+      body: '{"ok":true}',
+      exitCode: 0,
+    });
+    const response = phpResponseToResponse(phpResponse);
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(
+      response.headers.get("content-type"),
+      "application/json; charset=utf-8",
+    );
+    assert.strictEqual(await response.text(), '{"ok":true}');
+    assert.strictEqual(
+      response.headers.get("x-playground-php-exit-code"),
+      null,
+    );
+  });
+
+  it("exit 1 with headers + body → pass-through, no HTML wrapper, extra diagnostic headers attached", async () => {
+    const phpResponse = makePhpResponse({
+      status: 200,
+      headers: { "content-type": ["application/json; charset=utf-8"] },
+      body: '{"error":"Omeka-S API error"}',
+      exitCode: 1,
+      errors: "Notice: undefined index in /www/moodle/foo.php on line 9\n",
+    });
+    assert.strictEqual(shouldPassThroughFailedPhpResponse(phpResponse), true);
+
+    const response = phpResponseToResponse(phpResponse, {
+      "x-playground-php-exit-code": "1",
+      "x-playground-php-stderr": encodeHeaderValue(phpResponse.errors),
+    });
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(
+      response.headers.get("content-type"),
+      "application/json; charset=utf-8",
+    );
+    assert.strictEqual(response.headers.get("x-playground-php-exit-code"), "1");
+    const stderrHeader = response.headers.get("x-playground-php-stderr");
+    assert.ok(stderrHeader);
+    // round-trip base64 decode to make sure stderr survives the header round trip
+    const decoded = Buffer.from(stderrHeader, "base64").toString("utf8");
+    assert.match(decoded, /Notice: undefined index/u);
+    // Body must be the original JSON, NOT an HTML diagnostic page.
+    const text = await response.text();
+    assert.strictEqual(text, '{"error":"Omeka-S API error"}');
+    assert.doesNotMatch(text, /<!doctype html/iu);
+    assert.doesNotMatch(text, /PHP\.run\(\) failed with exit code/u);
+  });
+
+  it("exit 1 with empty body → discriminator rejects pass-through (diagnostic wrapper still runs upstream)", () => {
+    const phpResponse = makePhpResponse({
+      status: 200,
+      headers: { "content-type": ["text/html; charset=utf-8"] },
+      body: "",
+      exitCode: 1,
+      errors: "PHP Fatal error: Uncaught Error in /www/moodle/foo.php\n",
+    });
+    assert.strictEqual(shouldPassThroughFailedPhpResponse(phpResponse), false);
+  });
+});
+
+describe("encodeHeaderValue", () => {
+  it("base64-encodes multi-line stderr so it survives HTTP header grammar", () => {
+    const input =
+      "Notice: undefined index in /foo.php on line 9\nWarning: something else\n";
+    const encoded = encodeHeaderValue(input);
+    // Header values must be ASCII and contain no CR/LF.
+    assert.match(encoded, /^[A-Za-z0-9+/=]+$/u);
+    const decoded = Buffer.from(encoded, "base64").toString("utf8");
+    assert.strictEqual(decoded, input);
+  });
+
+  it("handles non-ASCII bytes", () => {
+    const input = "Errör — fühl dich frei";
+    const encoded = encodeHeaderValue(input);
+    assert.match(encoded, /^[A-Za-z0-9+/=]+$/u);
+    const decoded = Buffer.from(encoded, "base64").toString("utf8");
+    assert.strictEqual(decoded, input);
+  });
+});


### PR DESCRIPTION
## Symptom

Inside the playground, any Moodle AJAX endpoint that emits a valid JSON error and then exits non-zero (for example `repository_ajax.php` catching a `moodle_exception`, printing the JSON error, and calling `die()` / exit 1) reaches the browser as the diagnostic HTML wrapper instead of the JSON body:

```
<!doctype html><meta charset="utf-8"><title>Moodle Playground</title>
<body><pre>Error: PHP.run() failed with exit code 1.

=== Stdout ===
 {"error":"Omeka-S API error: ...","errorcode":"repositoryomeka_apierror",...}

=== Stderr ===
 
    at PHP.run (https://moodle-playground.com/dist/php-worker.bundle.js?...:143591:13)
    ...
</pre></body>
```

Because the `Content-Type` is forced to `text/html`, the frontend JS — which expected `application/json` for that URL, since the original PHP body IS JSON — falls over with:

```
SyntaxError: Unexpected token '<', "<!doctype "... is not valid JSON
```

This silently breaks any Moodle JSON-AJAX error path inside the playground, hiding the real error from users.

Discovered while testing the `moodle-repository_omeka` plugin PR ateeducacion/moodle-repository_omeka#21 in the playground: the plugin's `get_file()` correctly emits a Moodle JSON error which the playground was overwriting.

## Root cause

`@php-wasm/universal`'s `PHP.run()` throws `PHPExecutionFailureError` on any non-zero exit code, even when the script already produced a full CGI response (parsed headers + body). `wrapPhpInstance().request()` in `src/runtime/php-compat.js` let that propagate; `php-worker.js` then caught it as a non-fatal runtime error and substituted the response via `buildLoadingResponse()` — the HTML diagnostic page shown above. The non-zero exit was being treated as a crash, but for these Moodle paths it was the script's intentional `die()`.

## Fix

In `src/runtime/php-compat.js` (`wrapPhpInstance().request()`), catch `PHPExecutionFailureError` (detected by `error.name === "PHPExecutionFailureError"` and/or `error.source === "request"` with a `.response` attached), then check the attached `PHPResponse`:

- If it has **at least one parsed CGI header** AND **non-empty body bytes**, deliver it unchanged. The cookie jar still gets updated; `php-worker.js` never sees an error and therefore never produces the diagnostic HTML.
- Otherwise (no headers or empty body — segfault, fatal parse error before output, etc.), re-throw so the existing diagnostic wrapper still runs. This keeps playground behaviour for "really broken" PHP and only changes behaviour for "PHP emitted a real response then exited non-zero", the conservative discriminator the issue called for.

**Stderr is preserved** via two channels so debuggability isn't lost:
1. `console.warn("[playground] PHP exited N for <url> but emitted a CGI response; passing it through. stderr: …")`
2. Two response headers: `x-playground-php-exit-code: N` and `x-playground-php-stderr: <base64>` (base64 so multi-line/non-ASCII stderr survives HTTP header grammar).

## Files touched

- `src/runtime/php-compat.js` — new `shouldPassThroughFailedPhpResponse()` discriminator + `isPhpExecutionFailure()` shape detector; `phpResponseToResponse()` now takes optional extra headers; `request()` wraps `php.run()` in a try/catch that pass-throughs valid CGI responses on non-zero exit.
- `tests/runtime/php-compat-passthrough.test.js` — 13 new tests, all three scenarios from the spec plus base64 round-trip and shape-detection coverage.

## Test plan

- [x] `npm test` — full suite (342 tests across 76 suites) passes, including the 13 new tests in `tests/runtime/php-compat-passthrough.test.js`.
- [x] `npx biome check src/runtime/php-compat.js tests/runtime/php-compat-passthrough.test.js` — clean.
- [x] `npm run build:worker` — `dist/php-worker.bundle.js` and `sw.bundle.js` rebuild without warnings.
- [ ] Manual sanity check: trigger a Moodle JSON-AJAX error path (e.g. the Omeka repository plugin) inside the playground and confirm the browser receives JSON, not the HTML wrapper.