### PR TITLE
Bump @php-wasm to 3.1.35 and remove HEAD body workaround

### DIFF
--- a/esbuild.worker.mjs
+++ b/esbuild.worker.mjs
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import { readFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { dirname } from "node:path";
 import { build } from "esbuild";
@@ -19,43 +18,6 @@ const phpWasmIcuDataPlugin = {
     b.onResolve({ filter: /(^|\/)intl\/shared\/icu\.dat$/ }, () => ({
       path: `${phpWasmWebDir}/shared/icu.dat`,
     }));
-  },
-};
-
-// @php-wasm/web's `tcp-over-fetch-websocket.ts` (lines around 643 upstream)
-// builds an outbound `ReadableStream` body for every request whose method is
-// not exactly "GET", then constructs `new Request(url, { method, body })`.
-// HEAD passes through that branch and the browser throws
-// `Failed to construct 'Request': Request with GET/HEAD method cannot have body`,
-// which surfaces as an uncaught promise rejection from PHP curl. The published
-// @php-wasm/web bundle minifies the variable to `S.method`, so we patch the
-// single occurrence to also exclude HEAD before esbuild ingests the file.
-// Filed upstream at WordPress/wordpress-playground; remove this plugin once
-// it lands in a published @php-wasm/web release.
-const phpWasmHeadBodyFixPlugin = {
-  name: "php-wasm-tcp-over-fetch-head-body-fix",
-  setup(b) {
-    const phpWasmWebIndex = `${phpWasmWebDir}/index.js`;
-    b.onLoad({ filter: /@php-wasm\/web\/index\.js$/ }, async (args) => {
-      if (args.path !== phpWasmWebIndex) {
-        return null;
-      }
-      const source = await readFile(args.path, "utf8");
-      const pattern = /\bif\s*\(\s*S\.method\s*!==\s*"GET"\s*\)\s*\{/;
-      if (!pattern.test(source)) {
-        throw new Error(
-          "php-wasm-tcp-over-fetch-head-body-fix: pattern not found in "
-            + `${args.path}. The upstream bundle layout may have changed; `
-            + "verify parseHttpRequest() in @php-wasm/web/index.js and update "
-            + "the regex.",
-        );
-      }
-      const patched = source.replace(
-        pattern,
-        'if (S.method !== "GET" && S.method !== "HEAD") {',
-      );
-      return { contents: patched, loader: "js" };
-    });
   },
 };
 
@@ -78,7 +40,7 @@ await Promise.all([
     banner: {
       js: `const __APP_ROOT__ = new URL("../", import.meta.url).href;`,
     },
-    plugins: [phpWasmIcuDataPlugin, phpWasmHeadBodyFixPlugin],
+    plugins: [phpWasmIcuDataPlugin],
     loader: {
       ".wasm": "file",
       ".so": "file",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,8 @@
       "name": "moodle-playground",
       "dependencies": {
         "@php-wasm/stream-compression": "^3.1.35",
-        "@php-wasm/universal": "^3.1.30",
-        "@php-wasm/web": "^3.1.34",
+        "@php-wasm/universal": "^3.1.35",
+        "@php-wasm/web": "^3.1.35",
         "fflate": "^0.8.3"
       },
       "devDependencies": {
@@ -1138,14 +1138,14 @@
       "license": "MIT"
     },
     "node_modules/@php-wasm/fs-journal": {
-      "version": "3.1.34",
-      "resolved": "https://registry.npmjs.org/@php-wasm/fs-journal/-/fs-journal-3.1.34.tgz",
-      "integrity": "sha512-j3lSM9VjMs7LjMtQmxm7Y94A/V5vv/erAqGaHGKvWebQLYOY+aogVeTfml/FjudolMc9Vj+1lpNUEdemPfnNJw==",
+      "version": "3.1.35",
+      "resolved": "https://registry.npmjs.org/@php-wasm/fs-journal/-/fs-journal-3.1.35.tgz",
+      "integrity": "sha512-wboUBCEE35Latt6/2yKHMh0zt6XXkeSZyyk8G+i127sIDeitcu1Hf7adnXky9pHqYKbYxH98V3qFcJL2bcDZqg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.1.34",
-        "@php-wasm/universal": "3.1.34",
-        "@php-wasm/util": "3.1.34"
+        "@php-wasm/logger": "3.1.35",
+        "@php-wasm/universal": "3.1.35",
+        "@php-wasm/util": "3.1.35"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1153,9 +1153,9 @@
       }
     },
     "node_modules/@php-wasm/logger": {
-      "version": "3.1.34",
-      "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.34.tgz",
-      "integrity": "sha512-/B9smYeDOZfx7K6UjJBdgmQ05lsmVsFn3yiAK4wjaVXsGJxtjiGYOPkXlSJsMbnFw06KNsoiLSEVn31QU6PveQ==",
+      "version": "3.1.35",
+      "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.35.tgz",
+      "integrity": "sha512-5xIJ6c9Bh/Ja4iYN68p48AQlPFP0LLLANWtW9wwSwXmqpo3AxbV1SpQK0SbjhDLO6Ts1v2jKC6Q0IIV4sJKQ+w==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=20.10.0",
@@ -1163,12 +1163,12 @@
       }
     },
     "node_modules/@php-wasm/progress": {
-      "version": "3.1.34",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.34.tgz",
-      "integrity": "sha512-wUpYBYGRaqHt+CQcCilRR7vs67DpmgeHAnO8V84CrqdlVXWYBnwPn1UqR4tkLl+B7C4MuOxgeH8pDA19PRQiow==",
+      "version": "3.1.35",
+      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.35.tgz",
+      "integrity": "sha512-q189opZPpvXVtuTxwEtVuiSqXA3omxLibdWmtT1s+F9K+zO8rLdJb6SzfhV1S2JAYQ4w+PHGyduetNUrEAmVYg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.1.34"
+        "@php-wasm/logger": "3.1.35"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1176,9 +1176,9 @@
       }
     },
     "node_modules/@php-wasm/scopes": {
-      "version": "3.1.34",
-      "resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.34.tgz",
-      "integrity": "sha512-NifJwzlOU5M5BQHRjl1mEBJEROoE2F2Te8sZWtR2sbNzC9S/w9Y5zzTTTjNDTOvyaEjDtZUr5B0PXBbYNqTntg==",
+      "version": "3.1.35",
+      "resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.35.tgz",
+      "integrity": "sha512-6StQv8LCp6L9XOLBjnAhiTC6oasEGojk9DGYmLZsC8ZMBkjpLpQ2fBWh3wHAm/RcPh5lrW8Eb3jUWVqwtmEhbA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=20.10.0",
@@ -1194,7 +1194,24 @@
         "@php-wasm/util": "3.1.35"
       }
     },
-    "node_modules/@php-wasm/stream-compression/node_modules/@php-wasm/util": {
+    "node_modules/@php-wasm/universal": {
+      "version": "3.1.35",
+      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.35.tgz",
+      "integrity": "sha512-/7G87o6Lnux67MMzJFf+y/57Yi7rFQzBKuYLvhAsqg0l5na2m66FMOtTO8vOTYTt0tYcJPlCErenJ6Twd3yElQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/logger": "3.1.35",
+        "@php-wasm/progress": "3.1.35",
+        "@php-wasm/stream-compression": "3.1.35",
+        "@php-wasm/util": "3.1.35",
+        "ini": "4.1.2"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/util": {
       "version": "3.1.35",
       "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.35.tgz",
       "integrity": "sha512-JHbScavYz2yTfP/q1Hsn2Gg5tdQooKpQQXI5XEiTLU6YhaXGEW4hp5U+1hPBHFY+aawnByjIVjRkYfu9+YX2RQ==",
@@ -1203,62 +1220,27 @@
         "npm": ">=10.2.3"
       }
     },
-    "node_modules/@php-wasm/universal": {
-      "version": "3.1.34",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.34.tgz",
-      "integrity": "sha512-6QudhocrSUKtIfmuBMk25C+8P79PVHx8GqxpspJmeBDpFNI9M5qJRtbPKrcksfS6L9yPkBRNok/7ilIv903Q2w==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/logger": "3.1.34",
-        "@php-wasm/progress": "3.1.34",
-        "@php-wasm/stream-compression": "3.1.34",
-        "@php-wasm/util": "3.1.34",
-        "ini": "4.1.2"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@php-wasm/universal/node_modules/@php-wasm/stream-compression": {
-      "version": "3.1.34",
-      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.34.tgz",
-      "integrity": "sha512-cH16hONmOD0pTrPoAfNPLFlZSjCPU8/9YOiuC8rzIG+Pjse/WQEsgraedJQN/eRGzMQEZxxWm/jMv3DAZuUUww==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/util": "3.1.34"
-      }
-    },
-    "node_modules/@php-wasm/util": {
-      "version": "3.1.34",
-      "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.34.tgz",
-      "integrity": "sha512-6UCHopajKIO+iHyBFOh8D4cQIO8wFHfWI9TO2hQ6e/QGx2YL1r4ldf5JKUS1iPWviR9Js27trsYbDo3YRuZ9hQ==",
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
     "node_modules/@php-wasm/web": {
-      "version": "3.1.34",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web/-/web-3.1.34.tgz",
-      "integrity": "sha512-unr6MZF1zozTjuYtUIswu/tXQC9VNtDLEnY9vTNFCYL0szksQUgU8D68169VVxCgOHBKFYdraDOwxLnpS880cQ==",
+      "version": "3.1.35",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web/-/web-3.1.35.tgz",
+      "integrity": "sha512-nxnYth+NiWDGvrGHjqfZIngwbdSNUiyUeEfc3U59xQXOne/1IWszpZu+eVTfVSdlKoN+fvr+Np5nn2DScVyJvg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/fs-journal": "3.1.34",
-        "@php-wasm/logger": "3.1.34",
-        "@php-wasm/universal": "3.1.34",
-        "@php-wasm/util": "3.1.34",
-        "@php-wasm/web-5-2": "3.1.34",
-        "@php-wasm/web-7-4": "3.1.34",
-        "@php-wasm/web-8-0": "3.1.34",
-        "@php-wasm/web-8-1": "3.1.34",
-        "@php-wasm/web-8-2": "3.1.34",
-        "@php-wasm/web-8-3": "3.1.34",
-        "@php-wasm/web-8-4": "3.1.34",
-        "@php-wasm/web-8-5": "3.1.34",
-        "@php-wasm/web-service-worker": "3.1.34",
-        "@wp-playground/common": "3.1.34",
-        "@wp-playground/storage": "3.1.34",
+        "@php-wasm/fs-journal": "3.1.35",
+        "@php-wasm/logger": "3.1.35",
+        "@php-wasm/universal": "3.1.35",
+        "@php-wasm/util": "3.1.35",
+        "@php-wasm/web-5-2": "3.1.35",
+        "@php-wasm/web-7-4": "3.1.35",
+        "@php-wasm/web-8-0": "3.1.35",
+        "@php-wasm/web-8-1": "3.1.35",
+        "@php-wasm/web-8-2": "3.1.35",
+        "@php-wasm/web-8-3": "3.1.35",
+        "@php-wasm/web-8-4": "3.1.35",
+        "@php-wasm/web-8-5": "3.1.35",
+        "@php-wasm/web-service-worker": "3.1.35",
+        "@wp-playground/common": "3.1.35",
+        "@wp-playground/storage": "3.1.35",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1267,12 +1249,12 @@
       }
     },
     "node_modules/@php-wasm/web-5-2": {
-      "version": "3.1.34",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-5-2/-/web-5-2-3.1.34.tgz",
-      "integrity": "sha512-uw3VGsvj1wEprzmKn1LTvJgqjkIp/IWzTMevjX1IHmKm3JrUgTm2qT8fYxViNXXuwkp5euvqAeeevFFmSDJFRw==",
+      "version": "3.1.35",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-5-2/-/web-5-2-3.1.35.tgz",
+      "integrity": "sha512-6zt7dBdVp8XrUfqWWsin8hK4zt4xt2K7tVZHb3lG7PMzX2zHcXeAIcbVfpWvOFvvHdfHK5PO0AEkVsNqwiXHHg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.34",
+        "@php-wasm/universal": "3.1.35",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1281,12 +1263,12 @@
       }
     },
     "node_modules/@php-wasm/web-7-4": {
-      "version": "3.1.34",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-7-4/-/web-7-4-3.1.34.tgz",
-      "integrity": "sha512-El1GFcXaipZfb2zSNGLAsdYOL3O7JmdfIMumY+CmJh3YJFAZq1zMq+nrXJx2l9f0+s+whFHlHiml0hYqlY19+Q==",
+      "version": "3.1.35",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-7-4/-/web-7-4-3.1.35.tgz",
+      "integrity": "sha512-evyJJCc0Vh2L7CklAcFZO1R/SjVmNoldQS8Tdv9DSHFsljER+6KjmkfAykJKLipNif6bkx9G8/197v4vJKECqA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.34",
+        "@php-wasm/universal": "3.1.35",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1295,12 +1277,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-0": {
-      "version": "3.1.34",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-0/-/web-8-0-3.1.34.tgz",
-      "integrity": "sha512-3lCnAEe5cqVtdy5pzeoDlyLwVNsqwC6rfLDJesYk4Fdo2emmc+fQlTWEsyOkcr31KGdV0J7AUKrUphgnDLbHbA==",
+      "version": "3.1.35",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-0/-/web-8-0-3.1.35.tgz",
+      "integrity": "sha512-UXU5rwplNHKODPmzg+TMXsq9A2iXh8IXjPPmKNLtrl5vbDHhv0pnReTHuiU50U52/HyU7G0o/9yyO0xhi+smMw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.34",
+        "@php-wasm/universal": "3.1.35",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1309,12 +1291,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-1": {
-      "version": "3.1.34",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-1/-/web-8-1-3.1.34.tgz",
-      "integrity": "sha512-XS/bebtDldheUzgdWsH8zeTluDbqDBZdMPrMn1x2Jqr4+Pye5v23I1RXNdcRCGy16s/QFaJvy9aph7Uz2tI8/Q==",
+      "version": "3.1.35",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-1/-/web-8-1-3.1.35.tgz",
+      "integrity": "sha512-bSnFmBN5JQ3RUEk49ZgWkeVUScEJLvuSfCIVWWeC001pejcnZkJPGzbv788NoIUvo0C/yxldPMYxuBZiIfDoow==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.34",
+        "@php-wasm/universal": "3.1.35",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1323,12 +1305,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-2": {
-      "version": "3.1.34",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-2/-/web-8-2-3.1.34.tgz",
-      "integrity": "sha512-qI/AhW1FQpwWCEClu3lhd+AQBYF51uDA9L0pLVn1dAs1FceFXpqbcyM7q90bPsd6wxRfA7HwICn7NYBGB+HSHw==",
+      "version": "3.1.35",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-2/-/web-8-2-3.1.35.tgz",
+      "integrity": "sha512-gdq1KyPXOK4cO98av48Qh57qX99kiGWKBFlt4Nd8L6G8qbZKeMWy5XaB47TpRAJkuVEi30bPxvW5fGdihqxshQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.34",
+        "@php-wasm/universal": "3.1.35",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1337,12 +1319,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-3": {
-      "version": "3.1.34",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-3/-/web-8-3-3.1.34.tgz",
-      "integrity": "sha512-XjS48oDtnGS7T8YyqDdFmmiFIIR3oB1CxW9uFUMJ2jGsQJ7hNGR+6vhXharzHz01/+FXLRBYENPrD2rep4VqcA==",
+      "version": "3.1.35",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-3/-/web-8-3-3.1.35.tgz",
+      "integrity": "sha512-OsLOlblcmrbLL8CE0bAUUsPVNnhjIQWIWfFDdPDZiPp4+HdstE3aW+/yFothGtIYUkVcIIj31KOSAALHkCQ2Ag==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.34",
+        "@php-wasm/universal": "3.1.35",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1351,12 +1333,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-4": {
-      "version": "3.1.34",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-4/-/web-8-4-3.1.34.tgz",
-      "integrity": "sha512-DOSuwycYcqpAeA2QLudxYTdbT9SrmGzAVzu3x4B6+AIcw8TbYodAFDZnOFgKL6MuJDScnmss4tehN/aMBz3MHg==",
+      "version": "3.1.35",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-4/-/web-8-4-3.1.35.tgz",
+      "integrity": "sha512-J47FYCCLaFH+GDTIvL5CHqKgNr4sdOFX/q4/zZwaSj3nob310sQLRdnHsuHAu22Jdk9i9HNTtoHzeX3m5DuHsQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.34",
+        "@php-wasm/universal": "3.1.35",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1365,12 +1347,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-5": {
-      "version": "3.1.34",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-5/-/web-8-5-3.1.34.tgz",
-      "integrity": "sha512-lxPtEaiAKnQCANrb2BGXGyVW/QaxNRVFnNKCfRUVbZM6ATJxJKsVHXKsbTOYBI/kKYl0RHn0pNAVsxqg+mKJjg==",
+      "version": "3.1.35",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-5/-/web-8-5-3.1.35.tgz",
+      "integrity": "sha512-6/PVfKT9l3hGbi/C2FGM+M/18YlX3je+uDEEj5pTROANdC8UZCuM0dYAT7JBo5id94n+imZq/D6gYCnOibKdbA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.34",
+        "@php-wasm/universal": "3.1.35",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1379,13 +1361,13 @@
       }
     },
     "node_modules/@php-wasm/web-service-worker": {
-      "version": "3.1.34",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.34.tgz",
-      "integrity": "sha512-d7L17bMd8IXC2sGJ5GWDEyBhYnboOMroMQS2pdTSc+I0umDnomjrZGXWGBugXnCgzRwf6Sebxps0DKOTRIiKiQ==",
+      "version": "3.1.35",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.35.tgz",
+      "integrity": "sha512-WfPmMSlGKm8t13HlID/8ULZ20bT9ihbioZd9I6VX8ME88cyUK8+N0kzGvAcT9wjvUODrwSBC2dNzKNHpZe1m9w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/scopes": "3.1.34",
-        "@php-wasm/universal": "3.1.34"
+        "@php-wasm/scopes": "3.1.35",
+        "@php-wasm/universal": "3.1.35"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1446,13 +1428,13 @@
       }
     },
     "node_modules/@wp-playground/common": {
-      "version": "3.1.34",
-      "resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.34.tgz",
-      "integrity": "sha512-a8K9H0+h/ZNpDQHWrrHp9lpZYYbyaVCDK1xV0BSgJfkZ/KtHFn6qWIaTTUmjBAc3Bn/V9+BSAZEpgeYNjFIEUw==",
+      "version": "3.1.35",
+      "resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.35.tgz",
+      "integrity": "sha512-KVU5JWgCVjFU1SJ8PeaIl82oijCqs43JWRR5rfjgfJbDxXl6ntPfY/elPe7eI3noMoeyFJ10pAAO1ESXGWxygA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.34",
-        "@php-wasm/util": "3.1.34"
+        "@php-wasm/universal": "3.1.35",
+        "@php-wasm/util": "3.1.35"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1460,27 +1442,18 @@
       }
     },
     "node_modules/@wp-playground/storage": {
-      "version": "3.1.34",
-      "resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.34.tgz",
-      "integrity": "sha512-7fN5MjA+3SUz03JS6z3ERde8DZ7j6GhZWyHwBl02MB/IYSLvMqheO9SI65e0+ww7itcGSdFfmByYK0dDoAioOw==",
+      "version": "3.1.35",
+      "resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.35.tgz",
+      "integrity": "sha512-De7zdHGwBuwQE+kO1p0EGkN8jBim/QJ8ftjRuymxDJXzNimdLmfedqSNa0ajpNcRSq0HKFz/gyxpcWq1hSDnCw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/stream-compression": "3.1.34",
-        "@php-wasm/universal": "3.1.34",
-        "@php-wasm/util": "3.1.34",
+        "@php-wasm/stream-compression": "3.1.35",
+        "@php-wasm/universal": "3.1.35",
+        "@php-wasm/util": "3.1.35",
         "@zip.js/zip.js": "2.7.57",
         "isomorphic-git": "1.37.6",
         "octokit": "3.1.2",
         "pako": "^1.0.10"
-      }
-    },
-    "node_modules/@wp-playground/storage/node_modules/@php-wasm/stream-compression": {
-      "version": "3.1.34",
-      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.34.tgz",
-      "integrity": "sha512-cH16hONmOD0pTrPoAfNPLFlZSjCPU8/9YOiuC8rzIG+Pjse/WQEsgraedJQN/eRGzMQEZxxWm/jMv3DAZuUUww==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/util": "3.1.34"
       }
     },
     "node_modules/@zip.js/zip.js": {
@@ -2786,9 +2759,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3141,13 +3114,13 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.21.tgz",
+      "integrity": "sha512-zbRA8cVm6io/d5W8uIe2hblzN76/Wm3v/yiythQvr+dpBWeqhPSWIDNj4zOyHi4zKbMK6DN34Xsr9jPHJERAEw==",
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
+        "call-bind": "^1.0.9",
         "call-bound": "^1.0.4",
         "for-each": "^0.3.5",
         "get-proto": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -17,15 +17,15 @@
   },
   "dependencies": {
     "@php-wasm/stream-compression": "^3.1.35",
-    "@php-wasm/universal": "^3.1.30",
-    "@php-wasm/web": "^3.1.34",
+    "@php-wasm/universal": "^3.1.35",
+    "@php-wasm/web": "^3.1.35",
     "fflate": "^0.8.3"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.15",
+    "@playwright/test": "^1.60.0",
     "concurrently": "^9.2.1",
     "esbuild": "^0.28.0",
-    "@playwright/test": "^1.60.0",
     "http-server": "^14.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- `@php-wasm/web` 3.1.35 publishes WordPress/wordpress-playground#3632, which fixes `parseHttpRequest()` to skip the `ReadableStream` body for HEAD requests.
- Verified the published tarball contains `method !== "HEAD"` in `node_modules/@php-wasm/web/index.js`.
- Bumps `@php-wasm/web` and `@php-wasm/universal` to `^3.1.35` and removes the `php-wasm-tcp-over-fetch-head-body-fix` esbuild plugin (and the unused `readFile` import).

Closes #101

## Test plan
- [x] `npm run build:worker` succeeds
- [x] `make lint` passes
- [x] `make test` — 360/360 pass
- [x] CI: lint-and-test + build (6 Moodle branches) + e2e (chromium, firefox)
- [x] Manual smoke check: trigger a HEAD request from PHP (e.g. URL-downloader pulling an external file) and confirm no `Request` constructor error