### PR TITLE
fix(worker): patch @php-wasm/web tcp-over-fetch to allow HEAD without body

### DIFF
--- a/esbuild.worker.mjs
+++ b/esbuild.worker.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { readFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { dirname } from "node:path";
 import { build } from "esbuild";
@@ -18,6 +19,43 @@ const phpWasmIcuDataPlugin = {
     b.onResolve({ filter: /(^|\/)intl\/shared\/icu\.dat$/ }, () => ({
       path: `${phpWasmWebDir}/shared/icu.dat`,
     }));
+  },
+};
+
+// @php-wasm/web's `tcp-over-fetch-websocket.ts` (lines around 643 upstream)
+// builds an outbound `ReadableStream` body for every request whose method is
+// not exactly "GET", then constructs `new Request(url, { method, body })`.
+// HEAD passes through that branch and the browser throws
+// `Failed to construct 'Request': Request with GET/HEAD method cannot have body`,
+// which surfaces as an uncaught promise rejection from PHP curl. The published
+// @php-wasm/web bundle minifies the variable to `S.method`, so we patch the
+// single occurrence to also exclude HEAD before esbuild ingests the file.
+// Filed upstream at WordPress/wordpress-playground; remove this plugin once
+// it lands in a published @php-wasm/web release.
+const phpWasmHeadBodyFixPlugin = {
+  name: "php-wasm-tcp-over-fetch-head-body-fix",
+  setup(b) {
+    const phpWasmWebIndex = `${phpWasmWebDir}/index.js`;
+    b.onLoad({ filter: /@php-wasm\/web\/index\.js$/ }, async (args) => {
+      if (args.path !== phpWasmWebIndex) {
+        return null;
+      }
+      const source = await readFile(args.path, "utf8");
+      const pattern = /\bif\s*\(\s*S\.method\s*!==\s*"GET"\s*\)\s*\{/;
+      if (!pattern.test(source)) {
+        throw new Error(
+          "php-wasm-tcp-over-fetch-head-body-fix: pattern not found in "
+            + `${args.path}. The upstream bundle layout may have changed; `
+            + "verify parseHttpRequest() in @php-wasm/web/index.js and update "
+            + "the regex.",
+        );
+      }
+      const patched = source.replace(
+        pattern,
+        'if (S.method !== "GET" && S.method !== "HEAD") {',
+      );
+      return { contents: patched, loader: "js" };
+    });
   },
 };
 
@@ -40,7 +78,7 @@ await Promise.all([
     banner: {
       js: `const __APP_ROOT__ = new URL("../", import.meta.url).href;`,
     },
-    plugins: [phpWasmIcuDataPlugin],
+    plugins: [phpWasmIcuDataPlugin, phpWasmHeadBodyFixPlugin],
     loader: {
       ".wasm": "file",
       ".so": "file",


### PR DESCRIPTION
## Summary

`@php-wasm/web` ships a `parseHttpRequest()` that **always** builds an outbound `ReadableStream` body unless the method is exactly `GET`. HEAD requests fall through that branch and the browser throws:

> `Failed to construct 'Request': Request with GET/HEAD method cannot have body.`

That exception bubbles up as an uncaught promise rejection from `tcp-over-fetch-websocket.ts:parseHttpRequest`, corrupting the cURL call that emitted the HEAD probe. The symptom (#92) is that downloads through Moodle's URL-based repositories — including the built-in **URL downloader** (`repository_url`) and `repository_omeka` — fail in `@php-wasm`, while local form-uploads (which never traverse `tcpOverFetch`) work fine.

## What changed

Added a small esbuild plugin in `esbuild.worker.mjs` that intercepts the load of `@php-wasm/web/index.js` during bundling and string-replaces the single occurrence of:

```js
if (S.method !== "GET") {
```

with:

```js
if (S.method !== "GET" && S.method !== "HEAD") {
```

Three reasons for the build-plugin approach over editing `node_modules` directly:
- Survives `npm install` / `npm ci` (no committed `node_modules` change).
- Fails loud if the upstream bundle changes shape (the plugin throws when the pattern isn't found, so the next build surfaces it instead of silently going back to the broken behaviour).
- Zero-risk for non-worker bundles — only the `php-worker` build registers the plugin.

The fix should be deleted as soon as the same change lands in a published `@php-wasm/web` release. Upstream fix submitted at **WordPress/wordpress-playground#3632**; remove this plugin once that PR is merged and `@php-wasm/web` is bumped.

## Verification

- [x] `npm test` — 356 tests pass (no regression).
- [x] `npm run build:worker` — bundle rebuilt; `grep '\.method !== \"GET\" && \.method !== \"HEAD\"' dist/php-worker.bundle.js` returns 1 hit (line 153471).
- [x] **Manual chrome-devtools repro using Moodle's built-in URL downloader repository** (`<img class="fp-repo-icon" alt=" " width="16" height="16" src="/theme/image.php/boost/repository_url/.../icon">`) on the [pr-93 preview](https://pr-93--moodle-playground.netlify.app/): pasting a remote image URL into the picker now downloads correctly and `draftfile.php` serves the bytes. **Without this fix the same flow 404s** because the HEAD probe emitted by Moodle's cURL throws `Failed to construct 'Request'`.

## Note on `repository_omeka`

The omeka thumbnail 404 reported in #90 is a **separate bug** with the same surface symptom. It is not fixed by this PR — see #92 for the ongoing investigation (`pathnamehash` mismatch in `mdl_files` for files imported through the `repository_omeka` plugin). The HEAD fix landed here clears one real but unrelated TypeError on the way.

Refs #92, WordPress/wordpress-playground#3632.