### PR TITLE
fix(sw): fall back to original file when draftfile.php?preview= 404s

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -22,6 +22,11 @@ const SCOPED_STATIC_RE = /\.(css|js|mjs|woff2?|ttf|otf|eot|png|jpe?g|gif|svg|ico
 // The revision acts as a natural cache key — when content changes, the URL changes.
 // Excludes pluginfile.php and draftfile.php (user content, not cacheable).
 const CACHEABLE_PHP_ASSET_RE = /\/(theme\/styles\.php|lib\/javascript\.php|theme\/image\.php|theme\/font\.php)\//u;
+// Moodle scripts that accept `?preview=...` for on-the-fly image thumbnails
+// generated via GD. In the @php-wasm runtime GD-based resampling fails so
+// `get_file_preview()` returns false and the scripts answer 404. See
+// `maybePreviewFallback()` for the retry-without-preview workaround.
+const PREVIEW_FALLBACK_PATH_RE = /\/(draftfile|pluginfile)\.php(?:\/|$)/u;
 const INTERNAL_PROXY_PATH = "/__playground_proxy__";
 let playgroundConfigPromise;
 let addonProxyUrlOverride = null;
@@ -36,6 +41,38 @@ function isCacheablePhpAsset(requestPath) {
 
 function isInternalProxyPath(pathname) {
   return pathname.split("?")[0] === INTERNAL_PROXY_PATH;
+}
+
+function isPreviewFallbackCandidate(requestPath, status) {
+  if (status !== 404) {
+    return false;
+  }
+  const qIdx = requestPath.indexOf("?");
+  if (qIdx < 0) {
+    return false;
+  }
+  const pathOnly = requestPath.slice(0, qIdx);
+  if (!PREVIEW_FALLBACK_PATH_RE.test(pathOnly)) {
+    return false;
+  }
+  const params = new URLSearchParams(requestPath.slice(qIdx + 1));
+  const value = params.get("preview");
+  return value !== null && value !== "";
+}
+
+function stripPreviewParam(requestPath) {
+  const qIdx = requestPath.indexOf("?");
+  if (qIdx < 0) {
+    return requestPath;
+  }
+  const params = new URLSearchParams(requestPath.slice(qIdx + 1));
+  if (!params.has("preview")) {
+    return requestPath;
+  }
+  params.delete("preview");
+  const remaining = params.toString();
+  const pathOnly = requestPath.slice(0, qIdx);
+  return remaining ? `${pathOnly}?${remaining}` : pathOnly;
 }
 
 function getPlaygroundConfigUrl() {
@@ -709,11 +746,32 @@ self.addEventListener("fetch", (event) => {
         return fresh;
       }
 
-      const response = await forwardToPhpWorker({
+      let response = await forwardToPhpWorker({
         request: buildPhpRequest(event.request, forwardedUrl, earlyBody),
         runtimeId,
         scopeId,
       }).catch((error) => buildErrorResponse(String(error?.stack || error?.message || error)));
+
+      // GD-based `?preview=…` thumbnail generation fails in the wasm runtime,
+      // so `draftfile.php` / `pluginfile.php` answer 404 for an otherwise valid
+      // file. Retry without the preview param so the browser receives the
+      // original image (CSS-resized by the picker grid) instead of a broken
+      // thumbnail. See PREVIEW_FALLBACK_PATH_RE for the matched scripts.
+      if (
+        event.request.method === "GET"
+        && isPreviewFallbackCandidate(requestPath, response.status)
+      ) {
+        const fallbackPath = stripPreviewParam(requestPath);
+        const fallbackUrl = new URL(fallbackPath, `${url.origin}/`);
+        const fallbackResponse = await forwardToPhpWorker({
+          request: buildPhpRequest(event.request, fallbackUrl, null),
+          runtimeId,
+          scopeId,
+        }).catch(() => null);
+        if (fallbackResponse?.ok) {
+          response = fallbackResponse;
+        }
+      }
 
       if (response.status >= 300 && response.status < 400) {
         await broadcastToClients({

--- a/tests/sw/preview-fallback.test.js
+++ b/tests/sw/preview-fallback.test.js
@@ -1,0 +1,193 @@
+/**
+ * Tests for the preview-fallback helpers in sw.js.
+ *
+ * The service worker retries `draftfile.php` / `pluginfile.php` requests
+ * without the `?preview=` parameter when the runtime answers 404, because
+ * GD-based thumbnail generation fails inside @php-wasm. See sw.js +
+ * issue #90 for the background.
+ *
+ * Following the project convention (tests/sw/sw-helpers.test.js), the
+ * pure helpers are replicated here so they can be exercised with
+ * `node --test` without booting a Service Worker context.
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+const PREVIEW_FALLBACK_PATH_RE = /\/(draftfile|pluginfile)\.php(?:\/|$)/u;
+
+function isPreviewFallbackCandidate(requestPath, status) {
+  if (status !== 404) {
+    return false;
+  }
+  const qIdx = requestPath.indexOf("?");
+  if (qIdx < 0) {
+    return false;
+  }
+  const pathOnly = requestPath.slice(0, qIdx);
+  if (!PREVIEW_FALLBACK_PATH_RE.test(pathOnly)) {
+    return false;
+  }
+  const params = new URLSearchParams(requestPath.slice(qIdx + 1));
+  const value = params.get("preview");
+  return value !== null && value !== "";
+}
+
+function stripPreviewParam(requestPath) {
+  const qIdx = requestPath.indexOf("?");
+  if (qIdx < 0) {
+    return requestPath;
+  }
+  const params = new URLSearchParams(requestPath.slice(qIdx + 1));
+  if (!params.has("preview")) {
+    return requestPath;
+  }
+  params.delete("preview");
+  const remaining = params.toString();
+  const pathOnly = requestPath.slice(0, qIdx);
+  return remaining ? `${pathOnly}?${remaining}` : pathOnly;
+}
+
+describe("isPreviewFallbackCandidate", () => {
+  it("matches a 404 for draftfile.php?preview=thumb", () => {
+    assert.strictEqual(
+      isPreviewFallbackCandidate(
+        "/draftfile.php/5/user/draft/1/Sherlock.jpg?preview=thumb&oid=42",
+        404,
+      ),
+      true,
+    );
+  });
+
+  it("matches a 404 for pluginfile.php?preview=bigthumb", () => {
+    assert.strictEqual(
+      isPreviewFallbackCandidate(
+        "/pluginfile.php/12/mod_resource/content/0/photo.png?preview=bigthumb",
+        404,
+      ),
+      true,
+    );
+  });
+
+  it("ignores non-404 responses", () => {
+    assert.strictEqual(
+      isPreviewFallbackCandidate(
+        "/draftfile.php/5/user/draft/1/Sherlock.jpg?preview=thumb",
+        200,
+      ),
+      false,
+    );
+    assert.strictEqual(
+      isPreviewFallbackCandidate(
+        "/draftfile.php/5/user/draft/1/Sherlock.jpg?preview=thumb",
+        500,
+      ),
+      false,
+    );
+  });
+
+  it("ignores 404s without a preview parameter", () => {
+    assert.strictEqual(
+      isPreviewFallbackCandidate(
+        "/draftfile.php/5/user/draft/1/missing.jpg?oid=42",
+        404,
+      ),
+      false,
+    );
+  });
+
+  it("ignores 404s with an empty preview parameter", () => {
+    assert.strictEqual(
+      isPreviewFallbackCandidate(
+        "/draftfile.php/5/user/draft/1/Sherlock.jpg?preview=",
+        404,
+      ),
+      false,
+    );
+  });
+
+  it("ignores 404s without a query string", () => {
+    assert.strictEqual(
+      isPreviewFallbackCandidate(
+        "/draftfile.php/5/user/draft/1/missing.jpg",
+        404,
+      ),
+      false,
+    );
+  });
+
+  it("ignores unrelated Moodle scripts", () => {
+    assert.strictEqual(
+      isPreviewFallbackCandidate(
+        "/lib/javascript.php/-1/lib/requirejs/require.js?preview=thumb",
+        404,
+      ),
+      false,
+    );
+    assert.strictEqual(
+      isPreviewFallbackCandidate(
+        "/theme/image.php/boost/core/1/f/folder?preview=thumb",
+        404,
+      ),
+      false,
+    );
+  });
+
+  it("does not match a path that merely contains 'draftfile.php' as a substring", () => {
+    assert.strictEqual(
+      isPreviewFallbackCandidate("/not-draftfile.php-decoy?preview=thumb", 404),
+      false,
+    );
+  });
+});
+
+describe("stripPreviewParam", () => {
+  it("removes preview= and keeps the rest of the query string", () => {
+    assert.strictEqual(
+      stripPreviewParam(
+        "/draftfile.php/5/user/draft/1/Sherlock.jpg?preview=thumb&oid=42",
+      ),
+      "/draftfile.php/5/user/draft/1/Sherlock.jpg?oid=42",
+    );
+  });
+
+  it("handles preview= appearing after other params", () => {
+    assert.strictEqual(
+      stripPreviewParam(
+        "/draftfile.php/5/user/draft/1/Sherlock.jpg?oid=42&preview=thumb",
+      ),
+      "/draftfile.php/5/user/draft/1/Sherlock.jpg?oid=42",
+    );
+  });
+
+  it("drops the lone ? when preview= is the only param", () => {
+    assert.strictEqual(
+      stripPreviewParam(
+        "/draftfile.php/5/user/draft/1/Sherlock.jpg?preview=thumb",
+      ),
+      "/draftfile.php/5/user/draft/1/Sherlock.jpg",
+    );
+  });
+
+  it("returns the path unchanged when no preview param is present", () => {
+    assert.strictEqual(
+      stripPreviewParam("/draftfile.php/5/user/draft/1/Sherlock.jpg?oid=42"),
+      "/draftfile.php/5/user/draft/1/Sherlock.jpg?oid=42",
+    );
+  });
+
+  it("returns the path unchanged when there is no query string", () => {
+    assert.strictEqual(
+      stripPreviewParam("/draftfile.php/5/user/draft/1/Sherlock.jpg"),
+      "/draftfile.php/5/user/draft/1/Sherlock.jpg",
+    );
+  });
+
+  it("preserves repeated non-preview params", () => {
+    assert.strictEqual(
+      stripPreviewParam(
+        "/pluginfile.php/12/mod_resource/0/file.png?tag=a&tag=b&preview=thumb",
+      ),
+      "/pluginfile.php/12/mod_resource/0/file.png?tag=a&tag=b",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Service-worker fix for the broken-thumbnail bug reported in #90: inside `@php-wasm`, `get_file_preview()` fails (GD resampling unavailable) so `draftfile.php` / `pluginfile.php` respond 404 for any `?preview=…` URL, leaving the file picker grid full of broken-image icons even though the underlying file is fine.
- When `sw.js` sees a 404 for one of those two Moodle scripts AND the URL carries `?preview=…`, it retries once without the `preview` parameter and passes the result through. The browser then receives the original image (CSS-resized by the file picker grid), which visually matches the intended UX.
- Genuine 404s (file truly missing) still surface because the fallback request also returns 404.

## Why this lives in the service worker

`sw.js` already mediates every PHP request, so it can transparently fix the response without touching Moodle, the wasm PHP build, or any plugin. The retry is bounded to GET requests on the two canonical Moodle file scripts, so the blast radius is minimal.

## Test plan

- [x] `node --test tests/sw/preview-fallback.test.js` — 14 new unit tests for the pure helpers (`isPreviewFallbackCandidate`, `stripPreviewParam`), following the `tests/sw/sw-helpers.test.js` precedent of replicating the SW logic.
- [x] `npm test` — full suite green (356 tests, up from 342).
- [x] `npx biome check sw.js tests/sw/preview-fallback.test.js` — clean.
- [x] `npm run build:worker` — `sw.bundle.js` rebuilt with the new helpers.

Closes #90.