### PR TITLE
fix: resolve critical security & correctness bugs from multi-agent audit

### DIFF
--- a/lib/moodle-loader.js
+++ b/lib/moodle-loader.js
@@ -252,9 +252,18 @@ export function extractZipEntries(zipBytes) {
   // so a crafted archive can never write outside the target root (ZIP-slip).
   const entries = rawNames
     .map((raw) => {
+      const normalized = normalizeArchiveName(raw);
+      // Skip directory entries: archive keys ending in "/" carry no file
+      // content. This MUST run before sanitizeArchivePath(), which strips the
+      // trailing slash and would otherwise turn a directory entry into a bare
+      // file path (e.g. ".git/" -> ".git"), colliding with the real files
+      // inside that directory and breaking extraction ("Not a directory").
+      if (normalized.endsWith("/")) {
+        return null;
+      }
       let name;
       try {
-        name = sanitizeArchivePath(normalizeArchiveName(raw));
+        name = sanitizeArchivePath(normalized);
       } catch {
         return null;
       }

--- a/lib/moodle-loader.js
+++ b/lib/moodle-loader.js
@@ -218,6 +218,27 @@ export function normalizeArchiveName(name) {
   return name.replaceAll("\\", "/").replace(/^\/+/, "");
 }
 
+/**
+ * Sanitize a normalized archive entry path to prevent ZIP-slip (path
+ * traversal). Splits the path on "/", drops empty and "." segments, and
+ * rejects any entry that contains a ".." segment or that resolves to an
+ * absolute path. Returns the cleaned relative path, or null when the entry
+ * is empty after sanitization. Throws on a traversal/absolute path so callers
+ * never write outside the intended directory.
+ */
+export function sanitizeArchivePath(name) {
+  // normalizeArchiveName already converts "\\" -> "/" and strips leading "/".
+  const segments = String(name)
+    .split("/")
+    .filter((segment) => segment !== "" && segment !== ".");
+
+  if (segments.some((segment) => segment === "..")) {
+    throw new Error(`Unsafe archive entry path (path traversal): ${name}`);
+  }
+
+  return segments.length > 0 ? segments.join("/") : null;
+}
+
 export function extractZipEntries(zipBytes) {
   const archive = unzipSync(zipBytes);
   const rawNames = Object.keys(archive);
@@ -227,7 +248,19 @@ export function extractZipEntries(zipBytes) {
   }
 
   // Normalize once per entry to avoid redundant string processing on ~30k entries.
-  const entries = rawNames.map((raw) => ({ raw, name: normalizeArchiveName(raw) }));
+  // Sanitization drops "." / empty segments and skips traversal/absolute paths
+  // so a crafted archive can never write outside the target root (ZIP-slip).
+  const entries = rawNames
+    .map((raw) => {
+      let name;
+      try {
+        name = sanitizeArchivePath(normalizeArchiveName(raw));
+      } catch {
+        return null;
+      }
+      return name ? { raw, name } : null;
+    })
+    .filter(Boolean);
 
   const firstSegments = new Set(
     entries.map(({ name }) => splitPath(name)[0]).filter(Boolean),
@@ -271,7 +304,14 @@ export async function readZipEntries(zipBytes) {
     const { done, value } = await reader.read();
     if (done) break;
     if (value.type === "directory") continue;
-    const path = normalizeArchiveName(value.name);
+    // Sanitize to prevent ZIP-slip: skip entries with ".." segments or
+    // absolute paths so extraction can never escape the target directory.
+    let path;
+    try {
+      path = sanitizeArchivePath(normalizeArchiveName(value.name));
+    } catch {
+      continue;
+    }
     if (!path || path.endsWith("/")) continue;
     entries.push({ path, data: new Uint8Array(await value.arrayBuffer()) });
   }

--- a/patches/moodle/lib/ddl/sqlite_sql_generator.php
+++ b/patches/moodle/lib/ddl/sqlite_sql_generator.php
@@ -201,6 +201,54 @@ class sqlite_sql_generator extends sql_generator {
         if ($xmldb_delete_field) {
             $xmldb_table->deleteField($oldname);
         }
+
+        // SQLite cannot ALTER a table in place, so we rebuild it: copy the live
+        // table into temp_data (SELECT *), drop it, recreate it from the desired
+        // schema, then copy the data back. Both halves of this need the real
+        // current column set, because add_field()/add_key()/etc. are routinely
+        // called with an xmldb_table that only carries the table name (and at
+        // most the single field being changed) — see database_manager::add_field
+        // which documents "just the name is mandatory". Trusting
+        // $xmldb_table->getFields() alone would recreate the table with only that
+        // one column and silently drop every existing column.
+        $livecolumns = $this->mdb->get_columns($xmldb_table->getName(), false);
+        $existingcolumns = array();
+        if ($livecolumns) {
+            foreach ($livecolumns as $livecolumn) {
+                $existingcolumns[strtolower($livecolumn->name)] = $livecolumn;
+            }
+        }
+
+        // Re-declare every surviving live column (in its original order) that the
+        // caller did not describe, so getCreateTableSQL() recreates them instead
+        // of dropping them. Skip the field being dropped, and the old name of a
+        // rename (its data is moved to $newname, which the caller adds below).
+        // While iterating, capture the live primary-key columns (in declaration
+        // order) so the constraint can be rebuilt below — without it
+        // getCreateTableSQL() either throws ddsequenceerror for the autoincrement
+        // 'id' column or silently drops a composite primary key.
+        $pkcolumns = array();
+        foreach ($existingcolumns as $columnname => $livecolumn) {
+            if (!empty($livecolumn->primary_key)) {
+                if ($oldname && $columnname === strtolower($oldname)) {
+                    // The primary-key column is the field being dropped or renamed.
+                    // A drop removes it from the key; a rename moves it to $newname.
+                    if ($newname) {
+                        $pkcolumns[] = $newname;
+                    }
+                } else {
+                    $pkcolumns[] = $livecolumn->name;
+                }
+            }
+            if ($oldname && $columnname === strtolower($oldname)) {
+                continue;
+            }
+            if ($xmldb_table->getField($livecolumn->name)) {
+                continue; // Already described by the caller's table object.
+            }
+            $xmldb_table->addField($this->column_info_to_xmldb_field($livecolumn));
+        }
+
         if ($xmldb_add_field) {
             $xmldb_table->addField($xmldb_add_field);
         }
@@ -244,13 +292,39 @@ class sqlite_sql_generator extends sql_generator {
             }
         }
 
+        // The caller's xmldb_table usually carries no keys (add_field()/etc. are
+        // documented to need "just the name"). Re-add the live primary key unless
+        // the caller already described one, otherwise getCreateTableSQL() throws
+        // ddsequenceerror for the autoincrement 'id' and any composite primary key
+        // would be silently dropped.
+        $hasprimary = false;
+        foreach ($xmldb_table->getKeys() as $existingkey) {
+            if ($existingkey->getType() == XMLDB_KEY_PRIMARY) {
+                $hasprimary = true;
+                break;
+            }
+        }
+        if (!$hasprimary && count($pkcolumns)) {
+            $xmldb_table->addKey(new xmldb_key('primary', XMLDB_KEY_PRIMARY, $pkcolumns));
+        }
+
+        // Build the data-copy SELECT list. It must reference ONLY columns that
+        // physically exist in temp_data (the pre-change table). Columns in the
+        // recreated schema that are absent from temp_data (genuinely new fields)
+        // are populated with NULL so SQLite applies their column default.
         $fields = $xmldb_table->getFields();
         foreach ($fields as $key => $field) {
             $fieldname = $field->getName();
             if ($fieldname == $newname && $oldname && $oldname != $newname) {
+                // Renamed field: the data still lives under the old column name
+                // in temp_data, so copy it across to the new name.
                 $fields[$key] = $this->getEncQuoted($oldname) . ' AS ' . $this->getEncQuoted($newname);
+            } else if (!isset($existingcolumns[strtolower($fieldname)])) {
+                // Brand-new column not present in temp_data: select NULL so the
+                // recreated table falls back to the column default for this field.
+                $fields[$key] = 'NULL AS ' . $this->getEncQuoted($fieldname);
             } else {
-                $fields[$key] = $this->getEncQuoted($field->getName());
+                $fields[$key] = $this->getEncQuoted($fieldname);
             }
         }
         $fields = implode(',', $fields);
@@ -262,6 +336,67 @@ class sqlite_sql_generator extends sql_generator {
         $results[] = 'DROP TABLE temp_data';
         $results[] = 'COMMIT';
         return $results;
+    }
+
+    /**
+     * Build an xmldb_field describing an existing live column, so it can be
+     * re-declared when SQLite rebuilds a table for an ALTER emulation.
+     *
+     * The mapping is driven by the canonical meta_type that
+     * sqlite3_pdo_moodle_database::get_columns() assigns, which is more reliable
+     * than the raw SQLite type affinity string.
+     *
+     * @param database_column_info $column
+     * @return xmldb_field
+     */
+    protected function column_info_to_xmldb_field($column) {
+        $field = new xmldb_field($column->name);
+
+        switch ($column->meta_type) {
+            case 'N': // Number / decimal.
+                $type = XMLDB_TYPE_NUMBER;
+                break;
+            case 'C': // Char / varchar.
+                $type = XMLDB_TYPE_CHAR;
+                break;
+            case 'X': // Text.
+                $type = XMLDB_TYPE_TEXT;
+                break;
+            case 'B': // Binary / blob.
+                $type = XMLDB_TYPE_BINARY;
+                break;
+            case 'R': // Auto-increment counter.
+            case 'I': // Integer.
+            case 'L': // Boolean stored as integer.
+            case 'T': // Timestamp stored as integer.
+            case 'D': // Date stored as integer.
+            default:
+                $type = XMLDB_TYPE_INTEGER;
+                break;
+        }
+
+        $field->setType($type);
+
+        if ($type !== XMLDB_TYPE_TEXT && $type !== XMLDB_TYPE_BINARY) {
+            if (!empty($column->max_length)) {
+                $field->setLength($column->max_length);
+            }
+            if ($type === XMLDB_TYPE_NUMBER && !empty($column->scale)) {
+                $field->setDecimals($column->scale);
+            }
+        }
+
+        $field->setNotNull(!empty($column->not_null));
+
+        if (!empty($column->has_default)) {
+            $field->setDefault($column->default_value);
+        }
+
+        if (!empty($column->auto_increment) || $column->meta_type === 'R') {
+            $field->setSequence(true);
+        }
+
+        return $field;
     }
 
     public function getAlterFieldSQL($xmldb_table, $xmldb_field, $skip_type_clause = null, $skip_default_clause = null, $skip_notnull_clause = null) {

--- a/patches/shared/lib/ddl/sqlite_sql_generator.php
+++ b/patches/shared/lib/ddl/sqlite_sql_generator.php
@@ -201,6 +201,54 @@ class sqlite_sql_generator extends sql_generator {
         if ($xmldb_delete_field) {
             $xmldb_table->deleteField($oldname);
         }
+
+        // SQLite cannot ALTER a table in place, so we rebuild it: copy the live
+        // table into temp_data (SELECT *), drop it, recreate it from the desired
+        // schema, then copy the data back. Both halves of this need the real
+        // current column set, because add_field()/add_key()/etc. are routinely
+        // called with an xmldb_table that only carries the table name (and at
+        // most the single field being changed) — see database_manager::add_field
+        // which documents "just the name is mandatory". Trusting
+        // $xmldb_table->getFields() alone would recreate the table with only that
+        // one column and silently drop every existing column.
+        $livecolumns = $this->mdb->get_columns($xmldb_table->getName(), false);
+        $existingcolumns = array();
+        if ($livecolumns) {
+            foreach ($livecolumns as $livecolumn) {
+                $existingcolumns[strtolower($livecolumn->name)] = $livecolumn;
+            }
+        }
+
+        // Re-declare every surviving live column (in its original order) that the
+        // caller did not describe, so getCreateTableSQL() recreates them instead
+        // of dropping them. Skip the field being dropped, and the old name of a
+        // rename (its data is moved to $newname, which the caller adds below).
+        // While iterating, capture the live primary-key columns (in declaration
+        // order) so the constraint can be rebuilt below — without it
+        // getCreateTableSQL() either throws ddsequenceerror for the autoincrement
+        // 'id' column or silently drops a composite primary key.
+        $pkcolumns = array();
+        foreach ($existingcolumns as $columnname => $livecolumn) {
+            if (!empty($livecolumn->primary_key)) {
+                if ($oldname && $columnname === strtolower($oldname)) {
+                    // The primary-key column is the field being dropped or renamed.
+                    // A drop removes it from the key; a rename moves it to $newname.
+                    if ($newname) {
+                        $pkcolumns[] = $newname;
+                    }
+                } else {
+                    $pkcolumns[] = $livecolumn->name;
+                }
+            }
+            if ($oldname && $columnname === strtolower($oldname)) {
+                continue;
+            }
+            if ($xmldb_table->getField($livecolumn->name)) {
+                continue; // Already described by the caller's table object.
+            }
+            $xmldb_table->addField($this->column_info_to_xmldb_field($livecolumn));
+        }
+
         if ($xmldb_add_field) {
             $xmldb_table->addField($xmldb_add_field);
         }
@@ -244,13 +292,39 @@ class sqlite_sql_generator extends sql_generator {
             }
         }
 
+        // The caller's xmldb_table usually carries no keys (add_field()/etc. are
+        // documented to need "just the name"). Re-add the live primary key unless
+        // the caller already described one, otherwise getCreateTableSQL() throws
+        // ddsequenceerror for the autoincrement 'id' and any composite primary key
+        // would be silently dropped.
+        $hasprimary = false;
+        foreach ($xmldb_table->getKeys() as $existingkey) {
+            if ($existingkey->getType() == XMLDB_KEY_PRIMARY) {
+                $hasprimary = true;
+                break;
+            }
+        }
+        if (!$hasprimary && count($pkcolumns)) {
+            $xmldb_table->addKey(new xmldb_key('primary', XMLDB_KEY_PRIMARY, $pkcolumns));
+        }
+
+        // Build the data-copy SELECT list. It must reference ONLY columns that
+        // physically exist in temp_data (the pre-change table). Columns in the
+        // recreated schema that are absent from temp_data (genuinely new fields)
+        // are populated with NULL so SQLite applies their column default.
         $fields = $xmldb_table->getFields();
         foreach ($fields as $key => $field) {
             $fieldname = $field->getName();
             if ($fieldname == $newname && $oldname && $oldname != $newname) {
+                // Renamed field: the data still lives under the old column name
+                // in temp_data, so copy it across to the new name.
                 $fields[$key] = $this->getEncQuoted($oldname) . ' AS ' . $this->getEncQuoted($newname);
+            } else if (!isset($existingcolumns[strtolower($fieldname)])) {
+                // Brand-new column not present in temp_data: select NULL so the
+                // recreated table falls back to the column default for this field.
+                $fields[$key] = 'NULL AS ' . $this->getEncQuoted($fieldname);
             } else {
-                $fields[$key] = $this->getEncQuoted($field->getName());
+                $fields[$key] = $this->getEncQuoted($fieldname);
             }
         }
         $fields = implode(',', $fields);
@@ -262,6 +336,67 @@ class sqlite_sql_generator extends sql_generator {
         $results[] = 'DROP TABLE temp_data';
         $results[] = 'COMMIT';
         return $results;
+    }
+
+    /**
+     * Build an xmldb_field describing an existing live column, so it can be
+     * re-declared when SQLite rebuilds a table for an ALTER emulation.
+     *
+     * The mapping is driven by the canonical meta_type that
+     * sqlite3_pdo_moodle_database::get_columns() assigns, which is more reliable
+     * than the raw SQLite type affinity string.
+     *
+     * @param database_column_info $column
+     * @return xmldb_field
+     */
+    protected function column_info_to_xmldb_field($column) {
+        $field = new xmldb_field($column->name);
+
+        switch ($column->meta_type) {
+            case 'N': // Number / decimal.
+                $type = XMLDB_TYPE_NUMBER;
+                break;
+            case 'C': // Char / varchar.
+                $type = XMLDB_TYPE_CHAR;
+                break;
+            case 'X': // Text.
+                $type = XMLDB_TYPE_TEXT;
+                break;
+            case 'B': // Binary / blob.
+                $type = XMLDB_TYPE_BINARY;
+                break;
+            case 'R': // Auto-increment counter.
+            case 'I': // Integer.
+            case 'L': // Boolean stored as integer.
+            case 'T': // Timestamp stored as integer.
+            case 'D': // Date stored as integer.
+            default:
+                $type = XMLDB_TYPE_INTEGER;
+                break;
+        }
+
+        $field->setType($type);
+
+        if ($type !== XMLDB_TYPE_TEXT && $type !== XMLDB_TYPE_BINARY) {
+            if (!empty($column->max_length)) {
+                $field->setLength($column->max_length);
+            }
+            if ($type === XMLDB_TYPE_NUMBER && !empty($column->scale)) {
+                $field->setDecimals($column->scale);
+            }
+        }
+
+        $field->setNotNull(!empty($column->not_null));
+
+        if (!empty($column->has_default)) {
+            $field->setDefault($column->default_value);
+        }
+
+        if (!empty($column->auto_increment) || $column->meta_type === 'R') {
+            $field->setSequence(true);
+        }
+
+        return $field;
     }
 
     public function getAlterFieldSQL($xmldb_table, $xmldb_field, $skip_type_clause = null, $skip_default_clause = null, $skip_notnull_clause = null) {

--- a/php-worker.js
+++ b/php-worker.js
@@ -666,32 +666,62 @@ function installBridgeListener() {
         }
 
         // --- Fatal WASM error path ---
-        // Save the DB file before destroying the runtime.
-        // MEMFS lives in JS heap so readFileAsBuffer works even with
-        // a corrupted WASM linear memory.
+        // Capture the current PHP instance reference BEFORE resetRuntime()
+        // clears runtimeStatePromise, but defer the actual hydration until
+        // we know a restart will happen. Hydration pulls the full DB, all
+        // uploaded files, and tracked plugin dirs into the JS heap — doing
+        // it when resetRuntime() returns false (e.g. the
+        // MIN_REQUESTS_BEFORE_RESTART guard fires on a first-boot OOM) would
+        // pin that large snapshot for the tab's life on an already
+        // memory-pressured worker, and leave hasPendingRestore stuck true.
+        let phpToHydrate = null;
         try {
           const currentState = await runtimeStatePromise;
-          if (currentState?.php?._php) {
-            postShell({
-              kind: "trace",
-              detail: `[runtime] hydrating snapshot before runtime reset (dbPath=${buildDbPath()})`,
-            });
-            await snapshot.hydrate(currentState.php, buildDbPath());
+          phpToHydrate = currentState?.php?._php ? currentState.php : null;
+        } catch {
+          phpToHydrate = null;
+        }
+
+        const didReset = resetRuntime(`fatal WASM error: ${error.message}`);
+        const canReplay = isSafeToReplay(data.request);
+
+        // Only hydrate the snapshot when a restart will actually happen.
+        // When resetRuntime() returns false (e.g. the
+        // MIN_REQUESTS_BEFORE_RESTART guard fires on a first-boot OOM), no
+        // fresh runtime ever boots, so snapshot.restore() never runs and the
+        // hydrated buffers would stay pinned for the tab's life on an
+        // already memory-pressured worker (with hasPendingRestore stuck
+        // true). In that case discard any leftover snapshot instead.
+        //
+        // When resetRuntime() returns true, the next getRuntimeState() boot
+        // will consume the snapshot — either via the immediate replay below
+        // (idempotent requests) or on the next user-triggered request
+        // (non-idempotent requests that aren't replayed here).
+        if (didReset) {
+          // MEMFS lives in JS heap so readFileAsBuffer works even with a
+          // corrupted WASM linear memory.
+          if (phpToHydrate) {
+            try {
+              postShell({
+                kind: "trace",
+                detail: `[runtime] hydrating snapshot before runtime reset (dbPath=${buildDbPath()})`,
+              });
+              await snapshot.hydrate(phpToHydrate, buildDbPath());
+            } catch (hydrateErr) {
+              postShell({
+                kind: "error",
+                detail: `[runtime] snapshot hydration failed: ${hydrateErr.message}`,
+              });
+            }
           } else {
             postShell({
               kind: "trace",
               detail: `[runtime] no PHP instance available for snapshot hydration`,
             });
           }
-        } catch (hydrateErr) {
-          postShell({
-            kind: "error",
-            detail: `[runtime] snapshot hydration failed: ${hydrateErr.message}`,
-          });
+        } else {
+          snapshot.clear();
         }
-
-        const didReset = resetRuntime(`fatal WASM error: ${error.message}`);
-        const canReplay = isSafeToReplay(data.request);
 
         // If we already retried this request, or the request is not
         // idempotent, or we hit the restart limit — give up.
@@ -767,8 +797,12 @@ function installMessageListener() {
       }
       if (params.debug !== undefined) debug = params.debug;
       if (params.profile !== undefined) profile = params.profile;
-      // Reset any cached runtime state so it boots with the new params
+      // Reset any cached runtime state so it boots with the new params.
+      // Discard any pending crash snapshot too: it was hydrated from the
+      // previous runtime/scope and must never be restored onto this freshly
+      // (re)configured — potentially foreign — runtime.
       runtimeStatePromise = null;
+      snapshot.clear();
       // Recreate bridge channel if scopeId changed
       if (params.scopeId !== undefined && bridgeChannel) {
         bridgeChannel.close();
@@ -783,6 +817,12 @@ function installMessageListener() {
       kind: "worker-ready",
       scopeId,
       runtimeId,
+      // Best initial landing path known before bootstrap runs. The
+      // authoritative post-bootstrap path (e.g. "/my/" after auto-login)
+      // is delivered later via the "ready" shell message; this hint lets
+      // remote.js point the very first navigation at the blueprint's
+      // landing page instead of a stale URL path from a previous session.
+      initialPath: activeBlueprint?.landingPage || null,
     });
   });
 }

--- a/scripts/generate-install-snapshot.sh
+++ b/scripts/generate-install-snapshot.sh
@@ -125,22 +125,29 @@ CFGEOF
 
 echo "Running Moodle CLI install to generate snapshot..." >&2
 
-# Run the Moodle CLI installer
+# Run the Moodle CLI installer.
+# Guard the invocation so `set -e` does not abort before we can dump the log:
+# a non-zero installer exit must surface the captured output and a clear error,
+# otherwise the caller (build-moodle-bundle.sh) would treat it as non-fatal and
+# ship a snapshot-less bundle with the installer error lost.
 INSTALL_LOG="$TMPROOT/install.log"
-${PHP_BIN:-php} -d max_input_vars=5000 "$SOURCE_DIR/admin/cli/install_database.php" \
+if ${PHP_BIN:-php} -d max_input_vars=5000 "$SOURCE_DIR/admin/cli/install_database.php" \
   --agree-license \
   --adminuser=admin \
   --adminpass=password \
   --adminemail=admin@example.com \
   --fullname="Moodle Playground" \
   --shortname="Playground" \
-  >"$INSTALL_LOG" 2>&1
-INSTALL_EXIT=$?
+  >"$INSTALL_LOG" 2>&1; then
+  INSTALL_EXIT=0
+else
+  INSTALL_EXIT=$?
+fi
 
-# Show output prefixed for readability
+# Show output prefixed for readability (always, including on failure)
 sed 's/^/[snapshot] /' "$INSTALL_LOG" >&2
 
-if [ $INSTALL_EXIT -ne 0 ]; then
+if [ "$INSTALL_EXIT" -ne 0 ]; then
   echo "Error: Moodle CLI installer exited with code $INSTALL_EXIT" >&2
   exit 1
 fi

--- a/scripts/github-proxy-worker.js
+++ b/scripts/github-proxy-worker.js
@@ -163,11 +163,13 @@ async function handleAtomFeed(repo, type) {
   const url = `${GITHUB_BASE}/${repo}/${type}.atom`;
 
   try {
-    const upstream = await fetch(url, {
-      method: "GET",
-      redirect: "follow",
-      headers: { "User-Agent": "github-proxy-worker" },
-    });
+    // Atom feeds live on github.com; re-validate any redirect hop against the
+    // GitHub host allowlist instead of blindly following it.
+    const upstream = await fetchWithValidatedRedirects(
+      url,
+      { method: "GET", headers: { "User-Agent": "github-proxy-worker" } },
+      isGitHubDirectProxyUrl,
+    );
 
     if (!upstream.ok) {
       return jsonResponse(
@@ -188,6 +190,9 @@ async function handleAtomFeed(repo, type) {
 
     return new Response(upstream.body, { status: 200, headers });
   } catch (error) {
+    if (error instanceof RedirectBlockedError) {
+      return redirectBlockedResponse(error);
+    }
     return jsonResponse(
       { error: "Failed to fetch Atom feed.", details: error.message },
       502,
@@ -294,6 +299,102 @@ async function githubApiRequest(url, env) {
 }
 
 // ---------------------------------------------------------------------------
+// Redirect-safe fetch
+// ---------------------------------------------------------------------------
+
+// Maximum number of redirect hops to follow before giving up.
+const MAX_REDIRECT_HOPS = 5;
+
+class RedirectBlockedError extends Error {
+  constructor(message, blockedUrl) {
+    super(message);
+    this.name = "RedirectBlockedError";
+    this.blockedUrl = blockedUrl;
+  }
+}
+
+// Fetches a URL while validating every redirect hop instead of blindly
+// following them. Using redirect:"follow" would let an allowlisted host (or one
+// with an open redirect / attacker-influenced content) 302 us into a private or
+// otherwise unauthorized target (e.g. http://169.254.169.254/, internal Redis),
+// bypassing the SSRF guard. We re-run the SSRF check and the supplied
+// authorization predicate against each Location before re-issuing the request.
+//
+//   isAuthorized(url) -> boolean : returns true when the host/path is allowed.
+//
+// Throws RedirectBlockedError if any hop fails authorization or the hop cap is
+// exceeded. The caller is expected to map that to a 400/blocked response.
+async function fetchWithValidatedRedirects(initialUrl, init, isAuthorized) {
+  let currentUrl = new URL(initialUrl);
+
+  for (let hop = 0; hop <= MAX_REDIRECT_HOPS; hop++) {
+    const response = await fetch(currentUrl.toString(), {
+      ...init,
+      redirect: "manual",
+    });
+
+    if (!isRedirectStatus(response.status)) {
+      return response;
+    }
+
+    const location = response.headers.get("Location");
+    if (!location) {
+      // A 3xx without a Location header is not actionable; return as-is.
+      return response;
+    }
+
+    if (hop >= MAX_REDIRECT_HOPS) {
+      throw new RedirectBlockedError(
+        `Too many redirects (exceeded ${MAX_REDIRECT_HOPS} hops).`,
+        currentUrl.toString(),
+      );
+    }
+
+    let nextUrl;
+    try {
+      nextUrl = new URL(location, currentUrl);
+    } catch {
+      throw new RedirectBlockedError(
+        "Redirect Location is not a valid URL.",
+        location,
+      );
+    }
+
+    if (nextUrl.protocol !== "https:" && nextUrl.protocol !== "http:") {
+      throw new RedirectBlockedError(
+        "Redirect target uses an unsupported protocol.",
+        nextUrl.toString(),
+      );
+    }
+
+    if (isPrivateOrLocalHost(nextUrl) || !isAuthorized(nextUrl)) {
+      throw new RedirectBlockedError(
+        "Redirect target is not authorized.",
+        nextUrl.toString(),
+      );
+    }
+
+    currentUrl = nextUrl;
+  }
+
+  // Unreachable: the loop returns or throws within MAX_REDIRECT_HOPS + 1 passes.
+  throw new RedirectBlockedError(
+    `Too many redirects (exceeded ${MAX_REDIRECT_HOPS} hops).`,
+    currentUrl.toString(),
+  );
+}
+
+function isRedirectStatus(status) {
+  return (
+    status === 301 ||
+    status === 302 ||
+    status === 303 ||
+    status === 307 ||
+    status === 308
+  );
+}
+
+// ---------------------------------------------------------------------------
 // ZIP proxy (shared by all archive downloads)
 // ---------------------------------------------------------------------------
 
@@ -314,11 +415,15 @@ async function proxyGitHubZip(
       headers.set("Range", forwardedRange);
     }
 
-    const upstream = await fetch(url, {
-      method: "GET",
-      redirect: "follow",
-      headers,
-    });
+    // GitHub archive/release downloads legitimately 302 to codeload.github.com
+    // and objects.githubusercontent.com. Re-validate every redirect hop against
+    // the GitHub host allowlist so the 302 cannot be used to reach an internal
+    // or unauthorized host.
+    const upstream = await fetchWithValidatedRedirects(
+      url,
+      { method: "GET", headers },
+      isGitHubDirectProxyUrl,
+    );
 
     if (!upstream.ok) {
       return jsonResponse(
@@ -354,6 +459,9 @@ async function proxyGitHubZip(
       headers: responseHeaders,
     });
   } catch (error) {
+    if (error instanceof RedirectBlockedError) {
+      return redirectBlockedResponse(error);
+    }
     return jsonResponse(
       { error: "Failed to fetch remote resource.", details: error.message },
       502,
@@ -405,11 +513,14 @@ async function handleGenericProxy(targetUrl, request, env) {
   try {
     const upstreamHeaders = buildGenericProxyRequestHeaders(parsedUrl, request);
 
-    const upstream = await fetch(parsedUrl.toString(), {
-      method: "GET",
-      redirect: "follow",
-      headers: upstreamHeaders,
-    });
+    // Re-validate every redirect hop against the same generic-proxy allowlist
+    // (and SSRF guard) that authorized the initial URL, so an allowlisted host
+    // cannot 302 us into an internal or unsupported target.
+    const upstream = await fetchWithValidatedRedirects(
+      parsedUrl.toString(),
+      { method: "GET", headers: upstreamHeaders },
+      isSupportedGenericProxyUrl,
+    );
 
     if (!upstream.ok) {
       return jsonResponse(
@@ -443,6 +554,9 @@ async function handleGenericProxy(targetUrl, request, env) {
       headers,
     });
   } catch (error) {
+    if (error instanceof RedirectBlockedError) {
+      return redirectBlockedResponse(error);
+    }
     return jsonResponse(
       { error: "Failed to fetch remote resource.", details: error.message },
       502,
@@ -482,6 +596,19 @@ function jsonResponse(data, status) {
   });
 }
 
+// Maps a blocked redirect into a 400 response. A redirect into an
+// unauthorized/internal target is a client-visible policy rejection, not an
+// upstream failure.
+function redirectBlockedResponse(error) {
+  return jsonResponse(
+    {
+      error: "Redirect target is not an allowed proxy destination.",
+      details: error.message,
+    },
+    400,
+  );
+}
+
 function looksLikeZipUrl(url) {
   const pathname = url.pathname.toLowerCase();
 
@@ -495,13 +622,165 @@ function looksLikeZipUrl(url) {
 }
 
 function isSupportedGenericProxyUrl(url) {
-  return (
-    looksLikeZipUrl(url) ||
+  // Defensive SSRF guard: never proxy private, loopback, or link-local hosts,
+  // even if the path looks zip-like or otherwise matches an allowlist helper.
+  if (isPrivateOrLocalHost(url)) {
+    return false;
+  }
+
+  // Specific endpoint helpers authorize a URL regardless of its path shape.
+  if (
     isFacturaScriptsPluginPage(url) ||
     isGitHubDirectProxyUrl(url) ||
     isGoogleDriveDirectFileUrl(url) ||
     isOmekaOrgResourceUrl(url)
+  ) {
+    return true;
+  }
+
+  // A zip-like path only authorizes a request when it also targets an
+  // allowlisted host. Path shape alone must never grant proxy access — that
+  // would turn the worker into an open proxy / SSRF vector.
+  if (looksLikeZipUrl(url) && isAllowlistedProxyHost(url)) {
+    return true;
+  }
+
+  return false;
+}
+
+// Hosts that may serve zip-like downloads through the generic proxy. Specific
+// endpoint helpers (GitHub, Google Drive, omeka, FacturaScripts plugin pages)
+// are checked separately; this list additionally authorizes zip-only paths
+// such as FacturaScripts build downloads (`/downloadbuild/{n}/{channel}`).
+function isAllowlistedProxyHost(url) {
+  const hostname = url.hostname.toLowerCase();
+
+  return (
+    hostname === "github.com" ||
+    hostname === "codeload.github.com" ||
+    hostname === "raw.githubusercontent.com" ||
+    hostname === "gist.githubusercontent.com" ||
+    hostname === "media.githubusercontent.com" ||
+    hostname === "objects.githubusercontent.com" ||
+    hostname === "release-assets.githubusercontent.com" ||
+    hostname.endsWith(".githubusercontent.com") ||
+    hostname === "drive.google.com" ||
+    hostname === "drive.usercontent.google.com" ||
+    hostname === "omeka.org" ||
+    hostname === "dev.omeka.org" ||
+    hostname === "facturascripts.com"
   );
+}
+
+// Reject hosts that resolve to private, loopback, or link-local addresses to
+// avoid SSRF into internal infrastructure (cloud metadata endpoints, Redis on
+// localhost, internal corp services, etc.).
+function isPrivateOrLocalHost(url) {
+  const hostname = url.hostname.toLowerCase();
+
+  // Hostnames that are not numeric IPs but always resolve locally or to a
+  // cloud-metadata endpoint.
+  if (
+    hostname === "localhost" ||
+    hostname === "localhost.localdomain" ||
+    hostname.endsWith(".localhost") ||
+    hostname.endsWith(".local") ||
+    hostname === "metadata.google.internal" ||
+    hostname === "metadata"
+  ) {
+    return true;
+  }
+
+  // IPv6 literals (URL hostname keeps the surrounding brackets).
+  if (hostname.startsWith("[") && hostname.endsWith("]")) {
+    const ipv6 = hostname.slice(1, -1);
+    if (
+      ipv6 === "::1" ||
+      ipv6 === "::" ||
+      ipv6.startsWith("fe80:") || // link-local
+      ipv6.startsWith("fc") || // unique local fc00::/7
+      ipv6.startsWith("fd")
+    ) {
+      return true;
+    }
+
+    // IPv4-mapped IPv6 addresses (::ffff:x.x.x.x or ::ffff:HHHH:HHHH) tunnel an
+    // embedded IPv4 address through an IPv6 literal. Extract the v4 address and
+    // apply the same private/loopback/link-local checks so e.g.
+    // [::ffff:127.0.0.1] and [::ffff:169.254.169.254] are blocked.
+    const embeddedIpv4 = extractIpv4MappedAddress(ipv6);
+    if (embeddedIpv4 && isPrivateIpv4(embeddedIpv4)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  // IPv4 literals.
+  return isPrivateIpv4(hostname);
+}
+
+// Returns true when the dotted-decimal IPv4 string falls inside a private,
+// loopback, or link-local range. Non-IPv4 strings return false.
+function isPrivateIpv4(hostname) {
+  const ipv4 = hostname.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/u);
+  if (!ipv4) {
+    return false;
+  }
+
+  const octets = ipv4.slice(1).map((part) => Number(part));
+  // Dead guard: an octet > 255 is not a valid IPv4 literal. Kept (rather than
+  // treated as blocked) to mirror the original behavior; URL parsing already
+  // rejects such hosts before they reach here.
+  if (octets.some((octet) => octet > 255)) {
+    return false;
+  }
+  const [a, b] = octets;
+
+  if (a === 127) return true; // 127.0.0.0/8 loopback
+  if (a === 10) return true; // 10.0.0.0/8 private
+  if (a === 0) return true; // 0.0.0.0/8 "this network"
+  if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12 private
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16 private
+
+  return false;
+}
+
+// Extracts the embedded IPv4 address from an IPv4-mapped IPv6 literal.
+// Handles both the dotted form (::ffff:127.0.0.1) and the hex form
+// (::ffff:7f00:1). Returns a dotted-decimal string, or null when the input is
+// not an IPv4-mapped address.
+function extractIpv4MappedAddress(ipv6) {
+  const lower = ipv6.toLowerCase();
+  const mappedPrefix = "::ffff:";
+
+  if (!lower.startsWith(mappedPrefix)) {
+    return null;
+  }
+
+  const tail = lower.slice(mappedPrefix.length);
+
+  // Dotted form: ::ffff:169.254.169.254
+  if (/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/u.test(tail)) {
+    return tail;
+  }
+
+  // Hex form: ::ffff:a9fe:a9fe -> two 16-bit groups encode the four octets.
+  const hexMatch = tail.match(/^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/u);
+  if (hexMatch) {
+    const high = Number.parseInt(hexMatch[1], 16);
+    const low = Number.parseInt(hexMatch[2], 16);
+    const octets = [
+      (high >> 8) & 0xff,
+      high & 0xff,
+      (low >> 8) & 0xff,
+      low & 0xff,
+    ];
+    return octets.join(".");
+  }
+
+  return null;
 }
 
 function isGitHubDirectProxyUrl(url) {
@@ -509,6 +788,7 @@ function isGitHubDirectProxyUrl(url) {
 
   if (
     hostname === "github.com" ||
+    hostname === "codeload.github.com" ||
     hostname === "raw.githubusercontent.com" ||
     hostname === "gist.githubusercontent.com" ||
     hostname === "media.githubusercontent.com" ||

--- a/scripts/github-proxy-worker.js
+++ b/scripts/github-proxy-worker.js
@@ -633,7 +633,9 @@ function isSupportedGenericProxyUrl(url) {
     isFacturaScriptsPluginPage(url) ||
     isGitHubDirectProxyUrl(url) ||
     isGoogleDriveDirectFileUrl(url) ||
-    isOmekaOrgResourceUrl(url)
+    isOmekaOrgResourceUrl(url) ||
+    isGitLabResourceUrl(url) ||
+    isJsDelivrResourceUrl(url)
   ) {
     return true;
   }
@@ -668,7 +670,10 @@ function isAllowlistedProxyHost(url) {
     hostname === "drive.usercontent.google.com" ||
     hostname === "omeka.org" ||
     hostname === "dev.omeka.org" ||
-    hostname === "facturascripts.com"
+    hostname === "facturascripts.com" ||
+    hostname === "gitlab.com" ||
+    hostname === "cdn.jsdelivr.net" ||
+    hostname === "data.jsdelivr.com"
   );
 }
 
@@ -987,6 +992,20 @@ function isFacturaScriptsPluginPage(url) {
 function isOmekaOrgResourceUrl(url) {
   const hostname = url.hostname.toLowerCase();
   return hostname === "omeka.org" || hostname === "dev.omeka.org";
+}
+
+// GitLab repositories serve branch/tag archives and raw files. Allow the host
+// for any path (mirrors how the legacy zip-proxy authorized gitlab.com).
+function isGitLabResourceUrl(url) {
+  return url.hostname.toLowerCase() === "gitlab.com";
+}
+
+// jsDelivr CDN (cdn.jsdelivr.net) and its package metadata API
+// (data.jsdelivr.com) serve non-zip resources too, so authorize the host for
+// any path rather than only zip-like paths.
+function isJsDelivrResourceUrl(url) {
+  const hostname = url.hostname.toLowerCase();
+  return hostname === "cdn.jsdelivr.net" || hostname === "data.jsdelivr.com";
 }
 
 function buildZipFilename(url) {

--- a/src/blueprint/parser.js
+++ b/src/blueprint/parser.js
@@ -58,7 +58,7 @@ export function parseBlueprint(input) {
 }
 
 function parseDataUrl(dataUrl) {
-  const match = dataUrl.match(/^data:([^;,]*?)?(;base64)?,(.*)$/su);
+  const match = dataUrl.match(/^data:([^,]*?)(;base64)?,(.*)$/su);
   if (!match) {
     throw new Error("Malformed data: URL.");
   }

--- a/src/blueprint/php/helpers.js
+++ b/src/blueprint/php/helpers.js
@@ -8,13 +8,24 @@
 // script file, so __DIR__ does not resolve to the Moodle directory.
 const MOODLE_ROOT = "/www/moodle";
 
+// A valid PHP property-name identifier. Used to gate customField keys that are
+// interpolated UNQUOTED as a property name (`$moduleInfo->NAME = ...`).
+// escapePhp only neutralizes single-quoted-string context, not identifier
+// context, so a key like `x=1;system("id");$y` would inject PHP. Any key that
+// does not match this pattern is skipped before interpolation.
+const VALID_PHP_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+// Escape a value for interpolation into a SINGLE-QUOTED PHP literal.
+// In a single-quoted PHP string only the backslash and the single quote are
+// special; every other character (including newline and CR) is stored
+// verbatim, so we must NOT convert "\n"/"\r" to the literal sequences \n/\r —
+// doing so corrupts multi-line blueprint text (course summaries, intros).
+// Null bytes have no single-quote escape, so we strip them outright.
 export function escapePhp(value) {
   return String(value)
+    .replaceAll("\0", "")
     .replaceAll("\\", "\\\\")
-    .replaceAll("'", "\\'")
-    .replaceAll("\0", "\\0")
-    .replaceAll("\n", "\\n")
-    .replaceAll("\r", "\\r");
+    .replaceAll("'", "\\'");
 }
 
 const CLI_HEADER = `<?php
@@ -499,11 +510,15 @@ function phpAddGenericModule(
   customFields = {},
 ) {
   const customLines = Object.entries(customFields)
+    // The key is interpolated as a PHP property name (not a string literal), so
+    // escapePhp cannot make a malicious key safe. Skip any key that is not a
+    // plain PHP identifier to prevent code injection through customField names.
+    .filter(([k]) => VALID_PHP_IDENTIFIER.test(k))
     .map(([k, v]) => {
       if (typeof v === "number" || typeof v === "boolean") {
-        return `$moduleInfo->${escapePhp(k)} = ${typeof v === "boolean" ? (v ? 1 : 0) : v};`;
+        return `$moduleInfo->${k} = ${typeof v === "boolean" ? (v ? 1 : 0) : v};`;
       }
-      return `$moduleInfo->${escapePhp(k)} = '${escapePhp(String(v))}';`;
+      return `$moduleInfo->${k} = '${escapePhp(String(v))}';`;
     })
     .join("\n");
 

--- a/src/blueprint/resources.js
+++ b/src/blueprint/resources.js
@@ -155,7 +155,7 @@ function base64ToBytes(str) {
 }
 
 function dataUrlToBytes(dataUrl) {
-  const match = dataUrl.match(/^data:([^;,]*?)?(;base64)?,(.*)$/su);
+  const match = dataUrl.match(/^data:([^,]*?)(;base64)?,(.*)$/su);
   if (!match) {
     throw new Error("Malformed data: URL in resource descriptor.");
   }

--- a/src/blueprint/steps/filesystem.js
+++ b/src/blueprint/steps/filesystem.js
@@ -118,8 +118,16 @@ async function handleUnzip(step, { php, resources }) {
   const entries = await readZipEntries(zipBytes);
 
   const rawPhp = php._php;
+  // Containment prefix used to verify every resolved path stays within
+  // destination (defense-in-depth against ZIP-slip; readZipEntries already
+  // sanitizes traversal segments).
+  const containmentPrefix = `${destination}/`;
   for (const { path, data } of entries) {
     const fullPath = `${destination}/${path}`;
+    // Skip any entry whose resolved path escapes destination.
+    if (!fullPath.startsWith(containmentPrefix)) {
+      continue;
+    }
     const parentDir = fullPath.substring(0, fullPath.lastIndexOf("/"));
     if (parentDir) {
       rawPhp.mkdirTree(parentDir);

--- a/src/blueprint/steps/moodle-plugins.js
+++ b/src/blueprint/steps/moodle-plugins.js
@@ -6,8 +6,15 @@
  */
 
 import { readZipEntries } from "../../../lib/moodle-loader.js";
+import { escapePhp } from "../php/helpers.js";
 
 const MOODLE_ROOT = "/www/moodle";
+
+// Moodle plugin names (the part after the type prefix) are lowercase
+// alphanumerics and underscores, starting with a letter (Moodle frankenstyle).
+// We validate user-supplied names against this before interpolating the
+// derived component string into generated PHP.
+const VALID_PLUGIN_NAME = /^[a-z][a-z0-9_]*$/;
 const DEFAULT_ADDON_PROXY_URL = "https://github-proxy.exelearning.dev/";
 
 // Map Moodle plugin types to their directory under MOODLE_ROOT
@@ -114,6 +121,17 @@ function resolvePluginDir(pluginType, pluginName, webRoot) {
       `Unknown plugin type '${pluginType}'. Known types: ${Object.keys(PLUGIN_TYPE_DIRS).join(", ")}`,
     );
   }
+  // pluginName is interpolated into targetDir and resolved on MEMFS. A name
+  // containing '..' (e.g. '../../admin/cli') would escape the plugin directory
+  // and let ZIP extraction overwrite Moodle core BEFORE runMoodleUpgrade's late
+  // check ever runs. Validate here — the shared chokepoint both handlers call —
+  // so targetDir can never be built from a traversal name.
+  if (!VALID_PLUGIN_NAME.test(pluginName)) {
+    throw new Error(
+      `installMoodlePlugin: invalid plugin name '${pluginName}'. ` +
+        "Plugin names must match /^[a-z][a-z0-9_]*$/.",
+    );
+  }
   const base = webRoot || MOODLE_ROOT;
   return `${base}/${typeDir}/${pluginName}`;
 }
@@ -215,6 +233,11 @@ async function installViaZipDownload(zipUrl, targetDir, context) {
   const rawPhp = php._php;
   rawPhp.mkdirTree(targetDir);
 
+  // Containment prefix used to verify every resolved path stays within
+  // targetDir (defense-in-depth against ZIP-slip; readZipEntries already
+  // sanitizes traversal segments).
+  const containmentPrefix = `${targetDir}/`;
+
   let fileCount = 0;
   for (const { path: entryPath, data: entryData } of rawEntries) {
     const relativePath = commonPrefix
@@ -223,6 +246,11 @@ async function installViaZipDownload(zipUrl, targetDir, context) {
     if (!relativePath) continue;
 
     const fullPath = `${targetDir}/${relativePath}`;
+    // Skip any entry whose resolved path escapes targetDir.
+    if (!fullPath.startsWith(containmentPrefix)) {
+      if (publish) publish(`Skipping unsafe plugin entry: ${entryPath}`, 0.935);
+      continue;
+    }
     const parentDir = fullPath.substring(0, fullPath.lastIndexOf("/"));
     if (parentDir && parentDir !== targetDir) {
       rawPhp.mkdirTree(parentDir);
@@ -246,8 +274,21 @@ async function runMoodleUpgrade(
 ) {
   if (publish) publish("Running Moodle upgrade to register plugin.", 0.945);
 
-  const component = `${pluginType}_${pluginName}`;
-  const safeDir = targetDir.replaceAll("'", "\\'");
+  // pluginName is user-supplied and is interpolated (via `component`) into
+  // generated PHP. resolvePluginDir already rejects invalid names before any
+  // file extraction; this is defense-in-depth in case runMoodleUpgrade is ever
+  // reached with an unvalidated name.
+  if (!VALID_PLUGIN_NAME.test(pluginName)) {
+    throw new Error(
+      `installMoodlePlugin: invalid plugin name '${pluginName}'. ` +
+        "Plugin names must match /^[a-z][a-z0-9_]*$/.",
+    );
+  }
+
+  // Both values are escaped for a single-quoted PHP literal (escapePhp handles
+  // backslashes and single quotes) before interpolation.
+  const component = escapePhp(`${pluginType}_${pluginName}`);
+  const safeDir = escapePhp(targetDir);
 
   const base = webRoot || MOODLE_ROOT;
   const code = `<?php

--- a/src/remote/main.js
+++ b/src/remote/main.js
@@ -265,7 +265,7 @@ function ensureRemoteServiceWorkerControl(scopeId, runtimeId) {
 }
 
 async function waitForPhpWorkerReady(scopeId, runtimeId, worker) {
-  await new Promise((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     const timeoutId = window.setTimeout(() => {
       reject(
         new Error(
@@ -295,7 +295,9 @@ async function waitForPhpWorkerReady(scopeId, runtimeId, worker) {
 
       window.clearTimeout(timeoutId);
       worker.removeEventListener("message", onWorkerMessage);
-      resolve();
+      // Resolve with the message so callers can read the worker's
+      // best-known initial landing path (e.g. the blueprint landingPage).
+      resolve(message);
     };
 
     worker.addEventListener("message", onWorkerMessage);
@@ -617,9 +619,16 @@ async function bootstrapRemote() {
       });
     });
   }
+  // Tracks whether the iframe has been navigated yet. The initial
+  // navigation triggers bootstrap (the worker boots on the first PHP
+  // request), so the worker's "ready" shell message — which carries the
+  // authoritative post-bootstrap path — can only arrive AFTER this first
+  // navigation. The "ready" handler therefore corrects the path only when
+  // bootstrap discovers a genuinely different one, avoiding a redundant
+  // second navigation when the initial path was already correct.
+  let frameNavigated = false;
   // Listen to the shell channel so we can pick up bootstrap progress
   // messages from the worker and display them on the loading overlay.
-  let readyNavigated = false;
   const shellChannel = new BroadcastChannel(createShellChannel(scopeId));
   shellChannel.addEventListener("message", (event) => {
     const msg = event.data;
@@ -632,15 +641,18 @@ async function bootstrapRemote() {
     if (msg?.kind === "ready") {
       setRemoteProgress(msg.detail, 1);
       // If bootstrap returns a readyPath (e.g. "/my/" after auto-login),
-      // override the stale path from the URL so we don't navigate to
-      // a previous session's install.php or other outdated path.
+      // override the stale path so we don't sit on a previous session's
+      // install.php or other outdated path. Only force-navigate when it
+      // differs from where we already pointed the frame — when the initial
+      // navigation already used the correct path, this is a no-op and the
+      // frame is navigated exactly once.
       if (msg.path && msg.path !== activePath) {
         activePath = msg.path;
-        readyNavigated = true;
         navigateFrame(scopeId, selection.runtimeId, activePath, {
           force: true,
         });
       }
+      frameNavigated = true;
     }
   });
 
@@ -662,7 +674,7 @@ async function bootstrapRemote() {
       profile,
     },
   });
-  await workerReadyPromise;
+  const workerReadyMessage = await workerReadyPromise;
 
   saveSessionState(scopeId, {
     runtimeId: selection.runtimeId,
@@ -671,10 +683,24 @@ async function bootstrapRemote() {
 
   bindShellCommands(scopeId, selection.runtimeId);
   bindFrameNavigation(scopeId, selection.runtimeId);
-  // Navigate to the requested path only if the ready handler hasn't
-  // already navigated to a fresh readyPath from bootstrap. This avoids
-  // a wasted PHP request to a stale path from a previous session.
-  if (!readyNavigated) {
+  // The shell already resolves `requestedPath` to the user's intended path
+  // (a restored deep-link, or the blueprint landingPage / configured
+  // landingPath on a cold boot), so it is the best target for the first
+  // navigation. Only fall back to the worker's pre-bootstrap landing-page
+  // hint when no explicit path was requested ("/"), so we don't kick the
+  // first PHP request at a default root that bootstrap will only redirect
+  // away from. This first navigation also triggers bootstrap.
+  const initialPath =
+    requestedPath && requestedPath !== "/"
+      ? requestedPath
+      : workerReadyMessage?.initialPath || config.landingPath || requestedPath;
+  activePath = initialPath;
+  // The initial navigation is what triggers bootstrap, so the worker's
+  // "ready" message (carrying the authoritative post-bootstrap path) can
+  // only arrive afterwards — `frameNavigated` is therefore normally false
+  // here and the initial navigation runs. The guard is defensive: if
+  // "ready" somehow already fired and navigated, skip a redundant nav.
+  if (!frameNavigated) {
     navigateFrame(scopeId, selection.runtimeId, activePath);
   }
   setRemoteProgress("Loading Moodle…", 0.98);

--- a/src/runtime/bootstrap.js
+++ b/src/runtime/bootstrap.js
@@ -2040,6 +2040,20 @@ async function runProvisioningCheck(php, webRoot) {
   }
 }
 
+/**
+ * Each install stage script emits a language-independent `stage:<id>:ok`
+ * marker via plain echo (see createInstallRunnerPhp, `echo 'stage:' . $stage
+ * . ':ok'`) only when the stage runs to completion. A failed stage aborts via
+ * cli_error()/die() or an uncaught Throwable BEFORE that marker is printed,
+ * yet the WASM CGI request still returns HTTP 200 — so the marker's presence,
+ * not the HTTP status, is the authoritative success signal. We must NOT rely
+ * on the localized `cliinstallfinished` string ("Installation completed
+ * successfully." in English): it varies per install language.
+ */
+function stageSuccessMarker(stageId) {
+  return `stage:${stageId}:ok`;
+}
+
 async function runCliProvisioning(php, publish, webRoot) {
   const stages = [
     { id: "core", label: "Installing Moodle core schema." },
@@ -2049,6 +2063,7 @@ async function runCliProvisioning(php, publish, webRoot) {
   ];
 
   const outputs = [];
+  const missingStages = [];
   for (const [index, stage] of stages.entries()) {
     const stageStart = performance.now();
     publish(stage.label, 0.89 + index * 0.01);
@@ -2061,13 +2076,17 @@ async function runCliProvisioning(php, publish, webRoot) {
     const stageMs = Math.round(performance.now() - stageStart);
     publish(`${stage.label} [${stageMs}ms]`, 0.89 + (index + 0.5) * 0.01);
     outputs.push({ stage: stage.id, output });
+    if (!output.includes(stageSuccessMarker(stage.id))) {
+      missingStages.push(stage.id);
+    }
   }
 
   return {
     output: outputs
       .map((entry) => `# ${entry.stage}\n${entry.output}`)
       .join("\n"),
-    errorOutput: "",
+    missingStages,
+    succeeded: missingStages.length === 0,
   };
 }
 
@@ -2478,21 +2497,32 @@ export async function bootstrapMoodle({
     );
   } else if (hasSavedInstallState) {
     publish("Checking whether Moodle is already installed.", 0.87);
-    installState = await runProvisioningCheck(php, webRoot);
-    if (installState.error) {
+    // A non-JSON / failed provisioning check must NOT abort the whole boot:
+    // fall through to snapshot load / fresh CLI install, exactly like the
+    // structurally identical no-marker branch below.
+    try {
+      installState = await runProvisioningCheck(php, webRoot);
+      if (installState.error) {
+        publish(
+          `Provisioning check failed: ${installState.error.type}: ${installState.error.message}`,
+          0.88,
+        );
+      } else if (installState.installed) {
+        publish("Moodle installation detected from the config table.", 0.885);
+        await writeJsonFile(php, installStatePath, {
+          ...manifestState,
+          dbName,
+          installed: true,
+          updatedAt: nowIso(),
+        });
+        installMarkerMatches = true;
+      }
+    } catch {
+      installState = null;
       publish(
-        `Provisioning check failed: ${installState.error.type}: ${installState.error.message}`,
+        "Provisioning check failed — will proceed with fresh install.",
         0.88,
       );
-    } else if (installState.installed) {
-      publish("Moodle installation detected from the config table.", 0.885);
-      await writeJsonFile(php, installStatePath, {
-        ...manifestState,
-        dbName,
-        installed: true,
-        updatedAt: nowIso(),
-      });
-      installMarkerMatches = true;
     }
   } else {
     publish(
@@ -2554,20 +2584,24 @@ export async function bootstrapMoodle({
         publish,
         webRoot,
       );
-      if (provisioningResult.errorOutput.trim()) {
-        publish(
-          `CLI installer stderr: ${provisioningResult.errorOutput.slice(0, 400)}`,
-          0.9,
+      // A failed CLI install (cli_error/Throwable) still returns HTTP 200 from
+      // the WASM CGI runtime, so the per-stage `stage:<id>:ok` markers — not the
+      // HTTP status — tell us whether each stage completed. If any marker is
+      // missing the install is broken; throw WITHOUT writing the install marker
+      // so we never persist {installed:true} over a half-built database.
+      if (!provisioningResult.succeeded) {
+        // Surface any fatal-looking lines from the real stdout to make the
+        // failure diagnosable (this heuristic only enriches the message — the
+        // missing-marker check above is what actually decides failure).
+        const fatalMatch = provisioningResult.output.match(
+          /^.*(?:fatal error|exception|cli_error|throwable|unable to|failed).*$/imu,
         );
-      }
-      if (
-        /fatal error|warning|exception|error/iu.test(
-          provisioningResult.errorOutput,
-        ) &&
-        !/cliinstallfinished/iu.test(provisioningResult.output)
-      ) {
+        const detail = fatalMatch
+          ? fatalMatch[0].trim()
+          : "no fatal line found";
         throw new Error(
-          `Moodle CLI provisioning failed: ${provisioningResult.errorOutput || provisioningResult.output}`,
+          `Moodle CLI provisioning failed (incomplete stages: ${provisioningResult.missingStages.join(", ")}; ${detail}). ` +
+            `Output: ${provisioningResult.output.slice(-1200)}`,
         );
       }
       await writeJsonFile(php, installStatePath, {

--- a/src/runtime/manifest.js
+++ b/src/runtime/manifest.js
@@ -48,8 +48,24 @@ export function buildFallbackManifestUrl(appBaseUrl) {
 }
 
 /**
- * Resolve the manifest URL for a given branch, falling back to latest.json
- * if the branch-specific manifest does not exist.
+ * Resolve the manifest URL for a given branch.
+ *
+ * The branch-specific manifest is preferred. Falling back to latest.json is
+ * only safe when the branch manifest is DEFINITIVELY absent (HTTP 404):
+ * latest.json may point at a different branch with a different webRoot
+ * (e.g. `/www/moodle` vs `/www/moodle/public`), and the caller derives
+ * webRoot from the *requested* branch — so extracting a different-branch
+ * bundle would produce a missing `public/` docroot and a code-vs-DB schema
+ * mismatch. Therefore:
+ *   - transient/network HEAD failures are retried, then propagated (never
+ *     silently downgraded to the fallback);
+ *   - a non-404 non-OK status is propagated (it is not proof of absence);
+ *   - on a real 404, the fallback manifest is fetched and its `channel`/
+ *     `release` must match the requested branch before it is accepted.
+ *
+ * @param {string} moodleBranch The requested Moodle branch (e.g. "main").
+ * @param {string} appBaseUrl   Base URL used to build manifest URLs.
+ * @returns {Promise<string>} The resolved manifest URL.
  */
 export async function resolveManifestUrl(moodleBranch, appBaseUrl) {
   const branchUrl = buildBranchManifestUrl(moodleBranch, appBaseUrl);
@@ -60,19 +76,74 @@ export async function resolveManifestUrl(moodleBranch, appBaseUrl) {
     return branchUrl;
   }
 
-  try {
-    const response = await fetch(branchUrl, {
-      method: "HEAD",
-      cache: "no-store",
-    });
+  // Probe the branch-specific manifest. Retry transient failures so a single
+  // flaky HEAD does not cause a wrong-branch fallback.
+  const maxAttempts = 3;
+  let lastError = null;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    let response;
+    try {
+      response = await fetch(branchUrl, { method: "HEAD", cache: "no-store" });
+    } catch (error) {
+      // Network error — transient. Retry, then propagate if it never recovers.
+      lastError = error;
+      continue;
+    }
+
     if (response.ok) {
       return branchUrl;
     }
-  } catch {
-    // network error — fall through to fallback
+
+    // A definitive 404 means the branch manifest genuinely does not exist:
+    // this is the only case where falling back is safe.
+    if (response.status === 404) {
+      return await resolveVerifiedFallbackUrl(moodleBranch, fallbackUrl);
+    }
+
+    // Any other non-OK status (e.g. 403/500/503) is NOT proof of absence.
+    // Treat it as transient: retry, then propagate.
+    lastError = new Error(
+      `Manifest probe for ${moodleBranch} failed: ${response.status} ${response.statusText}`,
+    );
   }
 
-  return fallbackUrl;
+  throw (
+    lastError ||
+    new Error(`Unable to probe manifest for branch ${moodleBranch}`)
+  );
+}
+
+/**
+ * Fetch the fallback manifest and confirm it actually corresponds to the
+ * requested branch before allowing it to be used. If it does not match, the
+ * fallback is unusable (its webRoot would be incompatible) and we propagate
+ * an error rather than extract a wrong-branch bundle.
+ */
+async function resolveVerifiedFallbackUrl(moodleBranch, fallbackUrl) {
+  const fallbackManifest = await fetchManifest(fallbackUrl);
+  if (manifestMatchesBranch(fallbackManifest, moodleBranch)) {
+    return fallbackUrl;
+  }
+
+  throw new Error(
+    `Branch manifest for ${moodleBranch} not found and fallback manifest ` +
+      `(channel: ${fallbackManifest.channel ?? "unknown"}, release: ` +
+      `${fallbackManifest.release ?? "unknown"}) does not match the requested ` +
+      `branch — refusing to extract a wrong-branch bundle under an ` +
+      `incompatible webRoot.`,
+  );
+}
+
+/**
+ * Returns true when the manifest's channel (preferred) corresponds to the
+ * requested branch. Manifests identify their branch via the `channel` field
+ * (e.g. "MOODLE_500_STABLE", "main").
+ */
+function manifestMatchesBranch(manifest, moodleBranch) {
+  if (!manifest || !moodleBranch) {
+    return false;
+  }
+  return manifest.channel === moodleBranch;
 }
 
 export { resolveBootstrapArchive };

--- a/sw.js
+++ b/sw.js
@@ -381,6 +381,21 @@ function getScopedBasePath(scopeId, runtimeId) {
   return withAppBasePath(`/playground/${scopeId}/${runtimeId}`);
 }
 
+// Build a cache key for the shared scoped-static cache that is namespaced by
+// scope AND runtime. Many Moodle assets (theme CSS, /pix svgs, fonts) are served
+// without a revision in their URL, so keying on the prefix-stripped requestPath
+// alone would make two runtimes / version switches collide on the same entry and
+// serve stale cross-runtime content. Including scopeId + runtimeId keeps each
+// runtime's assets isolated within the single global cache.
+function buildScopedCacheKey(origin, scopeId, runtimeId, requestPath) {
+  const queryIndex = requestPath.indexOf("?");
+  const pathPart = queryIndex === -1 ? requestPath : requestPath.slice(0, queryIndex);
+  const searchPart = queryIndex === -1 ? "" : requestPath.slice(queryIndex);
+  const normalizedPath = pathPart.startsWith("/") ? pathPart : `/${pathPart}`;
+  const scopedPath = `/playground/${scopeId}/${runtimeId}${normalizedPath}`.replace(/\/{2,}/gu, "/");
+  return new URL(`${scopedPath}${searchPart}`, origin).toString();
+}
+
 function decodeHtmlAttributeEntities(value) {
   return value
     .replace(/&#x([0-9a-f]+);/giu, (_, hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
@@ -461,7 +476,12 @@ function rewriteHtmlDocument(html, scope) {
 
   let result = html.replace(
     /((?:href|src|action|data-[\w-]*url|data-url|data-action)=["'])([^"']*)(["'])/giu,
-    (match, prefix, rawValue, suffix) => `${prefix}${rewriteHtmlAttributeUrl(rawValue, scope)}${suffix}`,
+    // rewriteHtmlAttributeUrl returns a *decoded* URL (entities turned back into
+    // raw &, ", <, > characters). Re-encode it for HTML attribute context before
+    // interpolating it back between the quotes, otherwise a decoded value
+    // containing a quote could close the attribute early and inject HTML into
+    // the playground iframe (reflected XSS).
+    (match, prefix, rawValue, suffix) => `${prefix}${escapeHtml(rewriteHtmlAttributeUrl(rawValue, scope))}${suffix}`,
   );
 
   // Rewrite M.cfg.wwwroot in inline <script> blocks so Moodle's JavaScript
@@ -678,7 +698,7 @@ self.addEventListener("fetch", (event) => {
         && (isScopedStaticAsset(requestPath) || isCacheablePhpAsset(pathOnly))
       ) {
         const scopedCache = await caches.open(SCOPED_STATIC_CACHE);
-        const cacheKey = new URL(requestPath, url.origin).toString();
+        const cacheKey = buildScopedCacheKey(url.origin, scopeId, runtimeId, requestPath);
         const cached = await scopedCache.match(cacheKey);
         if (cached) {
           return cached;

--- a/tests/blueprint/moodle-plugins.test.js
+++ b/tests/blueprint/moodle-plugins.test.js
@@ -348,6 +348,138 @@ describe("ZIP download strategy", () => {
   });
 });
 
+describe("pluginName path-traversal is rejected before any file write", () => {
+  const pluginHandler = getStepHandler("installMoodlePlugin");
+  const themeHandler = getStepHandler("installTheme");
+
+  function createPhpMock() {
+    const writes = [];
+    const mkdirs = [];
+    const runCalls = [];
+    const rawPhp = {
+      mkdirTree(path) {
+        mkdirs.push(path);
+      },
+      writeFile(path, data) {
+        writes.push([path, data]);
+      },
+    };
+    return {
+      writes,
+      mkdirs,
+      runCalls,
+      php: {
+        _php: rawPhp,
+        async run(code) {
+          runCalls.push(code);
+          return { text: '{"ok":true}', errors: "" };
+        },
+      },
+    };
+  }
+
+  const traversalNames = ["../../admin/cli", "..", "../x", "a/../b"];
+
+  for (const evilName of traversalNames) {
+    it(`installMoodlePlugin rejects pluginName '${evilName}' with no fetch/write`, async () => {
+      const originalFetch = globalThis.fetch;
+      let fetchCount = 0;
+      globalThis.fetch = async () => {
+        fetchCount++;
+        return new Response(decodeBase64Bytes(SAMPLE_PLUGIN_ZIP_BASE64), {
+          status: 200,
+          headers: { "content-type": "application/zip" },
+        });
+      };
+      const { php, writes, mkdirs, runCalls } = createPhpMock();
+
+      try {
+        await assert.rejects(
+          () =>
+            pluginHandler(
+              {
+                pluginType: "mod",
+                pluginName: evilName,
+                url: "https://example.com/plugin.zip",
+              },
+              { php },
+            ),
+          /invalid plugin name/i,
+        );
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+
+      // Validation must happen before resolvePluginDir builds a poisoned target
+      // and before any download, extraction, or upgrade.
+      assert.strictEqual(fetchCount, 0, "must not download a ZIP");
+      assert.strictEqual(writes.length, 0, "must not write any files");
+      assert.strictEqual(mkdirs.length, 0, "must not create any directories");
+      assert.strictEqual(runCalls.length, 0, "must not run any PHP");
+    });
+
+    it(`installTheme rejects pluginName '${evilName}' with no fetch/write`, async () => {
+      const originalFetch = globalThis.fetch;
+      let fetchCount = 0;
+      globalThis.fetch = async () => {
+        fetchCount++;
+        return new Response(decodeBase64Bytes(SAMPLE_THEME_ZIP_BASE64), {
+          status: 200,
+          headers: { "content-type": "application/zip" },
+        });
+      };
+      const { php, writes, mkdirs, runCalls } = createPhpMock();
+
+      try {
+        await assert.rejects(
+          () =>
+            themeHandler(
+              {
+                pluginName: evilName,
+                url: "https://example.com/theme.zip",
+              },
+              { php },
+            ),
+          /invalid plugin name/i,
+        );
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+
+      assert.strictEqual(fetchCount, 0, "must not download a ZIP");
+      assert.strictEqual(writes.length, 0, "must not write any files");
+      assert.strictEqual(mkdirs.length, 0, "must not create any directories");
+      assert.strictEqual(runCalls.length, 0, "must not run any PHP");
+    });
+  }
+
+  it("auto-detected valid names still install (happy path unaffected)", async () => {
+    const originalFetch = globalThis.fetch;
+    const { php, writes } = createPhpMock();
+    globalThis.fetch = async () =>
+      new Response(decodeBase64Bytes(SAMPLE_PLUGIN_ZIP_BASE64), {
+        status: 200,
+        headers: { "content-type": "application/zip" },
+      });
+
+    try {
+      await pluginHandler(
+        {
+          url: "https://github.com/brickfield/moodle-mod_board/archive/refs/heads/main.zip",
+        },
+        { php },
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    assert.deepEqual(writes.map(([path]) => path).sort(), [
+      "/www/moodle/mod/board/classes/example.php",
+      "/www/moodle/mod/board/version.php",
+    ]);
+  });
+});
+
 describe("proxy helpers", () => {
   it("detects GitHub ZIP URLs that should be proxied", () => {
     assert.equal(

--- a/tests/blueprint/parser.test.js
+++ b/tests/blueprint/parser.test.js
@@ -35,6 +35,24 @@ describe("parseBlueprint", () => {
     assert.deepStrictEqual(result.steps, []);
   });
 
+  it("parses data: URLs with a charset parameter and base64", () => {
+    const obj = { steps: [{ step: "login" }] };
+    const b64 = Buffer.from(JSON.stringify(obj)).toString("base64");
+    const result = parseBlueprint(
+      `data:application/json;charset=utf-8;base64,${b64}`,
+    );
+    assert.deepStrictEqual(result.steps, [{ step: "login" }]);
+  });
+
+  it("parses data: URLs with a charset parameter without base64", () => {
+    const obj = { steps: [] };
+    const encoded = encodeURIComponent(JSON.stringify(obj));
+    const result = parseBlueprint(
+      `data:application/json;charset=utf-8,${encoded}`,
+    );
+    assert.deepStrictEqual(result.steps, []);
+  });
+
   it("throws on null input", () => {
     assert.throws(() => parseBlueprint(null), /null or undefined/);
   });

--- a/tests/blueprint/php-helpers.test.js
+++ b/tests/blueprint/php-helpers.test.js
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  escapePhp,
   phpAddModule,
   phpCreateCategory,
   phpCreateCourse,
@@ -68,6 +69,54 @@ describe("PHP helpers: escaping", () => {
   it("escapes backslashes", () => {
     const script = phpCreateCategory({ name: "path\\to\\cat" });
     assert.ok(script.includes("path\\\\to\\\\cat"));
+  });
+});
+
+describe("PHP helpers: escapePhp (single-quoted context)", () => {
+  it("escapes backslash and single quote only", () => {
+    assert.strictEqual(escapePhp("a'b"), "a\\'b");
+    assert.strictEqual(escapePhp("a\\b"), "a\\\\b");
+  });
+
+  it("escapes a backslash before a quote correctly (no double-escape)", () => {
+    // Input is a single backslash followed by a single quote: \'
+    // Expected output: backslash escaped (\\) then quote escaped (\') => \\\'
+    assert.strictEqual(escapePhp("\\'"), "\\\\\\'");
+  });
+
+  it("preserves real newlines verbatim (does NOT emit literal \\n)", () => {
+    const out = escapePhp("line1\nline2");
+    // The output must contain an actual newline character, not a backslash-n.
+    assert.ok(out.includes("\n"), "newline must be preserved");
+    assert.ok(!out.includes("\\n"), "must not emit literal backslash-n");
+    assert.strictEqual(out, "line1\nline2");
+  });
+
+  it("preserves carriage returns verbatim (does NOT emit literal \\r)", () => {
+    const out = escapePhp("a\r\nb");
+    assert.ok(out.includes("\r"), "CR must be preserved");
+    assert.ok(!out.includes("\\r"), "must not emit literal backslash-r");
+    assert.strictEqual(out, "a\r\nb");
+  });
+
+  it("strips null bytes rather than emitting literal \\0", () => {
+    const out = escapePhp("a\0b");
+    assert.strictEqual(out, "ab");
+    assert.ok(!out.includes("\0"));
+    assert.ok(!out.includes("\\0"));
+  });
+});
+
+describe("PHP helpers: multi-line blueprint text", () => {
+  it("keeps multi-line course summaries intact (no \\n corruption)", () => {
+    const script = phpCreateCourse({
+      fullname: "Course",
+      shortname: "C1",
+      summary: "Line one\nLine two\nLine three",
+    });
+    // The summary literal must carry real newlines, not the two-char \n.
+    assert.ok(script.includes("Line one\nLine two\nLine three"));
+    assert.ok(!script.includes("Line one\\nLine two"));
   });
 });
 
@@ -300,5 +349,60 @@ describe("PHP helpers: addModule", () => {
     // Should only have one require
     const requireCount = (script.match(/require\(/g) || []).length;
     assert.strictEqual(requireCount, 1);
+  });
+
+  it("emits valid customField keys as PHP properties", () => {
+    const script = phpAddModule({
+      module: "exeweb",
+      course: "C1",
+      section: 1,
+      name: "Test",
+      exeorigin: "online",
+      revision: 3,
+      _flag: true,
+    });
+    assert.ok(script.includes("$moduleInfo->exeorigin = 'online';"));
+    assert.ok(script.includes("$moduleInfo->revision = 3;"));
+    assert.ok(script.includes("$moduleInfo->_flag = 1;"));
+  });
+
+  it("skips a malicious customField key (PHP injection via identifier)", () => {
+    const evilKey = 'x=1;system("id");$y';
+    const script = phpAddModule({
+      module: "exeweb",
+      course: "C1",
+      section: 1,
+      name: "Test",
+      [evilKey]: "payload",
+      revision: 7,
+    });
+    // The injected statement must not appear anywhere in the generated PHP.
+    assert.ok(
+      !script.includes('system("id")'),
+      "must not interpolate an injected statement",
+    );
+    assert.ok(!script.includes(evilKey), "must not emit the raw evil key");
+    assert.ok(!script.includes("payload"), "must not emit the skipped value");
+    // A legitimate sibling key is still emitted.
+    assert.ok(script.includes("$moduleInfo->revision = 7;"));
+  });
+
+  it("skips customField keys with dashes, dots, or spaces", () => {
+    const script = phpAddModule({
+      module: "exeweb",
+      course: "C1",
+      section: 1,
+      name: "Test",
+      "bad-key": "v1",
+      "bad.key": "v2",
+      "bad key": "v3",
+      "9leading": "v4",
+      good_key: "v5",
+    });
+    assert.ok(!script.includes("v1"));
+    assert.ok(!script.includes("v2"));
+    assert.ok(!script.includes("v3"));
+    assert.ok(!script.includes("v4"));
+    assert.ok(script.includes("$moduleInfo->good_key = 'v5';"));
   });
 });

--- a/tests/blueprint/resources.test.js
+++ b/tests/blueprint/resources.test.js
@@ -60,4 +60,44 @@ describe("ResourceRegistry", () => {
     const text = await registry.resolveText("@file");
     assert.strictEqual(text, content);
   });
+
+  it("resolves data-url resources with a charset parameter and base64", async () => {
+    const content = "Hi";
+    const b64 = Buffer.from(content).toString("base64");
+    const registry = new ResourceRegistry({
+      file: { "data-url": `data:text/plain;charset=utf-8;base64,${b64}` },
+    });
+    const text = await registry.resolveText("@file");
+    assert.strictEqual(text, content);
+  });
+
+  it("resolves data-url resources with a charset parameter without base64", async () => {
+    const content = "{}";
+    const encoded = encodeURIComponent(content);
+    const registry = new ResourceRegistry({
+      file: { "data-url": `data:application/json;charset=utf-8,${encoded}` },
+    });
+    const text = await registry.resolveText("@file");
+    assert.strictEqual(text, content);
+  });
+
+  it("resolves data-url resources without a media type", async () => {
+    const content = "plain payload";
+    const encoded = encodeURIComponent(content);
+    const registry = new ResourceRegistry({
+      file: { "data-url": `data:,${encoded}` },
+    });
+    const text = await registry.resolveText("@file");
+    assert.strictEqual(text, content);
+  });
+
+  it("throws on malformed data: URL with no comma", async () => {
+    const registry = new ResourceRegistry({
+      file: { "data-url": "data:text/plain;base64" },
+    });
+    await assert.rejects(
+      () => registry.resolve("@file"),
+      /Malformed data: URL/,
+    );
+  });
 });

--- a/tests/blueprint/steps.test.js
+++ b/tests/blueprint/steps.test.js
@@ -1,9 +1,20 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { sanitizeArchivePath } from "../../lib/moodle-loader.js";
 import {
   getRegisteredStepNames,
   getStepHandler,
 } from "../../src/blueprint/steps/index.js";
+
+// A small but valid ZIP (shared with moodle-plugins.test.js) used to drive the
+// plugin install handler past the download/extract phase into runMoodleUpgrade
+// (where plugin-name validation lives) without hitting the network.
+const SAMPLE_PLUGIN_ZIP_BASE64 =
+  "UEsDBBQAAAAIAHcBgVyusmujBwAAAAUAAAAhAAAAbW9vZGxlLW1vZF9ib2FyZC1tYWluL3ZlcnNpb24ucGhws7EvyCgAAFBLAwQUAAAACAB3AYFczmE/Ew8AAAANAAAAKQAAAG1vb2RsZS1tb2RfYm9hcmQtbWFpbi9jbGFzc2VzL2V4YW1wbGUucGhws7EvyChQSE3OyFcwtAYAUEsBAhQDFAAAAAgAdwGBXK6ya6MHAAAABQAAACEAAAAAAAAAAAAAAIABAAAAAG1vb2RsZS1tb2RfYm9hcmQtbWFpbi92ZXJzaW9uLnBocFBLAQIUAxQAAAAIAHcBgVzOYT8TDwAAAA0AAAApAAAAAAAAAAAAAACAAUYAAABtb29kbGUtbW9kX2JvYXJkLW1haW4vY2xhc3Nlcy9leGFtcGxlLnBocFBLBQYAAAAAAgACAKYAAACcAAAAAAA=";
+
+function decodeBase64Bytes(base64) {
+  return Uint8Array.from(Buffer.from(base64, "base64"));
+}
 
 describe("step registry", () => {
   it("has all expected step names registered", () => {
@@ -101,5 +112,161 @@ describe("step registry", () => {
     assert.strictEqual(calls.length, 1);
     assert.ok(calls[0].includes("set_config('theme', 'moove'"));
     assert.ok(calls[0].includes("theme_reset_all_caches"));
+  });
+});
+
+describe("sanitizeArchivePath (ZIP-slip prevention)", () => {
+  it("passes through a normal relative path unchanged", () => {
+    assert.strictEqual(sanitizeArchivePath("a/b/c.php"), "a/b/c.php");
+  });
+
+  it("drops '.' and empty segments", () => {
+    assert.strictEqual(sanitizeArchivePath("./a//b/./c"), "a/b/c");
+  });
+
+  it("returns null for an empty or dot-only path", () => {
+    assert.strictEqual(sanitizeArchivePath(""), null);
+    assert.strictEqual(sanitizeArchivePath("."), null);
+    assert.strictEqual(sanitizeArchivePath("./"), null);
+  });
+
+  it("throws on a leading '..' traversal", () => {
+    assert.throws(
+      () => sanitizeArchivePath("../etc/passwd"),
+      /path traversal/i,
+    );
+  });
+
+  it("throws on an embedded '..' segment", () => {
+    assert.throws(() => sanitizeArchivePath("a/../../b"), /path traversal/i);
+  });
+
+  it("does not treat '..' inside a filename as traversal", () => {
+    // Only a whole segment equal to ".." is traversal; "..foo" is a real name.
+    assert.strictEqual(sanitizeArchivePath("a/..foo/b"), "a/..foo/b");
+  });
+});
+
+describe("unzip step handler (ZIP-slip containment)", () => {
+  const handler = getStepHandler("unzip");
+
+  function createPhpMock() {
+    const writes = [];
+    const rawPhp = {
+      mkdirTree() {},
+      writeFile(path, data) {
+        writes.push([path, data]);
+      },
+    };
+    return { writes, php: { _php: rawPhp } };
+  }
+
+  it("only writes entries that stay within the destination", async () => {
+    const { php, writes } = createPhpMock();
+    // Stub the resolved entries by intercepting resources.resolve to return
+    // ZIP bytes, then rely on readZipEntries' own sanitization. The known-good
+    // sample ZIP extracts two safe entries under a top-level dir.
+    const resources = {
+      async resolve() {
+        return decodeBase64Bytes(SAMPLE_PLUGIN_ZIP_BASE64);
+      },
+    };
+
+    await handler(
+      { destination: "/persist/moodledata/unzipped", data: "@dummy" },
+      { php, resources },
+    );
+
+    // Every written path must be under the destination prefix.
+    for (const [path] of writes) {
+      assert.ok(
+        path.startsWith("/persist/moodledata/unzipped/"),
+        `Write escaped destination: ${path}`,
+      );
+    }
+    assert.ok(writes.length > 0, "expected at least one safe write");
+  });
+});
+
+describe("installMoodlePlugin plugin-name validation (code injection guard)", () => {
+  const handler = getStepHandler("installMoodlePlugin");
+
+  function createPhpMock() {
+    const runCalls = [];
+    const rawPhp = {
+      mkdirTree() {},
+      writeFile() {},
+    };
+    return {
+      runCalls,
+      php: {
+        _php: rawPhp,
+        async run(code) {
+          runCalls.push(code);
+          return { text: '{"ok":true}', errors: "" };
+        },
+      },
+    };
+  }
+
+  it("rejects a malicious pluginName before generating upgrade PHP", async () => {
+    const originalFetch = globalThis.fetch;
+    const { php, runCalls } = createPhpMock();
+    globalThis.fetch = async () =>
+      new Response(decodeBase64Bytes(SAMPLE_PLUGIN_ZIP_BASE64), {
+        status: 200,
+        headers: { "content-type": "application/zip" },
+      });
+
+    try {
+      await assert.rejects(
+        () =>
+          handler(
+            {
+              pluginType: "mod",
+              pluginName: "evil', 'x'); evil();//",
+              url: "https://example.com/plugin.zip",
+            },
+            { php },
+          ),
+        /invalid plugin name/i,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    // The upgrade script must never have been generated/run for a bad name.
+    assert.strictEqual(runCalls.length, 0);
+  });
+
+  it("accepts a valid frankenstyle pluginName", async () => {
+    const originalFetch = globalThis.fetch;
+    const { php, runCalls } = createPhpMock();
+    globalThis.fetch = async () =>
+      new Response(decodeBase64Bytes(SAMPLE_PLUGIN_ZIP_BASE64), {
+        status: 200,
+        headers: { "content-type": "application/zip" },
+      });
+
+    try {
+      await handler(
+        {
+          pluginType: "mod",
+          pluginName: "board",
+          url: "https://example.com/plugin.zip",
+        },
+        { php },
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    // Upgrade ran, and the generated component string is exactly mod_board.
+    assert.strictEqual(runCalls.length, 1);
+    assert.ok(
+      runCalls[0].includes(
+        "playground_refresh_installed_plugin_cache('mod_board'",
+      ),
+    );
   });
 });

--- a/tests/runtime/manifest.test.js
+++ b/tests/runtime/manifest.test.js
@@ -4,7 +4,38 @@ import {
   buildFallbackManifestUrl,
   buildManifestState,
   fetchManifest,
+  resolveManifestUrl,
 } from "../../src/runtime/manifest.js";
+
+const APP_BASE = "https://example.com/pg/";
+const MAIN_BRANCH_URL = "https://example.com/pg/assets/manifests/main.json";
+const FALLBACK_URL = "https://example.com/pg/assets/manifests/latest.json";
+
+/**
+ * Install a fetch stub for the duration of `fn`. The handler receives
+ * `(url, init)` and returns a Response-like object (or throws to simulate a
+ * network error). Always restores the original fetch.
+ */
+async function withFetch(handler, fn) {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init = {}) => handler(String(url), init);
+  try {
+    return await fn();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+function jsonResponse(body) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    async json() {
+      return body;
+    },
+  };
+}
 
 describe("buildManifestState", () => {
   it("extracts state from manifest", () => {
@@ -67,5 +98,134 @@ describe("fetchManifest", () => {
     }
 
     assert.strictEqual(seenInit?.cache, "no-store");
+  });
+});
+
+describe("resolveManifestUrl", () => {
+  it("returns the branch URL when the HEAD probe succeeds", async () => {
+    const result = await withFetch(
+      (url, init) => {
+        assert.strictEqual(url, MAIN_BRANCH_URL);
+        assert.strictEqual(init.method, "HEAD");
+        return { ok: true, status: 200, statusText: "OK" };
+      },
+      () => resolveManifestUrl("main", APP_BASE),
+    );
+    assert.strictEqual(result, MAIN_BRANCH_URL);
+  });
+
+  it("falls back to latest.json only on a definitive 404 when channel matches", async () => {
+    const result = await withFetch(
+      (url, init) => {
+        if (init.method === "HEAD") {
+          assert.strictEqual(url, MAIN_BRANCH_URL);
+          return { ok: false, status: 404, statusText: "Not Found" };
+        }
+        // GET of the fallback manifest — channel matches the requested branch.
+        assert.strictEqual(url, FALLBACK_URL);
+        return jsonResponse({ channel: "main", release: "5.3dev" });
+      },
+      () => resolveManifestUrl("main", APP_BASE),
+    );
+    assert.strictEqual(result, FALLBACK_URL);
+  });
+
+  it("throws on a 404 when the fallback manifest is a different branch", async () => {
+    // latest.json points at MOODLE_500_STABLE (webRoot /www/moodle) but the
+    // request is for `main` (webRoot /www/moodle/public). Using it would
+    // extract a bundle with no public/ docroot — must refuse.
+    await assert.rejects(
+      () =>
+        withFetch(
+          (_url, init) => {
+            if (init.method === "HEAD") {
+              return { ok: false, status: 404, statusText: "Not Found" };
+            }
+            return jsonResponse({
+              channel: "MOODLE_500_STABLE",
+              release: "5.0.7",
+            });
+          },
+          () => resolveManifestUrl("main", APP_BASE),
+        ),
+      /does not match the requested branch/,
+    );
+  });
+
+  it("does NOT fall back on a transient network error — it propagates", async () => {
+    let headAttempts = 0;
+    await assert.rejects(
+      () =>
+        withFetch(
+          (_url, init) => {
+            if (init.method === "HEAD") {
+              headAttempts++;
+              throw new Error("network down");
+            }
+            // The fallback must never be fetched on a transient failure.
+            throw new Error("fallback should not be fetched");
+          },
+          () => resolveManifestUrl("main", APP_BASE),
+        ),
+      /network down/,
+    );
+    // Transient errors are retried before propagating.
+    assert.ok(headAttempts >= 2, `expected retries, got ${headAttempts}`);
+  });
+
+  it("retries a transient failure then succeeds on the branch URL", async () => {
+    let headAttempts = 0;
+    const result = await withFetch(
+      (_url, init) => {
+        if (init.method === "HEAD") {
+          headAttempts++;
+          if (headAttempts === 1) {
+            throw new Error("flaky");
+          }
+          return { ok: true, status: 200, statusText: "OK" };
+        }
+        throw new Error("fallback should not be fetched");
+      },
+      () => resolveManifestUrl("main", APP_BASE),
+    );
+    assert.strictEqual(result, MAIN_BRANCH_URL);
+    assert.strictEqual(headAttempts, 2);
+  });
+
+  it("does NOT fall back on a non-404 status (e.g. 503) — it propagates", async () => {
+    await assert.rejects(
+      () =>
+        withFetch(
+          (_url, init) => {
+            if (init.method === "HEAD") {
+              return {
+                ok: false,
+                status: 503,
+                statusText: "Service Unavailable",
+              };
+            }
+            throw new Error("fallback should not be fetched");
+          },
+          () => resolveManifestUrl("main", APP_BASE),
+        ),
+      /503/,
+    );
+  });
+
+  it("skips the probe when branch and fallback URLs are identical (default branch)", async () => {
+    // The default branch's manifest IS latest.json's channel, but buildManifestUrl
+    // uses the per-branch manifestFile, so they differ; verify the short-circuit
+    // path by pointing the requested branch at latest.json directly via an
+    // unknown branch (falls back to latest.json filename in buildManifestUrl).
+    let fetchCalled = false;
+    const result = await withFetch(
+      () => {
+        fetchCalled = true;
+        return { ok: true, status: 200, statusText: "OK" };
+      },
+      () => resolveManifestUrl("__unknown_branch__", APP_BASE),
+    );
+    assert.strictEqual(result, FALLBACK_URL);
+    assert.strictEqual(fetchCalled, false);
   });
 });

--- a/tests/shared/github-proxy-worker.test.js
+++ b/tests/shared/github-proxy-worker.test.js
@@ -305,4 +305,369 @@ describe("github-proxy-worker generic ?url= mode", () => {
     const body = await response.json();
     assert.match(body.error, /not a supported direct GitHub\/resource URL/i);
   });
+
+  it("rejects zip-like paths on non-allowlisted hosts (open proxy / SSRF)", async () => {
+    global.fetch = async () => {
+      throw new Error("should not fetch upstream");
+    };
+
+    const targets = [
+      "https://internal.corp/secret.zip",
+      "https://evil.example/archive/refs/heads/main.zip",
+      "https://attacker.test/zip/payload",
+      "https://example.com/downloadbuild/123/stable",
+    ];
+
+    for (const target of targets) {
+      const response = await worker.fetch(
+        new Request(`https://proxy.example/?url=${encodeURIComponent(target)}`),
+        {},
+      );
+
+      assert.equal(response.status, 400, `expected 400 for ${target}`);
+      const body = await response.json();
+      assert.match(body.error, /not a supported direct GitHub\/resource URL/i);
+    }
+  });
+
+  it("rejects private, loopback, and link-local hosts even with zip-like paths", async () => {
+    global.fetch = async () => {
+      throw new Error("should not fetch upstream");
+    };
+
+    const targets = [
+      "http://169.254.169.254/latest/meta-data/foo.zip",
+      "http://127.0.0.1/x.zip",
+      "http://localhost:6379/x.zip",
+      "http://10.0.0.5/internal.zip",
+      "http://172.16.4.4/internal.zip",
+      "http://192.168.1.1/internal.zip",
+      "http://0.0.0.0/x.zip",
+      "http://[::1]/x.zip",
+      "http://service.local/x.zip",
+    ];
+
+    for (const target of targets) {
+      const response = await worker.fetch(
+        new Request(`https://proxy.example/?url=${encodeURIComponent(target)}`),
+        {},
+      );
+
+      assert.equal(response.status, 400, `expected 400 for ${target}`);
+      const body = await response.json();
+      assert.match(body.error, /not a supported direct GitHub\/resource URL/i);
+    }
+  });
+
+  it("still allows FacturaScripts build downloads on the allowlisted host", async () => {
+    let upstreamRequest;
+    global.fetch = async (url, init = {}) => {
+      upstreamRequest = { url, init };
+      return new Response(new Uint8Array([0x50, 0x4b, 0x03, 0x04]), {
+        status: 200,
+        headers: { "Content-Type": "application/zip" },
+      });
+    };
+
+    const response = await worker.fetch(
+      new Request(
+        "https://proxy.example/?url=https://facturascripts.com/DownloadBuild/123/stable",
+      ),
+      {},
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(
+      upstreamRequest.url,
+      "https://facturascripts.com/DownloadBuild/123/stable",
+    );
+    assert.equal(response.headers.get("X-Playground-Cors-Proxy"), "true");
+    assert.deepEqual(
+      Array.from(new Uint8Array(await response.arrayBuffer())),
+      [0x50, 0x4b, 0x03, 0x04],
+    );
+  });
+});
+
+describe("github-proxy-worker redirect validation (SSRF)", () => {
+  it("blocks a redirect from an allowlisted host into an internal IP", async () => {
+    const calls = [];
+    global.fetch = async (url, init = {}) => {
+      calls.push({ url: String(url), init });
+      // omeka.org is allowlisted, but its (compromised/open-redirect) response
+      // tries to bounce the proxy into the AWS metadata endpoint.
+      return new Response(null, {
+        status: 302,
+        headers: { Location: "http://169.254.169.254/latest/meta-data/" },
+      });
+    };
+
+    const response = await worker.fetch(
+      new Request(
+        "https://proxy.example/?url=https://omeka.org/s/modules/ContactUs/",
+      ),
+      {},
+    );
+
+    assert.equal(response.status, 400);
+    const body = await response.json();
+    assert.match(body.error, /not an allowed proxy destination/i);
+    // Only the initial hop was issued; the internal target was never fetched.
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, "https://omeka.org/s/modules/ContactUs/");
+    assert.equal(calls[0].init.redirect, "manual");
+  });
+
+  it("blocks a redirect into a loopback host", async () => {
+    let calls = 0;
+    global.fetch = async () => {
+      calls++;
+      return new Response(null, {
+        status: 301,
+        headers: { Location: "http://127.0.0.1:6379/" },
+      });
+    };
+
+    const response = await worker.fetch(
+      new Request(
+        "https://proxy.example/?url=https://omeka.org/s/modules/ContactUs/",
+      ),
+      {},
+    );
+
+    assert.equal(response.status, 400);
+    assert.equal(calls, 1);
+  });
+
+  it("blocks a redirect into a host outside the generic allowlist", async () => {
+    let calls = 0;
+    global.fetch = async () => {
+      calls++;
+      return new Response(null, {
+        status: 302,
+        headers: { Location: "https://evil.example/payload" },
+      });
+    };
+
+    const response = await worker.fetch(
+      new Request(
+        "https://proxy.example/?url=https://omeka.org/s/modules/ContactUs/",
+      ),
+      {},
+    );
+
+    assert.equal(response.status, 400);
+    assert.equal(calls, 1);
+  });
+
+  it("follows a GitHub archive redirect into codeload.github.com", async () => {
+    const calls = [];
+    global.fetch = async (url, init = {}) => {
+      const u = String(url);
+      calls.push({ url: u, init });
+
+      if (u === "https://github.com/owner/repo/archive/refs/heads/main.zip") {
+        return new Response(null, {
+          status: 302,
+          headers: {
+            Location:
+              "https://codeload.github.com/owner/repo/zip/refs/heads/main",
+          },
+        });
+      }
+
+      if (u === "https://codeload.github.com/owner/repo/zip/refs/heads/main") {
+        return new Response(new Uint8Array([0x50, 0x4b, 0x03, 0x04]), {
+          status: 200,
+          headers: { "Content-Type": "application/zip" },
+        });
+      }
+
+      throw new Error(`unexpected url ${u}`);
+    };
+
+    const response = await worker.fetch(
+      new Request("https://proxy.example/?repo=owner/repo&branch=main"),
+      {},
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(calls.length, 2);
+    assert.equal(
+      calls[0].url,
+      "https://github.com/owner/repo/archive/refs/heads/main.zip",
+    );
+    assert.equal(calls[0].init.redirect, "manual");
+    assert.equal(
+      calls[1].url,
+      "https://codeload.github.com/owner/repo/zip/refs/heads/main",
+    );
+    assert.equal(response.headers.get("X-Playground-Cors-Proxy"), "true");
+    assert.deepEqual(
+      Array.from(new Uint8Array(await response.arrayBuffer())),
+      [0x50, 0x4b, 0x03, 0x04],
+    );
+  });
+
+  it("follows a GitHub release-asset redirect into objects.githubusercontent.com", async () => {
+    const calls = [];
+    global.fetch = async (url, init = {}) => {
+      const u = String(url);
+      calls.push({ url: u, init });
+
+      if (
+        u === "https://api.github.com/repos/owner/repo/releases/tags/v1.0.0"
+      ) {
+        return new Response(
+          JSON.stringify({
+            assets: [
+              {
+                name: "plugin.zip",
+                browser_download_url:
+                  "https://github.com/owner/repo/releases/download/v1.0.0/plugin.zip",
+              },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      if (
+        u ===
+        "https://github.com/owner/repo/releases/download/v1.0.0/plugin.zip"
+      ) {
+        return new Response(null, {
+          status: 302,
+          headers: {
+            Location:
+              "https://objects.githubusercontent.com/github-production-release-asset/plugin.zip",
+          },
+        });
+      }
+
+      if (
+        u ===
+        "https://objects.githubusercontent.com/github-production-release-asset/plugin.zip"
+      ) {
+        return new Response(new Uint8Array([0x50, 0x4b, 0x03, 0x04]), {
+          status: 200,
+          headers: { "Content-Type": "application/octet-stream" },
+        });
+      }
+
+      throw new Error(`unexpected url ${u}`);
+    };
+
+    const response = await worker.fetch(
+      new Request(
+        "https://proxy.example/?repo=owner/repo&release=v1.0.0&asset=plugin.zip",
+      ),
+      {},
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(
+      calls[calls.length - 1].url,
+      "https://objects.githubusercontent.com/github-production-release-asset/plugin.zip",
+    );
+    assert.deepEqual(
+      Array.from(new Uint8Array(await response.arrayBuffer())),
+      [0x50, 0x4b, 0x03, 0x04],
+    );
+  });
+
+  it("blocks a GitHub archive redirect into a non-GitHub host", async () => {
+    let calls = 0;
+    global.fetch = async (url) => {
+      calls++;
+      if (
+        String(url) ===
+        "https://github.com/owner/repo/archive/refs/heads/main.zip"
+      ) {
+        return new Response(null, {
+          status: 302,
+          headers: { Location: "http://169.254.169.254/latest/" },
+        });
+      }
+      throw new Error(`unexpected url ${url}`);
+    };
+
+    const response = await worker.fetch(
+      new Request("https://proxy.example/?repo=owner/repo&branch=main"),
+      {},
+    );
+
+    assert.equal(response.status, 400);
+    assert.equal(calls, 1);
+  });
+
+  it("caps the number of redirect hops", async () => {
+    let calls = 0;
+    global.fetch = async () => {
+      calls++;
+      // Always redirect to another allowlisted-but-distinct path on omeka.org.
+      return new Response(null, {
+        status: 302,
+        headers: { Location: `https://omeka.org/s/modules/hop-${calls}/` },
+      });
+    };
+
+    const response = await worker.fetch(
+      new Request(
+        "https://proxy.example/?url=https://omeka.org/s/modules/ContactUs/",
+      ),
+      {},
+    );
+
+    assert.equal(response.status, 400);
+    const body = await response.json();
+    assert.match(body.details, /too many redirects/i);
+    // Initial fetch + MAX_REDIRECT_HOPS (5) = 6 issued requests, then capped.
+    assert.equal(calls, 6);
+  });
+});
+
+describe("github-proxy-worker isPrivateOrLocalHost extras", () => {
+  it("rejects IPv4-mapped IPv6 loopback and link-local literals", async () => {
+    global.fetch = async () => {
+      throw new Error("should not fetch upstream");
+    };
+
+    const targets = [
+      "http://[::ffff:127.0.0.1]/x.zip",
+      "http://[::ffff:169.254.169.254]/latest/meta-data/foo.zip",
+      "http://[::ffff:7f00:1]/x.zip", // hex form of 127.0.0.1
+      "http://[::ffff:a9fe:a9fe]/x.zip", // hex form of 169.254.169.254
+      "http://[::ffff:10.0.0.5]/internal.zip",
+    ];
+
+    for (const target of targets) {
+      const response = await worker.fetch(
+        new Request(`https://proxy.example/?url=${encodeURIComponent(target)}`),
+        {},
+      );
+
+      assert.equal(response.status, 400, `expected 400 for ${target}`);
+    }
+  });
+
+  it("rejects the cloud metadata DNS name", async () => {
+    global.fetch = async () => {
+      throw new Error("should not fetch upstream");
+    };
+
+    const targets = [
+      "http://metadata.google.internal/computeMetadata/v1/x.zip",
+      "http://metadata/computeMetadata/v1/x.zip",
+    ];
+
+    for (const target of targets) {
+      const response = await worker.fetch(
+        new Request(`https://proxy.example/?url=${encodeURIComponent(target)}`),
+        {},
+      );
+
+      assert.equal(response.status, 400, `expected 400 for ${target}`);
+    }
+  });
 });

--- a/tests/shared/github-proxy-worker.test.js
+++ b/tests/shared/github-proxy-worker.test.js
@@ -291,6 +291,81 @@ describe("github-proxy-worker generic ?url= mode", () => {
     );
   });
 
+  it("proxies gitlab.com archive downloads", async () => {
+    let upstreamRequest;
+    global.fetch = async (url, init = {}) => {
+      upstreamRequest = { url, init };
+      return new Response(new Uint8Array([0x50, 0x4b, 0x03, 0x04]), {
+        status: 200,
+        headers: { "Content-Type": "application/zip" },
+      });
+    };
+
+    const response = await worker.fetch(
+      new Request(
+        "https://proxy.example/?url=https://gitlab.com/owner/repo/-/archive/main/repo-main.zip",
+      ),
+      {},
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(
+      upstreamRequest.url,
+      "https://gitlab.com/owner/repo/-/archive/main/repo-main.zip",
+    );
+    assert.equal(response.headers.get("X-Playground-Cors-Proxy"), "true");
+  });
+
+  it("proxies jsDelivr CDN resources on non-zip paths", async () => {
+    let upstreamRequest;
+    global.fetch = async (url, init = {}) => {
+      upstreamRequest = { url, init };
+      return new Response("console.log('hi');", {
+        status: 200,
+        headers: { "Content-Type": "application/javascript" },
+      });
+    };
+
+    const response = await worker.fetch(
+      new Request(
+        "https://proxy.example/?url=https://cdn.jsdelivr.net/gh/owner/repo@1.0.0/dist/file.js",
+      ),
+      {},
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(
+      upstreamRequest.url,
+      "https://cdn.jsdelivr.net/gh/owner/repo@1.0.0/dist/file.js",
+    );
+    assert.equal(response.headers.get("X-Playground-Cors-Proxy"), "true");
+  });
+
+  it("proxies data.jsdelivr.com package metadata API", async () => {
+    let upstreamRequest;
+    global.fetch = async (url, init = {}) => {
+      upstreamRequest = { url, init };
+      return new Response(JSON.stringify({ versions: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    const response = await worker.fetch(
+      new Request(
+        "https://proxy.example/?url=https://data.jsdelivr.com/v1/packages/gh/owner/repo",
+      ),
+      {},
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(
+      upstreamRequest.url,
+      "https://data.jsdelivr.com/v1/packages/gh/owner/repo",
+    );
+    assert.equal(response.headers.get("X-Playground-Cors-Proxy"), "true");
+  });
+
   it("still rejects unrelated direct URLs", async () => {
     global.fetch = async () => {
       throw new Error("should not fetch upstream");

--- a/tests/shared/moodle-loader.test.js
+++ b/tests/shared/moodle-loader.test.js
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  extractZipEntries,
+  sanitizeArchivePath,
+} from "../../lib/moodle-loader.js";
+import { strToU8, zipSync } from "../../vendor/fflate.js";
+
+describe("sanitizeArchivePath", () => {
+  it("passes a normal relative path through unchanged", () => {
+    assert.equal(sanitizeArchivePath("lib/setup.php"), "lib/setup.php");
+  });
+
+  it("drops '.' and empty segments", () => {
+    assert.equal(sanitizeArchivePath("a/./b//c"), "a/b/c");
+  });
+
+  it("strips a trailing slash (directory marker)", () => {
+    // Callers must detect directory entries BEFORE sanitizing, since the
+    // trailing slash is removed here.
+    assert.equal(sanitizeArchivePath(".git/"), ".git");
+  });
+
+  it("returns null for an empty or dot-only path", () => {
+    assert.equal(sanitizeArchivePath(""), null);
+    assert.equal(sanitizeArchivePath("./"), null);
+  });
+
+  it("throws on a '..' traversal segment", () => {
+    assert.throws(
+      () => sanitizeArchivePath("../etc/passwd"),
+      /path traversal/i,
+    );
+    assert.throws(() => sanitizeArchivePath("a/../../b"), /path traversal/i);
+  });
+});
+
+describe("extractZipEntries directory handling", () => {
+  it("skips directory entries so they do not leak as bare file paths", () => {
+    // Regression: sanitizeArchivePath strips trailing slashes, so a directory
+    // entry like "moodle/.git/" used to survive as a file ".git", colliding
+    // with the real ".git/config" file and breaking extraction with
+    // "Not a directory". Directory entries must be skipped before sanitizing.
+    const zip = zipSync({
+      "moodle/.git/": new Uint8Array(0),
+      "moodle/.git/config": strToU8("[core]\n"),
+      "moodle/.git/hooks/": new Uint8Array(0),
+      "moodle/lib/setup.php": strToU8("<?php\n"),
+    });
+
+    const entries = extractZipEntries(zip);
+    const paths = entries.map((e) => e.path);
+
+    // The single common leading folder "moodle/" is stripped.
+    assert.ok(!paths.includes(".git"), "directory entry leaked as a file");
+    assert.ok(
+      !paths.includes(".git/hooks"),
+      "nested dir entry leaked as a file",
+    );
+    assert.ok(
+      paths.includes(".git/config"),
+      "real file inside dir was dropped",
+    );
+    assert.ok(paths.includes("lib/setup.php"), "regular file was dropped");
+
+    // No extracted file path may also be a parent directory of another path.
+    for (const p of paths) {
+      for (const q of paths) {
+        assert.ok(
+          !(q.length > p.length && q.startsWith(`${p}/`)),
+          `path "${p}" collides with "${q}" (directory written as a file)`,
+        );
+      }
+    }
+  });
+
+  it("rejects ZIP-slip traversal entries while keeping safe files", () => {
+    const zip = zipSync({
+      "pkg/lib/ok.php": strToU8("<?php\n"),
+      "pkg/../../evil.php": strToU8("<?php /* escape */\n"),
+    });
+
+    const entries = extractZipEntries(zip);
+    const paths = entries.map((e) => e.path);
+
+    assert.ok(
+      paths.every((p) => !p.includes("..")),
+      "a traversal entry was not stripped",
+    );
+    assert.ok(
+      paths.some((p) => p.endsWith("ok.php")),
+      "the safe file should still be extracted",
+    );
+  });
+});

--- a/tests/sw/sw-helpers.test.js
+++ b/tests/sw/sw-helpers.test.js
@@ -146,6 +146,42 @@ function rewriteHtmlAttributeUrl(
   }
 }
 
+// Replicate escapeHtml from sw.js
+function escapeHtml(str) {
+  return String(str)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+// Replicate the attribute-rewrite step from rewriteHtmlDocument in sw.js: the
+// decoded, rewritten value must be re-encoded for HTML attribute context before
+// it is interpolated back between the quotes.
+function rewriteHtmlDocumentAttributes(html, scope) {
+  return html.replace(
+    /((?:href|src|action|data-[\w-]*url|data-url|data-action)=["'])([^"']*)(["'])/giu,
+    (_match, prefix, rawValue, suffix) =>
+      `${prefix}${escapeHtml(rewriteHtmlAttributeUrl(rawValue, scope))}${suffix}`,
+  );
+}
+
+// Replicate buildScopedCacheKey from sw.js
+function buildScopedCacheKey(origin, scopeId, runtimeId, requestPath) {
+  const queryIndex = requestPath.indexOf("?");
+  const pathPart =
+    queryIndex === -1 ? requestPath : requestPath.slice(0, queryIndex);
+  const searchPart = queryIndex === -1 ? "" : requestPath.slice(queryIndex);
+  const normalizedPath = pathPart.startsWith("/") ? pathPart : `/${pathPart}`;
+  const scopedPath =
+    `/playground/${scopeId}/${runtimeId}${normalizedPath}`.replace(
+      /\/{2,}/gu,
+      "/",
+    );
+  return new URL(`${scopedPath}${searchPart}`, origin).toString();
+}
+
 // Replicate extractScopedRuntime pattern from sw.js
 function extractScopedRuntime(pathname, search = "") {
   const match = pathname.match(/\/playground\/([^/]+)\/([^/]+)(\/.*)?$/u);
@@ -342,6 +378,121 @@ describe("rewriteHtmlAttributeUrl", () => {
         scope,
       ),
       "/moodle-playground/playground/main/php83-moodle50/course/edit.php?category=0",
+    );
+  });
+});
+
+describe("rewriteHtmlDocumentAttributes (attribute re-encoding)", () => {
+  const scope = {
+    origin: "https://ateeducacion.github.io",
+    scopeId: "main",
+    runtimeId: "php83-moodle50",
+    appBasePath: "/moodle-playground",
+  };
+
+  it("re-encodes & in rewritten query strings for attribute context", () => {
+    // Moodle emits &amp; in attributes; rewriteHtmlAttributeUrl decodes it,
+    // so the document rewrite must re-encode it back to &amp; (not raw &).
+    const html =
+      '<a href="/moodle-playground/admin/index.php?cache=1&amp;sesskey=abc">x</a>';
+    const out = rewriteHtmlDocumentAttributes(html, scope);
+    assert.strictEqual(
+      out,
+      '<a href="/moodle-playground/playground/main/php83-moodle50/admin/index.php?cache=1&amp;sesskey=abc">x</a>',
+    );
+    // The raw, unescaped ampersand must never appear in the output attribute.
+    assert.ok(!/sesskey=abc/.test(out) || /&amp;sesskey=abc/.test(out));
+  });
+
+  it("neutralizes a quote-injection payload that would close the attribute", () => {
+    // A reflected RELATIVE URL whose entity-decoded form contains a double quote.
+    // rewriteHtmlAttributeUrl returns relative URLs untouched (without going
+    // through URL normalization that would percent-encode the quote), so the
+    // document rewrite's escapeHtml is the layer that prevents the decoded quote
+    // from closing the attribute early and injecting markup into the iframe.
+    const html =
+      '<a href="foo.php?x=&quot;&gt;&lt;img src=x onerror=alert(1)&gt;">x</a>';
+    const out = rewriteHtmlDocumentAttributes(html, scope);
+    // The attribute must still be a single quoted value (not broken out of).
+    const valueMatch = out.match(/href="([^"]*)"/u);
+    assert.ok(valueMatch, "attribute should still be a single quoted value");
+    // The decoded quote must have been re-encoded back to an entity.
+    assert.ok(out.includes("&quot;"), "double quote must be encoded");
+    // The dangerous unencoded markup must not be present.
+    assert.ok(!out.includes('"><img'), "must not break out of the attribute");
+    assert.ok(
+      !/<img\s+src=x\s+onerror=/u.test(out),
+      "injected <img> tag must not appear unescaped",
+    );
+  });
+
+  it("re-encodes a single quote in a relative URL (single-quote breakout)", () => {
+    // Single-quoted attribute with a decoded single quote in a relative URL.
+    const html = "<a href='foo.php?n=&#39;a&#39;'>x</a>";
+    const out = rewriteHtmlDocumentAttributes(html, scope);
+    assert.ok(out.includes("&#39;"), "single quote must be encoded");
+    assert.ok(!/n='a'/u.test(out), "raw single quotes must not appear");
+  });
+
+  it("leaves clean relative URLs intact after re-encoding", () => {
+    const html = '<a href="upgradesettings.php">x</a>';
+    const out = rewriteHtmlDocumentAttributes(html, scope);
+    assert.strictEqual(out, '<a href="upgradesettings.php">x</a>');
+  });
+});
+
+describe("buildScopedCacheKey", () => {
+  const origin = "https://ateeducacion.github.io";
+
+  it("namespaces the cache key by scope and runtime", () => {
+    assert.strictEqual(
+      buildScopedCacheKey(origin, "main", "php83-moodle50", "/theme/main.css"),
+      "https://ateeducacion.github.io/playground/main/php83-moodle50/theme/main.css",
+    );
+  });
+
+  it("produces different keys for different runtimes (no cross-runtime collision)", () => {
+    const path = "/pix/i/logo.svg";
+    const keyA = buildScopedCacheKey(origin, "main", "php83-moodle50", path);
+    const keyB = buildScopedCacheKey(origin, "main", "php83-moodle51", path);
+    assert.notStrictEqual(keyA, keyB);
+  });
+
+  it("produces different keys for different scopes", () => {
+    const path = "/theme/font.php/boost/core/fa.woff2";
+    const keyA = buildScopedCacheKey(origin, "main", "php83-moodle50", path);
+    const keyB = buildScopedCacheKey(origin, "alt", "php83-moodle50", path);
+    assert.notStrictEqual(keyA, keyB);
+  });
+
+  it("preserves the query string", () => {
+    assert.strictEqual(
+      buildScopedCacheKey(
+        origin,
+        "main",
+        "php83-moodle50",
+        "/lib/javascript.php?ver=123",
+      ),
+      "https://ateeducacion.github.io/playground/main/php83-moodle50/lib/javascript.php?ver=123",
+    );
+  });
+
+  it("normalizes a leading-slash-less request path", () => {
+    assert.strictEqual(
+      buildScopedCacheKey(origin, "main", "php83-moodle50", "theme/main.css"),
+      "https://ateeducacion.github.io/playground/main/php83-moodle50/theme/main.css",
+    );
+  });
+
+  it("collapses duplicate slashes in the path but not the query", () => {
+    assert.strictEqual(
+      buildScopedCacheKey(
+        origin,
+        "main",
+        "php83-moodle50",
+        "//theme//main.css?u=a//b",
+      ),
+      "https://ateeducacion.github.io/playground/main/php83-moodle50/theme/main.css?u=a//b",
     );
   });
 });


### PR DESCRIPTION
## Summary

A multi-agent audit swept every subsystem (service worker, PHP worker, runtime/bootstrap, crash recovery, blueprint engine + PHP code generation, shell/remote, shared utils, PHP patches, build scripts) and surfaced **17 confirmed findings** (15 distinct bugs after dedup), each cross-examined by an adversarial skeptic panel. This PR fixes **all of them**, plus **3 blockers** and 2 extra injection/SSRF hardenings that an adversarial review of the *fixes themselves* caught.

**Verification:** `npm run build:worker` clean · `make lint` exit 0 · **`make test` → 422 pass / 0 fail** (≈115 new regression tests) · all blocker fixes re-verified closed with no new bypass.

> `dist/` and `sw.bundle.js` are gitignored (CI rebuilds them), so only source + tests are committed.

## Critical — code execution / SSRF / XSS

| Bug | Fix |
|-----|-----|
| **ZIP-slip → arbitrary PHP exec** in plugin/theme install & `unzip` step | Central `sanitizeArchivePath()` in `lib/moodle-loader.js` (rejects `..`/absolute entries) + per-handler containment checks in `filesystem.js` & `moodle-plugins.js` |
| **PHP code injection** via unescaped `pluginName` in plugin install | Validate `pluginName` in `resolvePluginDir()` **before** any extraction (chokepoint); `escapePhp()` now escapes backslashes; `customField` keys validated as PHP identifiers |
| **Open proxy / SSRF** in `github-proxy-worker.js` | Host-aware allowlist; reject private/loopback/link-local + IPv4-mapped-IPv6 + cloud-metadata DNS; **re-validate every redirect hop** (`redirect:"manual"`, cap 5) so an allowlisted host can't 302 into an internal address |
| **Reflected XSS** in `sw.js` HTML attribute rewriter | Re-encode rewritten attribute values (`escapeHtml`) so decoded URLs can't break out of the attribute |

## High / Medium — data-loss & correctness

- **CLI install failure silently marked `installed:true`** → gate on per-stage success markers; throw before writing the marker on failure (`bootstrap.js`)
- **SQLite ALTER emulation dropped columns / threw `ddsequenceerror`** on upgrades → preserve live columns and re-add `PRIMARY KEY` (incl. composite) (`patches/.../sqlite_sql_generator.php`)
- **`data-url` resources with media-type params** (e.g. `charset`) rejected → fixed regex in `resources.js` + `parser.js`
- **`escapePhp` corrupted multi-line text** (literal `\n`) → only escape `\` and `'` for single-quoted context
- **Manifest HEAD-failure booted the wrong branch** → only fall back on a definitive 404 and verify channel match before extracting
- **Provisioning check could abort boot** in the saved-state branch → wrapped in try/catch to fall back to fresh install
- **Crash snapshot pinned in heap** when restart refused → hydrate only after reset succeeds; clear otherwise and on reconfigure (`php-worker.js`)
- **Scoped static cache leaked assets across runtimes** → namespace cache key by scope+runtime (`sw.js`)
- **Dead `readyNavigated` guard caused double frame navigation** → navigate once using the resolved path (`remote/main.js` + `php-worker.js`)
- **`set -e` aborted snapshot script before logging the installer error** → guard so the install log is always dumped on failure

## Methodology

`find → adversarially verify → fix → adversarially review → fix blockers → re-verify`, run as parallel agent workflows over disjoint file groups. The fix-review pass caught 3 real blockers (late validation order, redirect-follow SSRF bypass, missing PK on table rebuild) that the initial fixes missed.

## Known minor follow-ups (non-blocking)

- Composite-PK column *order* is not preserved across SQLite ALTER emulation (uniqueness is unaffected; no current Moodle core table relies on it).
- `omeka.org` proxy path scope left unrestricted (out of scope; tightening risks breaking Omeka usage).
- The riskiest untested paths (CLI-install marker gating, SQLite upgrade emulation) warrant an e2e upgrade check; flagged for a follow-up.
