### PR TITLE
fix(github-proxy): download release assets directly instead of via the GitHub API

### DIFF
--- a/scripts/github-proxy-worker.js
+++ b/scripts/github-proxy-worker.js
@@ -36,7 +36,7 @@ export default {
 
     // Legacy generic proxy mode
     if (params.has("url")) {
-      return handleGenericProxy(params.get("url"), request, env);
+      return handleGenericProxy(params.get("url"), request);
     }
 
     // GitHub proxy mode
@@ -131,19 +131,38 @@ async function handleGitHubProxy(params, env) {
   // No branch specified – resolve the default branch via the API
   const defaultBranch = await getDefaultBranch(repo, env);
 
-  if (!defaultBranch) {
-    return jsonResponse(
-      {
-        error:
-          "Could not determine the default branch. Check that the repo exists and is public.",
-      },
-      502,
+  if (defaultBranch) {
+    return proxyGitHubZip(
+      `${GITHUB_BASE}/${repo}/archive/refs/heads/${defaultBranch}.zip`,
     );
   }
 
-  return proxyGitHubZip(
-    `${GITHUB_BASE}/${repo}/archive/refs/heads/${defaultBranch}.zip`,
-  );
+  // The API could not resolve the default branch (rate-limited, or the
+  // GITHUB_TOKEN is blocked for this repo by an org fine-grained-PAT policy).
+  // Fall back to the conventional branch names instead of failing outright.
+  return proxyFirstAvailableZip([
+    `${GITHUB_BASE}/${repo}/archive/refs/heads/main.zip`,
+    `${GITHUB_BASE}/${repo}/archive/refs/heads/master.zip`,
+  ]);
+}
+
+// Proxies the first candidate archive URL that resolves successfully, returning
+// the last failing response if none do. Used as a no-API fallback for
+// default-branch resolution.
+async function proxyFirstAvailableZip(urls) {
+  let lastResponse = null;
+
+  for (const url of urls) {
+    const response = await proxyGitHubZip(url);
+
+    if (response.status < 400) {
+      return response;
+    }
+
+    lastResponse = response;
+  }
+
+  return lastResponse;
 }
 
 // ---------------------------------------------------------------------------
@@ -223,40 +242,48 @@ async function handlePullRequest(repo, prNumber, env) {
 // ---------------------------------------------------------------------------
 
 async function handleReleaseAsset(repo, tag, assetName, env, request = null) {
+  // A release asset's browser_download_url is deterministic:
+  //   https://github.com/{repo}/releases/download/{tag}/{assetName}
+  // and 302s to the asset CDN with no API call. We query the API first only to
+  // surface a helpful "available_assets" list on a genuine typo — but we must
+  // NOT hard-depend on it. The API can be rate-limited, or the worker's
+  // GITHUB_TOKEN can be blocked for the repo (e.g. an org fine-grained-PAT
+  // policy 404s a public repo), which would otherwise turn every legitimate
+  // download into a 502 JSON body.
+  const directUrl = `${GITHUB_BASE}/${repo}/releases/download/${encodeURIComponent(
+    tag,
+  )}/${encodeURIComponent(assetName)}`;
+
   const apiUrl = `${GITHUB_API}/repos/${repo}/releases/tags/${tag}`;
   const data = await githubApiRequest(apiUrl, env);
 
-  if (!data?.assets) {
-    return jsonResponse(
-      {
-        error: `Could not find release "${tag}".`,
-        upstream_status: 404,
-        upstream_status_text: "Not Found",
-      },
-      502,
+  // API reachable: validate the asset name and use its canonical download URL.
+  if (data?.assets) {
+    const asset = data.assets.find(
+      (a) => a.name.toLowerCase() === assetName.toLowerCase(),
     );
+
+    if (!asset) {
+      const available = data.assets.map((a) => a.name);
+
+      return jsonResponse(
+        {
+          error: `Asset "${assetName}" not found in release "${tag}".`,
+          available_assets: available,
+        },
+        404,
+      );
+    }
+
+    return proxyGitHubZip(asset.browser_download_url, {
+      request,
+      downloadFilename: asset.name,
+    });
   }
 
-  const asset = data.assets.find(
-    (a) => a.name.toLowerCase() === assetName.toLowerCase(),
-  );
-
-  if (!asset) {
-    const available = data.assets.map((a) => a.name);
-
-    return jsonResponse(
-      {
-        error: `Asset "${assetName}" not found in release "${tag}".`,
-        available_assets: available,
-      },
-      404,
-    );
-  }
-
-  return proxyGitHubZip(asset.browser_download_url, {
-    request,
-    downloadFilename: asset.name,
-  });
+  // API unavailable/blocked: fall back to the deterministic direct URL so the
+  // download still works without any api.github.com call.
+  return proxyGitHubZip(directUrl, { request, downloadFilename: assetName });
 }
 
 // ---------------------------------------------------------------------------
@@ -473,7 +500,7 @@ async function proxyGitHubZip(
 // Legacy generic proxy mode
 // ---------------------------------------------------------------------------
 
-async function handleGenericProxy(targetUrl, request, env) {
+async function handleGenericProxy(targetUrl, request) {
   let parsedUrl;
 
   try {
@@ -501,11 +528,7 @@ async function handleGenericProxy(targetUrl, request, env) {
     );
   }
 
-  const translatedGitHubResponse = await maybeHandleDirectGitHubUrl(
-    parsedUrl,
-    env,
-    request,
-  );
+  const translatedGitHubResponse = await maybeHandleDirectGitHubUrl(parsedUrl);
   if (translatedGitHubResponse) {
     return translatedGitHubResponse;
   }
@@ -878,7 +901,7 @@ function extractGoogleDriveFileId(url) {
   return url.searchParams.get("id");
 }
 
-async function maybeHandleDirectGitHubUrl(url, env, request) {
+function maybeHandleDirectGitHubUrl(url) {
   const repoMatch = matchGitHubRepoPath(url.pathname);
   if (!repoMatch) {
     return null;
@@ -894,20 +917,13 @@ async function maybeHandleDirectGitHubUrl(url, env, request) {
     return handleAtomFeed(repo, "tags");
   }
 
-  const releaseAssetMatch = suffix.match(
-    /^\/releases\/download\/([^/]+)\/([^/]+)$/u,
-  );
-  if (releaseAssetMatch) {
-    const [, tag, assetName] = releaseAssetMatch;
-    return handleReleaseAsset(
-      repo,
-      decodeURIComponent(tag),
-      decodeURIComponent(assetName),
-      env,
-      request,
-    );
-  }
-
+  // NOTE: We deliberately do NOT intercept /releases/download/{tag}/{asset}
+  // URLs here. Routing them through handleReleaseAsset() means an api.github.com
+  // call to resolve the asset, which fails (returns null -> 502 JSON) whenever
+  // the API is rate-limited or the worker's GITHUB_TOKEN is blocked for the repo
+  // (e.g. an org's fine-grained-PAT policy 404s a public repo). A complete
+  // release-download URL is already an allowlisted github.com host that 302s to
+  // the asset CDN, so we let handleGenericProxy fetch it directly — no API call.
   return null;
 }
 

--- a/tests/shared/github-proxy-worker.test.js
+++ b/tests/shared/github-proxy-worker.test.js
@@ -43,34 +43,19 @@ describe("github-proxy-worker generic ?url= mode", () => {
     assert.equal(await response.text(), "<feed />");
   });
 
-  it("routes direct GitHub release asset URLs through the GitHub API asset resolver", async () => {
+  it("proxies direct GitHub release-asset URLs without calling the GitHub API", async () => {
+    // Regression: a complete /releases/download/{tag}/{asset} URL must be
+    // proxied directly (302 -> CDN), NOT rerouted through api.github.com — the
+    // API call fails (502 JSON) whenever it is rate-limited or the worker's
+    // GITHUB_TOKEN is blocked for the repo, which broke editor installs.
     const calls = [];
     global.fetch = async (url, init = {}) => {
-      calls.push({ url, init });
-      if (
-        String(url) ===
-        "https://api.github.com/repos/exelearning/exelearning/releases/tags/v4.0.0"
-      ) {
-        return new Response(
-          JSON.stringify({
-            assets: [
-              {
-                name: "exelearning-static-v4.0.0.zip",
-                browser_download_url:
-                  "https://release-assets.githubusercontent.com/exelearning-static-v4.0.0.zip",
-              },
-            ],
-          }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          },
-        );
-      }
+      const u = String(url);
+      calls.push({ url: u, init });
 
       if (
-        String(url) ===
-        "https://release-assets.githubusercontent.com/exelearning-static-v4.0.0.zip"
+        u ===
+        "https://github.com/exelearning/exelearning/releases/download/v4.0.0/exelearning-static-v4.0.0.zip"
       ) {
         return new Response(new Uint8Array([0x50, 0x4b, 0x03, 0x04]), {
           status: 206,
@@ -78,7 +63,7 @@ describe("github-proxy-worker generic ?url= mode", () => {
         });
       }
 
-      throw new Error(`unexpected url ${url}`);
+      throw new Error(`unexpected url ${u}`);
     };
 
     const response = await worker.fetch(
@@ -90,16 +75,15 @@ describe("github-proxy-worker generic ?url= mode", () => {
     );
 
     assert.equal(response.status, 206);
+    // Exactly one upstream fetch — and it is NOT an api.github.com call.
+    assert.equal(calls.length, 1);
     assert.equal(
       calls[0].url,
-      "https://api.github.com/repos/exelearning/exelearning/releases/tags/v4.0.0",
+      "https://github.com/exelearning/exelearning/releases/download/v4.0.0/exelearning-static-v4.0.0.zip",
     );
-    assert.equal(
-      calls[1].url,
-      "https://release-assets.githubusercontent.com/exelearning-static-v4.0.0.zip",
-    );
-    assert.equal(calls[1].init.headers.get("Range"), "bytes=0-3");
-    assert.equal(calls[1].init.headers.get("Cache-Control"), "no-cache");
+    assert.ok(!calls.some((c) => c.url.startsWith("https://api.github.com/")));
+    assert.equal(calls[0].init.headers.get("Range"), "bytes=0-3");
+    assert.equal(calls[0].init.headers.get("Cache-Control"), "no-cache");
     assert.equal(
       response.headers.get("Content-Disposition"),
       'attachment; filename="exelearning-static-v4.0.0.zip"',
@@ -110,32 +94,11 @@ describe("github-proxy-worker generic ?url= mode", () => {
     );
   });
 
-  it("includes upstream status details when the final asset fetch fails", async () => {
+  it("returns upstream status details when a direct release-asset fetch fails", async () => {
     global.fetch = async (url) => {
       if (
         String(url) ===
-        "https://api.github.com/repos/exelearning/exelearning/releases/tags/v4.0.0"
-      ) {
-        return new Response(
-          JSON.stringify({
-            assets: [
-              {
-                name: "exelearning-static-v4.0.0.zip",
-                browser_download_url:
-                  "https://release-assets.githubusercontent.com/exelearning-static-v4.0.0.zip",
-              },
-            ],
-          }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          },
-        );
-      }
-
-      if (
-        String(url) ===
-        "https://release-assets.githubusercontent.com/exelearning-static-v4.0.0.zip"
+        "https://github.com/exelearning/exelearning/releases/download/v4.0.0/exelearning-static-v4.0.0.zip"
       ) {
         return new Response("upstream bad gateway", {
           status: 502,
@@ -159,10 +122,6 @@ describe("github-proxy-worker generic ?url= mode", () => {
     assert.equal(body.error, "Upstream server returned an error.");
     assert.equal(body.status, 502);
     assert.equal(body.statusText, "Bad Gateway");
-    assert.equal(
-      body.upstream_url,
-      "https://release-assets.githubusercontent.com/exelearning-static-v4.0.0.zip",
-    );
   });
 
   it("forwards Range headers for generic raw GitHub resource downloads", async () => {
@@ -648,6 +607,139 @@ describe("github-proxy-worker redirect validation (SSRF)", () => {
     assert.deepEqual(
       Array.from(new Uint8Array(await response.arrayBuffer())),
       [0x50, 0x4b, 0x03, 0x04],
+    );
+  });
+
+  it("falls back to the direct download URL when the release API is blocked (?repo=&release=&asset=)", async () => {
+    // The release API 404s (e.g. an org fine-grained-PAT policy blocks the
+    // token for a public repo). The asset must still download via the
+    // deterministic /releases/download/{tag}/{asset} URL.
+    const calls = [];
+    global.fetch = async (url, init = {}) => {
+      const u = String(url);
+      calls.push({ url: u, init });
+
+      if (
+        u === "https://api.github.com/repos/owner/repo/releases/tags/v1.0.0"
+      ) {
+        return new Response(JSON.stringify({ message: "Not Found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      if (
+        u ===
+        "https://github.com/owner/repo/releases/download/v1.0.0/plugin.zip"
+      ) {
+        return new Response(new Uint8Array([0x50, 0x4b, 0x03, 0x04]), {
+          status: 200,
+          headers: { "Content-Type": "application/octet-stream" },
+        });
+      }
+
+      throw new Error(`unexpected url ${u}`);
+    };
+
+    const response = await worker.fetch(
+      new Request(
+        "https://proxy.example/?repo=owner/repo&release=v1.0.0&asset=plugin.zip",
+      ),
+      {},
+    );
+
+    assert.equal(response.status, 200);
+    assert.ok(
+      calls.some(
+        (c) =>
+          c.url ===
+          "https://github.com/owner/repo/releases/download/v1.0.0/plugin.zip",
+      ),
+    );
+    assert.deepEqual(
+      Array.from(new Uint8Array(await response.arrayBuffer())),
+      [0x50, 0x4b, 0x03, 0x04],
+    );
+  });
+
+  it("falls back to main when the default-branch API call is blocked (?repo=)", async () => {
+    const calls = [];
+    global.fetch = async (url) => {
+      const u = String(url);
+      calls.push(u);
+
+      if (u === "https://api.github.com/repos/owner/repo") {
+        return new Response(JSON.stringify({ message: "Not Found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      if (u === "https://github.com/owner/repo/archive/refs/heads/main.zip") {
+        return new Response(new Uint8Array([0x50, 0x4b, 0x03, 0x04]), {
+          status: 200,
+          headers: { "Content-Type": "application/zip" },
+        });
+      }
+
+      throw new Error(`unexpected url ${u}`);
+    };
+
+    const response = await worker.fetch(
+      new Request("https://proxy.example/?repo=owner/repo"),
+      {},
+    );
+
+    assert.equal(response.status, 200);
+    assert.ok(
+      calls.includes(
+        "https://github.com/owner/repo/archive/refs/heads/main.zip",
+      ),
+    );
+  });
+
+  it("falls back to master when main is absent and the default-branch API is blocked", async () => {
+    const calls = [];
+    global.fetch = async (url) => {
+      const u = String(url);
+      calls.push(u);
+
+      if (u === "https://api.github.com/repos/owner/repo") {
+        return new Response("rate limited", { status: 403 });
+      }
+
+      if (u === "https://github.com/owner/repo/archive/refs/heads/main.zip") {
+        return new Response("no main branch", {
+          status: 404,
+          statusText: "Not Found",
+        });
+      }
+
+      if (u === "https://github.com/owner/repo/archive/refs/heads/master.zip") {
+        return new Response(new Uint8Array([0x50, 0x4b, 0x03, 0x04]), {
+          status: 200,
+          headers: { "Content-Type": "application/zip" },
+        });
+      }
+
+      throw new Error(`unexpected url ${u}`);
+    };
+
+    const response = await worker.fetch(
+      new Request("https://proxy.example/?repo=owner/repo"),
+      {},
+    );
+
+    assert.equal(response.status, 200);
+    assert.ok(
+      calls.includes(
+        "https://github.com/owner/repo/archive/refs/heads/main.zip",
+      ),
+    );
+    assert.ok(
+      calls.includes(
+        "https://github.com/owner/repo/archive/refs/heads/master.zip",
+      ),
     );
   });
 


### PR DESCRIPTION
Fixes the eXeLearning editor install failing with **"not a valid ZIP archive"** (mod_exeweb) and **"does not match the SHA-256 digest"** (mod_exelearning).

## Root cause
Release-asset downloads (`?url=.../releases/download/{tag}/{asset}`) were rerouted through the GitHub REST API to resolve the asset URL (regression from `a34cc91`). That API call returns `null` → a 502 JSON error body whenever it is rate-limited **or** the worker `GITHUB_TOKEN` is blocked for the repo (an org fine-grained-PAT policy returns 404 even for public repos like `exelearning/exelearning`). Plugins then received the 116-byte error JSON instead of the ZIP.

## Fix
A release asset URL is deterministic (`github.com/{repo}/releases/download/{tag}/{asset}`) and 302s to the asset CDN with no API call:
- `maybeHandleDirectGitHubUrl`: stop intercepting `/releases/download/{tag}/{asset}` — proxy it directly.
- `handleReleaseAsset`: API is best-effort, fall back to the direct URL.
- `getDefaultBranch`: fall back to `main`/`master` when the API cannot resolve it.

Adds regression tests for all three fallbacks (435/435 unit tests pass, lint clean).

## Verified live
Deployed to both the `github-proxy` and `zip-proxy` workers. The editor asset now returns 200 / 34 MB and its **SHA-256 matches** GitHub's published digest (`cf7be75a…a040e2e`). Mirror PRs: ateeducacion/omeka-s-playground#72, erseco/facturascripts-playground#56.