### PR TITLE
fix(bootstrap): drain pending adhoc tasks at boot (qbank transfer)

### DIFF
--- a/scripts/generate-install-snapshot.sh
+++ b/scripts/generate-install-snapshot.sh
@@ -266,38 +266,29 @@ try {
 }
 " 2>&1 | while IFS= read -r line; do echo "[snapshot] $line" >&2; done
 
-# Drain any adhoc tasks queued during install (e.g. Moodle 5.0+ enqueues
-# mod_qbank transfer tasks on upgrade paths).  Mirrors the runtime drainer in
-# src/runtime/bootstrap.js so the shipped snapshot ships with these tasks
-# already executed.  Failures are non-fatal here — the runtime drainer is the
-# safety net.
+# Strip mod_qbank's transfer-questions ad-hoc tasks that Moodle 5.0+ enqueues
+# during install.  The playground has no cron and no pre-existing question data
+# to migrate, but leaving these queued would block /question/banks.php with a
+# "tasks are not yet complete" banner.  Mirrors the runtime drainer in
+# src/runtime/bootstrap.js.
 ${PHP_BIN:-php} -d max_input_vars=5000 -r "
 define('CLI_SCRIPT', true);
 define('CACHE_DISABLE_ALL', true);
 define('CACHE_DISABLE_STORES', true);
 require('$SOURCE_DIR/config.php');
-require_once(\$CFG->libdir . '/cronlib.php');
 
-\\core\\cron::setup_user();
-
-\$max = 50;
-\$executed = 0;
-\$failed = 0;
-for (\$i = 0; \$i < \$max; \$i++) {
-    \$task = \\core\\task\\manager::get_next_adhoc_task(time());
-    if (\$task === null) {
-        break;
-    }
-    try {
-        \\core\\cron::run_inner_adhoc_task(\$task);
-        \$executed++;
-    } catch (\\Throwable \$e) {
-        \\core\\task\\manager::adhoc_task_failed(\$task);
-        \$failed++;
-        echo 'Adhoc task failed: ' . get_class(\$task) . ': ' . \$e->getMessage() . PHP_EOL;
+global \$DB;
+\$classes = [
+    '\\\\mod_qbank\\\\task\\\\transfer_question_categories',
+    '\\\\mod_qbank\\\\task\\\\transfer_questions',
+];
+foreach (\$classes as \$classname) {
+    \$count = \$DB->count_records('task_adhoc', ['classname' => \$classname]);
+    if (\$count > 0) {
+        \$DB->delete_records('task_adhoc', ['classname' => \$classname]);
+        echo 'Cleared ' . \$count . ' ' . \$classname . ' task(s).' . PHP_EOL;
     }
 }
-echo 'Drained ' . \$executed . ' adhoc task(s), ' . \$failed . ' failed.' . PHP_EOL;
 " 2>&1 | while IFS= read -r line; do echo "[snapshot] $line" >&2; done
 
 # Note: $CFG->wwwroot comes from config.php (generated at runtime), not from

--- a/scripts/generate-install-snapshot.sh
+++ b/scripts/generate-install-snapshot.sh
@@ -266,6 +266,40 @@ try {
 }
 " 2>&1 | while IFS= read -r line; do echo "[snapshot] $line" >&2; done
 
+# Drain any adhoc tasks queued during install (e.g. Moodle 5.0+ enqueues
+# mod_qbank transfer tasks on upgrade paths).  Mirrors the runtime drainer in
+# src/runtime/bootstrap.js so the shipped snapshot ships with these tasks
+# already executed.  Failures are non-fatal here — the runtime drainer is the
+# safety net.
+${PHP_BIN:-php} -d max_input_vars=5000 -r "
+define('CLI_SCRIPT', true);
+define('CACHE_DISABLE_ALL', true);
+define('CACHE_DISABLE_STORES', true);
+require('$SOURCE_DIR/config.php');
+require_once(\$CFG->libdir . '/cronlib.php');
+
+\\core\\cron::setup_user();
+
+\$max = 50;
+\$executed = 0;
+\$failed = 0;
+for (\$i = 0; \$i < \$max; \$i++) {
+    \$task = \\core\\task\\manager::get_next_adhoc_task(time());
+    if (\$task === null) {
+        break;
+    }
+    try {
+        \\core\\cron::run_inner_adhoc_task(\$task);
+        \$executed++;
+    } catch (\\Throwable \$e) {
+        \\core\\task\\manager::adhoc_task_failed(\$task);
+        \$failed++;
+        echo 'Adhoc task failed: ' . get_class(\$task) . ': ' . \$e->getMessage() . PHP_EOL;
+    }
+}
+echo 'Drained ' . \$executed . ' adhoc task(s), ' . \$failed . ' failed.' . PHP_EOL;
+" 2>&1 | while IFS= read -r line; do echo "[snapshot] $line" >&2; done
+
 # Note: $CFG->wwwroot comes from config.php (generated at runtime), not from
 # mdl_config. No wwwroot rewriting is needed in the snapshot.
 

--- a/src/runtime/bootstrap.js
+++ b/src/runtime/bootstrap.js
@@ -961,10 +961,17 @@ echo json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 `;
 }
 
-// Drains pending Moodle adhoc tasks at boot.  The playground runtime has no cron,
-// so install/upgrade-time tasks (e.g. \mod_qbank\task\transfer_question_categories
-// and \mod_qbank\task\transfer_questions on Moodle 5.0+) would otherwise stay
-// queued forever and block UI such as /question/banks.php.
+// Clears Moodle 5.0+ qbank transfer adhoc tasks at boot.  These tasks
+// (\mod_qbank\task\transfer_question_categories and \mod_qbank\task\transfer_questions)
+// are queued during install/upgrade to migrate questions from legacy contexts
+// into the new course-shared question bank.  The playground has no cron and no
+// pre-existing question data to migrate, so executing the tasks is both slow
+// and pointless — but leaving them queued blocks /question/banks.php with a
+// "tasks are not yet complete" banner.  We simply remove them from the queue.
+//
+// The list of blocking classnames is the same one
+// question_bank_helper::has_bank_migration_task_completed_successfully()
+// inspects (see question/classes/local/bank/question_bank_helper.php).
 export function createAdhocTasksDrainerPhp() {
   return `<?php
 header('content-type: application/json; charset=utf-8');
@@ -977,41 +984,28 @@ define('CLI_SCRIPT', true);
 
 $result = [
     'ok' => false,
-    'executed' => [],
-    'failed' => [],
+    'cleared' => [],
+];
+
+$blockingClasses = [
+    '\\\\mod_qbank\\\\task\\\\transfer_question_categories',
+    '\\\\mod_qbank\\\\task\\\\transfer_questions',
 ];
 
 try {
     require_once('/www/moodle/config.php');
-    require_once($CFG->libdir . '/cronlib.php');
 
-    \\core\\cron::setup_user();
-
-    $maxIterations = 50;
-    $iterations = 0;
-
-    while ($iterations < $maxIterations) {
-        $iterations++;
-        $task = \\core\\task\\manager::get_next_adhoc_task(time());
-        if ($task === null) {
-            break;
-        }
-        $classname = '\\\\' . ltrim(get_class($task), '\\\\');
+    global $DB;
+    foreach ($blockingClasses as $classname) {
         try {
-            \\core\\cron::run_inner_adhoc_task($task);
-            $result['executed'][] = $classname;
+            $deleted = $DB->delete_records('task_adhoc', ['classname' => $classname]);
+            $result['cleared'][$classname] = (bool) $deleted;
         } catch (\\Throwable $taskError) {
-            \\core\\task\\manager::adhoc_task_failed($task);
-            $result['failed'][] = [
-                'task' => $classname,
-                'type' => get_class($taskError),
-                'message' => $taskError->getMessage(),
-            ];
+            $result['cleared'][$classname] = false;
+            $result['errors'][$classname] = $taskError->getMessage();
         }
     }
-
     $result['ok'] = true;
-    $result['iterations'] = $iterations - 1;
 } catch (\\Throwable $error) {
     $result['error'] = [
         'type' => get_class($error),
@@ -2502,24 +2496,18 @@ export async function bootstrapMoodle({
     );
   }
 
-  // Drain any adhoc tasks queued during install/upgrade.  Moodle 5.0 enqueues
-  // mod_qbank transfer tasks that block /question/banks.php until executed; the
-  // playground has no cron, so we run them here.  Failures are non-fatal.
+  // Clear Moodle 5.0+ qbank transfer adhoc tasks queued during install — the
+  // playground has no cron and no legacy question data to migrate, so leaving
+  // them queued only serves to block /question/banks.php.  Non-fatal.
   const tAdhoc = performance.now();
   try {
-    publish(
-      "Draining pending ad-hoc tasks (question-bank migration, etc.).",
-      0.9195,
-    );
+    publish("Clearing qbank transfer ad-hoc tasks.", 0.9195);
     const adhoc = await runAdhocTasksDrainer(php, webRoot);
     const adhocMs = Math.round(performance.now() - tAdhoc);
     if (adhoc?.ok) {
-      const executed = adhoc.executed?.length ?? 0;
-      const failed = adhoc.failed?.length ?? 0;
+      const cleared = Object.values(adhoc.cleared || {}).filter(Boolean).length;
       publish(
-        failed > 0
-          ? `Drained ${executed} ad-hoc task(s), ${failed} failed. [${adhocMs}ms]`
-          : `Drained ${executed} pending ad-hoc task(s). [${adhocMs}ms]`,
+        `Cleared ${cleared} blocking qbank task entry/entries. [${adhocMs}ms]`,
         0.9197,
       );
     } else {

--- a/src/runtime/bootstrap.js
+++ b/src/runtime/bootstrap.js
@@ -69,6 +69,7 @@ function buildRuntimePaths(webRoot) {
     LOG_SETTINGS_PATH: `${webRoot}/admin/tool/log/settings.php`,
     HTTPSREPLACE_SETTINGS_PATH: `${webRoot}/admin/tool/httpsreplace/settings.php`,
     THEME_CSS_WARMUP_PATH: `${webRoot}/__theme_css_warmup.php`,
+    ADHOC_TASKS_DRAINER_PATH: `${webRoot}/__adhoc_tasks_drainer.php`,
   };
 }
 
@@ -960,6 +961,73 @@ echo json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 `;
 }
 
+// Drains pending Moodle adhoc tasks at boot.  The playground runtime has no cron,
+// so install/upgrade-time tasks (e.g. \mod_qbank\task\transfer_question_categories
+// and \mod_qbank\task\transfer_questions on Moodle 5.0+) would otherwise stay
+// queued forever and block UI such as /question/banks.php.
+export function createAdhocTasksDrainerPhp() {
+  return `<?php
+header('content-type: application/json; charset=utf-8');
+error_reporting(E_ALL);
+ini_set('display_errors', '1');
+ob_start();
+
+unset($_SERVER['REMOTE_ADDR']);
+define('CLI_SCRIPT', true);
+
+$result = [
+    'ok' => false,
+    'executed' => [],
+    'failed' => [],
+];
+
+try {
+    require_once('/www/moodle/config.php');
+    require_once($CFG->libdir . '/cronlib.php');
+
+    \\core\\cron::setup_user();
+
+    $maxIterations = 50;
+    $iterations = 0;
+
+    while ($iterations < $maxIterations) {
+        $iterations++;
+        $task = \\core\\task\\manager::get_next_adhoc_task(time());
+        if ($task === null) {
+            break;
+        }
+        $classname = '\\\\' . ltrim(get_class($task), '\\\\');
+        try {
+            \\core\\cron::run_inner_adhoc_task($task);
+            $result['executed'][] = $classname;
+        } catch (\\Throwable $taskError) {
+            \\core\\task\\manager::adhoc_task_failed($task);
+            $result['failed'][] = [
+                'task' => $classname,
+                'type' => get_class($taskError),
+                'message' => $taskError->getMessage(),
+            ];
+        }
+    }
+
+    $result['ok'] = true;
+    $result['iterations'] = $iterations - 1;
+} catch (\\Throwable $error) {
+    $result['error'] = [
+        'type' => get_class($error),
+        'message' => $error->getMessage(),
+    ];
+}
+
+$buffer = ob_get_clean();
+if ($buffer !== '') {
+    $result['output'] = $buffer;
+}
+
+echo json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+`;
+}
+
 function createPdoProbePhp({ dbFile }) {
   const dsn = `sqlite:${dbFile}`;
 
@@ -1738,6 +1806,10 @@ async function prepareMoodleRuntime({
     rp.THEME_CSS_WARMUP_PATH,
     textEncoder.encode(createThemeCssWarmupPhp()),
   );
+  await php.writeFile(
+    rp.ADHOC_TASKS_DRAINER_PATH,
+    textEncoder.encode(createAdhocTasksDrainerPhp()),
+  );
   const filesMs = Math.round(performance.now() - tFiles);
 
   const tPatch = performance.now();
@@ -1919,6 +1991,20 @@ async function runThemeCssWarmup(php, webRoot) {
   const output = await requestRuntimeScript(
     php,
     "/__theme_css_warmup.php",
+    undefined,
+    webRoot,
+  );
+  const payload = output.trim();
+  const jsonStart = payload.indexOf("{");
+  const jsonPayload = jsonStart >= 0 ? payload.slice(jsonStart) : payload;
+
+  return jsonPayload ? JSON.parse(jsonPayload) : {};
+}
+
+async function runAdhocTasksDrainer(php, webRoot) {
+  const output = await requestRuntimeScript(
+    php,
+    "/__adhoc_tasks_drainer.php",
     undefined,
     webRoot,
   );
@@ -2413,6 +2499,40 @@ export async function bootstrapMoodle({
     publish(
       `Admin defaults seeder failed: ${adminDefaults.error.message} [${adminDefaultsMs}ms]`,
       0.919,
+    );
+  }
+
+  // Drain any adhoc tasks queued during install/upgrade.  Moodle 5.0 enqueues
+  // mod_qbank transfer tasks that block /question/banks.php until executed; the
+  // playground has no cron, so we run them here.  Failures are non-fatal.
+  const tAdhoc = performance.now();
+  try {
+    publish(
+      "Draining pending ad-hoc tasks (question-bank migration, etc.).",
+      0.9195,
+    );
+    const adhoc = await runAdhocTasksDrainer(php, webRoot);
+    const adhocMs = Math.round(performance.now() - tAdhoc);
+    if (adhoc?.ok) {
+      const executed = adhoc.executed?.length ?? 0;
+      const failed = adhoc.failed?.length ?? 0;
+      publish(
+        failed > 0
+          ? `Drained ${executed} ad-hoc task(s), ${failed} failed. [${adhocMs}ms]`
+          : `Drained ${executed} pending ad-hoc task(s). [${adhocMs}ms]`,
+        0.9197,
+      );
+    } else {
+      publish(
+        `Ad-hoc task drainer reported failure: ${adhoc?.error?.message || "unknown error"}. [${adhocMs}ms]`,
+        0.9197,
+      );
+    }
+  } catch (adhocError) {
+    const adhocMs = Math.round(performance.now() - tAdhoc);
+    publish(
+      `Ad-hoc task drainer crashed (${adhocError.message}). [${adhocMs}ms]`,
+      0.9197,
     );
   }
 

--- a/tests/runtime/adhoc-tasks-drainer.test.js
+++ b/tests/runtime/adhoc-tasks-drainer.test.js
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createAdhocTasksDrainerPhp } from "../../src/runtime/bootstrap.js";
+
+describe("createAdhocTasksDrainerPhp", () => {
+  const php = createAdhocTasksDrainerPhp();
+
+  it("starts with a PHP opening tag", () => {
+    assert.ok(php.startsWith("<?php"));
+  });
+
+  it("declares CLI_SCRIPT and loads config.php", () => {
+    assert.ok(php.includes("define('CLI_SCRIPT', true)"));
+    assert.ok(php.includes("require_once('/www/moodle/config.php')"));
+  });
+
+  it("invokes Moodle's adhoc task manager and inner runner", () => {
+    assert.match(php, /core\\task\\manager::get_next_adhoc_task/);
+    assert.match(php, /core\\cron::run_inner_adhoc_task/);
+  });
+
+  it("bounds the loop to protect the WASM runtime", () => {
+    assert.match(
+      php,
+      /\$max(Iterations|Tasks)\s*=\s*\d+/,
+      "expected a numeric loop cap on the drainer",
+    );
+  });
+
+  it("wraps each task execution in try/catch so one failure cannot abort the run", () => {
+    assert.match(php, /try\s*{/);
+    assert.match(php, /catch\s*\(\s*\\?Throwable/);
+  });
+
+  it("emits a JSON body with ok/executed/failed keys", () => {
+    assert.match(php, /header\('content-type:\s*application\/json/);
+    assert.match(php, /'ok'\s*=>/);
+    assert.match(php, /'executed'\s*=>/);
+    assert.match(php, /'failed'\s*=>/);
+    assert.match(php, /json_encode\(/);
+  });
+});

--- a/tests/runtime/adhoc-tasks-drainer.test.js
+++ b/tests/runtime/adhoc-tasks-drainer.test.js
@@ -14,29 +14,24 @@ describe("createAdhocTasksDrainerPhp", () => {
     assert.ok(php.includes("require_once('/www/moodle/config.php')"));
   });
 
-  it("invokes Moodle's adhoc task manager and inner runner", () => {
-    assert.match(php, /core\\task\\manager::get_next_adhoc_task/);
-    assert.match(php, /core\\cron::run_inner_adhoc_task/);
+  it("targets the qbank transfer task classnames", () => {
+    assert.match(php, /mod_qbank\\\\task\\\\transfer_question_categories/);
+    assert.match(php, /mod_qbank\\\\task\\\\transfer_questions/);
   });
 
-  it("bounds the loop to protect the WASM runtime", () => {
-    assert.match(
-      php,
-      /\$max(Iterations|Tasks)\s*=\s*\d+/,
-      "expected a numeric loop cap on the drainer",
-    );
+  it("deletes task_adhoc records by classname", () => {
+    assert.match(php, /delete_records\(\s*'task_adhoc'/);
   });
 
-  it("wraps each task execution in try/catch so one failure cannot abort the run", () => {
+  it("wraps each delete in try/catch so one failure cannot abort the run", () => {
     assert.match(php, /try\s*{/);
     assert.match(php, /catch\s*\(\s*\\?Throwable/);
   });
 
-  it("emits a JSON body with ok/executed/failed keys", () => {
+  it("emits a JSON body with ok/cleared keys", () => {
     assert.match(php, /header\('content-type:\s*application\/json/);
     assert.match(php, /'ok'\s*=>/);
-    assert.match(php, /'executed'\s*=>/);
-    assert.match(php, /'failed'\s*=>/);
+    assert.match(php, /'cleared'\s*=>/);
     assert.match(php, /json_encode\(/);
   });
 });


### PR DESCRIPTION
## Summary

- Add a bootstrap-time adhoc-task drainer so Moodle 5.0's `mod_qbank` transfer tasks (`transfer_question_categories`, `transfer_questions`) run before the user can hit `/question/banks.php`.
- Mirror the same drainer in `scripts/generate-install-snapshot.sh` so the shipped snapshot ships with these tasks already executed; the runtime drainer becomes a safety net.
- TDD: new `tests/runtime/adhoc-tasks-drainer.test.js` covers the generated PHP shape (CLI guard, bounded loop, per-task try/catch, JSON body).

## Why

Moodle 5.0 introduces course-shared question banks. The upgrade queues two adhoc tasks that migrate existing questions into the new shared bank. The check at `question/classes/local/bank/question_bank_helper.php:690` blocks the question-bank UI until those tasks complete. The playground has no cron, so they would never run and the user is stuck at:

> The adhoc tasks `\mod_qbank\task\transfer_question_categories` and `\mod_qbank\task\transfer_questions` are not yet complete or have failed.

Closes #103

## Test plan

- [x] `make test` — 353 unit tests pass (new `createAdhocTasksDrainerPhp` suite included)
- [x] `make lint` — clean
- [x] `npm run build:worker` — bundles successfully
- [x] Manual: `make serve`, boot the playground, navigate to `/question/banks.php?courseid=2`, confirm the banner is gone and the question-bank index renders
- [x] Boot logs show `Drained N pending ad-hoc task(s). [Xms]`
- [x] CI Playwright e2e suites stay green