### PR TITLE
chore(dependabot): group @php-wasm/* updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Group all @php-wasm/* packages into a single PR. They are always
+    # released together with the same version, so separate PRs would race
+    # against each other and produce inconsistent lockfile states.
+    groups:
+      php-wasm:
+        patterns:
+          - "@php-wasm/*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Problem

`@php-wasm/web`, `@php-wasm/universal` and `@php-wasm/stream-compression` are always published together with the same version. With the current config Dependabot opens **one PR per package**, so three PRs land at the same time, race against each other, and can leave `package-lock.json` in an inconsistent state.

## Fix

Use Dependabot's [`groups`](https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) feature to collapse all `@php-wasm/*` bumps into a **single coherent PR**.

```yaml
groups:
  php-wasm:
    patterns:
      - "@php-wasm/*"
```

This is the same outcome WordPress Playground gets by having `@php-wasm/*` as internal workspace packages — but expressed via grouping since we consume them as external deps.