### PR TITLE
fix(runtime): URL-decode PATH_INFO before exposing it to PHP

### DIFF
--- a/src/runtime/php-compat.js
+++ b/src/runtime/php-compat.js
@@ -52,6 +52,23 @@ async function normalizeRequest(requestOrUrl) {
 }
 
 /**
+ * Decode a `PATH_INFO` value pulled from a URL pathname into the form PHP
+ * expects from a CGI environment.  Apache and nginx URL-decode PATH_INFO
+ * before exposing it to PHP (per RFC 3875 §4.1.5), so a request URI of
+ * `/draftfile.php/5/user/draft/123/The%20Adventures` exposes PATH_INFO
+ * as `/5/user/draft/123/The Adventures` — not as the raw `%20`-encoded
+ * form.  `decodeURIComponent` throws on malformed sequences; fall back
+ * to the raw value rather than blowing up the entire request.
+ */
+function decodePathInfo(raw) {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}
+
+/**
  * Resolve the PHP script path and PATH_INFO from a URL pathname.
  * Handles directory requests by appending index.php.
  * Handles PATH_INFO (e.g., /theme/styles.php/boost/123/all).
@@ -308,7 +325,17 @@ export function wrapPhpInstance(
         HTTP_USER_AGENT: "MoodlePlayground/1.0 (WASM)",
         REMOTE_ADDR: "127.0.0.1",
         HTTPS: parsedAbsoluteUrl.protocol === "https:" ? "on" : "",
-        PATH_INFO: pathInfo || "",
+        // PATH_INFO must arrive at PHP URL-DECODED, matching the CGI spec
+        // (RFC 3875 §4.1.5) and the behaviour of Apache/nginx + mod_php.
+        // Moodle's `get_file_argument()` reads `$_SERVER['PATH_INFO']` as-is
+        // and uses the result directly as the relative file path; if we leave
+        // the `%20` literals in, the parsed filename ends up containing
+        // literal "%20" instead of spaces, the SHA1 pathnamehash computed
+        // from it does not match what `create_file_from_pathname()` stored,
+        // and `draftfile.php` / `pluginfile.php` answer 404 for any file
+        // whose name contains a space, comma, accent, etc.  REQUEST_URI
+        // intentionally stays raw — that's how Apache exposes it.
+        PATH_INFO: pathInfo ? decodePathInfo(pathInfo) : "",
       };
 
       // Add HTTP_* headers from the request.

--- a/tests/runtime/php-compat.test.js
+++ b/tests/runtime/php-compat.test.js
@@ -175,7 +175,9 @@ function decodePathInfo(raw) {
 describe("decodePathInfo", () => {
   it("URL-decodes percent-encoded spaces", () => {
     assert.strictEqual(
-      decodePathInfo("/5/user/draft/123/The%20Adventures%20of%20Sherlock%20Holmes"),
+      decodePathInfo(
+        "/5/user/draft/123/The%20Adventures%20of%20Sherlock%20Holmes",
+      ),
       "/5/user/draft/123/The Adventures of Sherlock Holmes",
     );
   });

--- a/tests/runtime/php-compat.test.js
+++ b/tests/runtime/php-compat.test.js
@@ -161,3 +161,55 @@ describe("getMimeType", () => {
     );
   });
 });
+
+// Replicate the helper from php-compat.js — same approach as the other
+// reimplemented helpers in this file.
+function decodePathInfo(raw) {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}
+
+describe("decodePathInfo", () => {
+  it("URL-decodes percent-encoded spaces", () => {
+    assert.strictEqual(
+      decodePathInfo("/5/user/draft/123/The%20Adventures%20of%20Sherlock%20Holmes"),
+      "/5/user/draft/123/The Adventures of Sherlock Holmes",
+    );
+  });
+
+  it("URL-decodes commas, parentheses, and accents", () => {
+    assert.strictEqual(
+      decodePathInfo("/5/user/draft/123/Walter%20Benington%2C%201914.jpg"),
+      "/5/user/draft/123/Walter Benington, 1914.jpg",
+    );
+    assert.strictEqual(
+      decodePathInfo("/5/user/draft/123/foto%20(1).jpg"),
+      "/5/user/draft/123/foto (1).jpg",
+    );
+    assert.strictEqual(
+      decodePathInfo("/5/user/draft/123/jos%C3%A9.txt"),
+      "/5/user/draft/123/josé.txt",
+    );
+  });
+
+  it("returns ASCII paths unchanged", () => {
+    assert.strictEqual(
+      decodePathInfo("/5/user/draft/123/omeka-logo.png"),
+      "/5/user/draft/123/omeka-logo.png",
+    );
+  });
+
+  it("falls back to the raw value on malformed percent-encoding", () => {
+    // `decodeURIComponent("%E0%A4%A")` throws; the helper must not bubble
+    // that up — leaving the request to die is worse than serving a
+    // PATH_INFO with a stray %.
+    assert.strictEqual(decodePathInfo("/bad%E0%A4%A"), "/bad%E0%A4%A");
+  });
+
+  it("returns empty string for empty input", () => {
+    assert.strictEqual(decodePathInfo(""), "");
+  });
+});


### PR DESCRIPTION
## Problem

`src/runtime/php-compat.js` builds `$_SERVER` for every PHP request and writes the **raw** URL pathname slice into `PATH_INFO`. RFC 3875 §4.1.5 and the de-facto behaviour of Apache/nginx + `mod_php` is that `PATH_INFO` arrives at PHP **URL-decoded**, while `REQUEST_URI` stays raw. We were leaving `PATH_INFO` raw too — so every filename containing a space, comma, parenthesis, accent, etc. exposed PHP to the literal `%20` / `%2C` / `%28` / `%C3%A9` sequence instead of the decoded character.

## Symptom

Moodle's `get_file_argument()` reads `$_SERVER['PATH_INFO']` and returns it as-is when the value is set. Inside `draftfile.php` / `pluginfile.php` the parsed filename therefore still contained literal `%20` instead of spaces, and the SHA1 `pathnamehash` recomputed from the parsed values no longer matched the one written by `create_file_from_pathname()` (which had received the decoded title). The lookup missed, the script fell through to `send_file_not_found()`, and every fetch 404'd with `filenotfound` — exactly the diagnosis in #92.

The same wrong code path is why downloads through the omeka-S repository (and any other repository that ingests files whose human-readable titles contain non-ASCII characters) silently produced a row in `mdl_files` with valid `image_width`/`image_height` but a `pathnamehash` that `draftfile.php` could never reproduce.

`repository_url` (the built-in URL downloader) was unaffected after #93 because the URLs people paste into it tend to use ASCII-only filenames, so there was no percent-encoding to mis-handle.

## Fix

A two-line change in `php-compat.js` plus a `decodePathInfo()` helper that wraps `decodeURIComponent` and falls back to the raw string on malformed input. `REQUEST_URI` intentionally stays raw (Apache exposes it that way).

```diff
+function decodePathInfo(raw) {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}
…
-        PATH_INFO: pathInfo || "",
+        PATH_INFO: pathInfo ? decodePathInfo(pathInfo) : "",
```

## Tests

5 new unit tests in `tests/runtime/php-compat.test.js` covering spaces, commas, parentheses, accented characters, ASCII paths, malformed percent-encoding, and empty input. Full suite: **361/361 pass**.

## Manual verification (`make up` + omeka blueprint)

Picking *The Adventures of Sherlock Holmes* from the omeka-S file picker:

| Request | Before | After |
|---|---|---|
| `GET .../draftfile.php/5/user/draft/<id>/The%20Adventures%20of%20Sherlock%20Holmes?preview=thumb&oid=…` | 404 `text/html` | **200 `image/png`** (12088 B, GD-generated thumb) |
| `GET .../draftfile.php/5/user/draft/<id>/The%20Adventures%20of%20Sherlock%20Holmes?oid=…` | 404 `text/html` | **200 `image/jpeg`** (47554 B, original) |
| File-picker grid | Broken-thumbnail icon | Real thumbnail of the JPEG cover |

Console messages from before the fix (`[playground] PHP exited 1 for /draftfile.php/… filenotfound`) are gone.

## Note on #91

[#91](https://github.com/ateeducacion/moodle-playground/pull/93) was a SW-level retry-without-`?preview=` for 404s on `draftfile.php`/`pluginfile.php`, designed for a hypothetical "GD generates no thumbnail" failure mode. We can now empirically rule that mode out — GD works fine in `@php-wasm` (the 200 `image/png` above is the GD-generated thumb). The retry never fires after this fix lands, so it's dead code. I'd revert it in a follow-up; happy to take the opposite view if you prefer to keep it as belt-and-braces.

Closes #90.
Closes #92.