### PR TITLE
feat(github-proxy): support Nextcloud / ownCloud public share downloads

### DIFF
--- a/scripts/github-proxy-worker.js
+++ b/scripts/github-proxy-worker.js
@@ -879,7 +879,8 @@ function isGoogleDriveDirectFileUrl(url) {
 //   /index.php/s/{token}[/download]   (pretty-URLs-disabled instances)
 // The SSRF guard (isPrivateOrLocalHost) is still enforced for every host and
 // redirect hop, so this is not an open proxy into internal infrastructure.
-const NEXTCLOUD_SHARE_PATH = /^(?:\/index\.php)?\/s\/[A-Za-z0-9._-]+(?:\/download)?\/?$/u;
+const NEXTCLOUD_SHARE_PATH =
+  /^(?:\/index\.php)?\/s\/[A-Za-z0-9._-]+(?:\/download)?\/?$/u;
 
 function isNextcloudShareUrl(url) {
   return NEXTCLOUD_SHARE_PATH.test(url.pathname);

--- a/scripts/github-proxy-worker.js
+++ b/scripts/github-proxy-worker.js
@@ -4,8 +4,9 @@
 //
 // 1. Generic proxy mode (legacy): ?url={full_url}
 //    Proxies supported direct URLs with CORS headers. This includes ZIP downloads,
-//    GitHub-hosted text/binary resources, FacturaScripts plugin pages, and
-//    omeka.org / dev.omeka.org resources (plugin/module pages and downloads).
+//    GitHub-hosted text/binary resources, FacturaScripts plugin pages,
+//    omeka.org / dev.omeka.org resources (plugin/module pages and downloads), and
+//    Nextcloud / ownCloud public share links (/s/{token}[/download]) on any host.
 //
 // 2. GitHub proxy mode: ?repo={owner/repo}[&branch=...][&pr=...][&commit=...][&release=...][&asset=...][&atom=...]
 //    Builds the correct GitHub URL from semantic parameters and proxies the response.
@@ -539,10 +540,20 @@ async function handleGenericProxy(targetUrl, request) {
     // Re-validate every redirect hop against the same generic-proxy allowlist
     // (and SSRF guard) that authorized the initial URL, so an allowlisted host
     // cannot 302 us into an internal or unsupported target.
+    //
+    // Nextcloud/ownCloud shares are the exception: GET /s/{token}/download
+    // 303-redirects to a signed DAV URL on the SAME host (e.g.
+    // /public.php/dav/files/{token}/), which does not match the public-share
+    // path shape. Authorize redirects that stay on the original share's host
+    // instead. The SSRF guard still runs for every hop.
+    const isAuthorizedRedirect = isNextcloudShareUrl(parsedUrl)
+      ? (candidate) => candidate.hostname === parsedUrl.hostname
+      : isSupportedGenericProxyUrl;
+
     const upstream = await fetchWithValidatedRedirects(
       parsedUrl.toString(),
       { method: "GET", headers: upstreamHeaders },
-      isSupportedGenericProxyUrl,
+      isAuthorizedRedirect,
     );
 
     if (!upstream.ok) {
@@ -656,6 +667,7 @@ function isSupportedGenericProxyUrl(url) {
     isFacturaScriptsPluginPage(url) ||
     isGitHubDirectProxyUrl(url) ||
     isGoogleDriveDirectFileUrl(url) ||
+    isNextcloudShareUrl(url) ||
     isOmekaOrgResourceUrl(url) ||
     isGitLabResourceUrl(url) ||
     isJsDelivrResourceUrl(url)
@@ -859,7 +871,25 @@ function isGoogleDriveDirectFileUrl(url) {
   return false;
 }
 
+// Nextcloud / ownCloud public share links live on arbitrary self-hosted
+// domains, so they cannot be matched by a fixed host allowlist. Authorize them
+// instead by their well-known public-share path shape:
+//   /s/{token}                  (share page)
+//   /s/{token}/download         (direct download; what eXeViewer requests)
+//   /index.php/s/{token}[/download]   (pretty-URLs-disabled instances)
+// The SSRF guard (isPrivateOrLocalHost) is still enforced for every host and
+// redirect hop, so this is not an open proxy into internal infrastructure.
+const NEXTCLOUD_SHARE_PATH = /^(?:\/index\.php)?\/s\/[A-Za-z0-9._-]+(?:\/download)?\/?$/u;
+
+function isNextcloudShareUrl(url) {
+  return NEXTCLOUD_SHARE_PATH.test(url.pathname);
+}
+
 function normalizeSupportedGenericProxyUrl(url) {
+  if (isNextcloudShareUrl(url)) {
+    return normalizeNextcloudShareUrl(url);
+  }
+
   if (!isGoogleDriveDirectFileUrl(url)) {
     return url;
   }
@@ -888,6 +918,21 @@ function normalizeSupportedGenericProxyUrl(url) {
 
   normalized.searchParams.set("id", fileId);
   normalized.searchParams.set("export", "download");
+
+  return normalized;
+}
+
+// Rewrite a bare Nextcloud/ownCloud share page (/s/{token}) to its direct
+// download endpoint (/s/{token}/download). A URL that already targets /download
+// (or carries a path/files query selecting a file inside a folder share) is
+// returned unchanged.
+function normalizeNextcloudShareUrl(url) {
+  if (url.pathname.replace(/\/$/u, "").endsWith("/download")) {
+    return url;
+  }
+
+  const normalized = new URL(url.toString());
+  normalized.pathname = `${normalized.pathname.replace(/\/$/u, "")}/download`;
 
   return normalized;
 }
@@ -1367,8 +1412,9 @@ function landingPageHtml(origin) {
         <span class="method">GET</span>
         <span class="endpoint-name">URL Proxy</span>
       </div>
-      <div class="endpoint-desc">Proxy supported ZIP, GitHub resource, Google Drive, or omeka.org / dev.omeka.org URLs with CORS headers.</div>
+      <div class="endpoint-desc">Proxy supported ZIP, GitHub resource, Google Drive, Nextcloud / ownCloud share, or omeka.org / dev.omeka.org URLs with CORS headers.</div>
       <div class="endpoint-desc">Drive accepts direct <code>/uc?id=...</code> links and shared <code>/file/d/{id}/view</code> links.</div>
+      <div class="endpoint-desc">Nextcloud / ownCloud accepts public share links <code>/s/{token}</code> and <code>/s/{token}/download</code> on any host.</div>
       <div class="url-box">${base}/?url=<span class="param">{full_url}</span></div>
     </div>
 

--- a/tests/shared/github-proxy-worker.test.js
+++ b/tests/shared/github-proxy-worker.test.js
@@ -894,7 +894,10 @@ describe("github-proxy-worker Nextcloud / ownCloud public shares", () => {
 
     assert.equal(response.status, 200);
     assert.equal(calls.length, 1);
-    assert.equal(calls[0].url, "https://cloud.example.org/s/aB3xToken9/download");
+    assert.equal(
+      calls[0].url,
+      "https://cloud.example.org/s/aB3xToken9/download",
+    );
   });
 
   it("follows the same-host 303 redirect to the public DAV endpoint", async () => {

--- a/tests/shared/github-proxy-worker.test.js
+++ b/tests/shared/github-proxy-worker.test.js
@@ -838,3 +838,193 @@ describe("github-proxy-worker isPrivateOrLocalHost extras", () => {
     }
   });
 });
+
+describe("github-proxy-worker Nextcloud / ownCloud public shares", () => {
+  it("proxies a /s/{token}/download URL on an arbitrary host", async () => {
+    const calls = [];
+    global.fetch = async (url, init = {}) => {
+      calls.push({ url: String(url), init });
+      return new Response(new Uint8Array([0x50, 0x4b, 0x03, 0x04]), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/octet-stream",
+          "Content-Disposition": 'attachment; filename="content.elpx"',
+        },
+      });
+    };
+
+    const target = "https://cloud.example.org/s/aB3xToken9/download";
+    const response = await worker.fetch(
+      new Request(`https://proxy.example/?url=${encodeURIComponent(target)}`),
+      {},
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, target);
+    assert.equal(response.headers.get("X-Playground-Cors-Proxy"), "true");
+    assert.equal(
+      response.headers.get("Content-Disposition"),
+      'attachment; filename="content.elpx"',
+    );
+    assert.deepEqual(
+      Array.from(new Uint8Array(await response.arrayBuffer())),
+      [0x50, 0x4b, 0x03, 0x04],
+    );
+  });
+
+  it("normalizes a bare /s/{token} share page to /s/{token}/download", async () => {
+    const calls = [];
+    global.fetch = async (url, init = {}) => {
+      calls.push({ url: String(url), init });
+      return new Response(new Uint8Array([0x50, 0x4b, 0x03, 0x04]), {
+        status: 200,
+        headers: { "Content-Type": "application/octet-stream" },
+      });
+    };
+
+    const response = await worker.fetch(
+      new Request(
+        `https://proxy.example/?url=${encodeURIComponent(
+          "https://cloud.example.org/s/aB3xToken9",
+        )}`,
+      ),
+      {},
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, "https://cloud.example.org/s/aB3xToken9/download");
+  });
+
+  it("follows the same-host 303 redirect to the public DAV endpoint", async () => {
+    const calls = [];
+    global.fetch = async (url, init = {}) => {
+      const u = String(url);
+      calls.push({ url: u, init });
+
+      if (u === "https://cloud.example.org/s/aB3xToken9/download") {
+        return new Response(null, {
+          status: 303,
+          headers: {
+            Location:
+              "https://cloud.example.org/public.php/dav/files/aB3xToken9/?accept=zip",
+          },
+        });
+      }
+
+      if (
+        u ===
+        "https://cloud.example.org/public.php/dav/files/aB3xToken9/?accept=zip"
+      ) {
+        return new Response(new Uint8Array([0x50, 0x4b, 0x03, 0x04]), {
+          status: 200,
+          headers: { "Content-Type": "application/octet-stream" },
+        });
+      }
+
+      throw new Error(`unexpected url ${u}`);
+    };
+
+    const response = await worker.fetch(
+      new Request(
+        `https://proxy.example/?url=${encodeURIComponent(
+          "https://cloud.example.org/s/aB3xToken9/download",
+        )}`,
+      ),
+      {},
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].init.redirect, "manual");
+    assert.equal(
+      calls[1].url,
+      "https://cloud.example.org/public.php/dav/files/aB3xToken9/?accept=zip",
+    );
+    assert.deepEqual(
+      Array.from(new Uint8Array(await response.arrayBuffer())),
+      [0x50, 0x4b, 0x03, 0x04],
+    );
+  });
+
+  it("blocks a Nextcloud share redirect that leaves the original host", async () => {
+    let calls = 0;
+    global.fetch = async () => {
+      calls++;
+      return new Response(null, {
+        status: 303,
+        headers: { Location: "https://evil.example/payload" },
+      });
+    };
+
+    const response = await worker.fetch(
+      new Request(
+        `https://proxy.example/?url=${encodeURIComponent(
+          "https://cloud.example.org/s/aB3xToken9/download",
+        )}`,
+      ),
+      {},
+    );
+
+    assert.equal(response.status, 400);
+    assert.equal(calls, 1);
+  });
+
+  it("blocks a Nextcloud share that redirects into an internal IP", async () => {
+    let calls = 0;
+    global.fetch = async () => {
+      calls++;
+      return new Response(null, {
+        status: 303,
+        headers: { Location: "http://169.254.169.254/latest/meta-data/" },
+      });
+    };
+
+    const response = await worker.fetch(
+      new Request(
+        `https://proxy.example/?url=${encodeURIComponent(
+          "https://cloud.example.org/s/aB3xToken9/download",
+        )}`,
+      ),
+      {},
+    );
+
+    assert.equal(response.status, 400);
+    assert.equal(calls, 1);
+  });
+
+  it("does not authorize non-share paths on an arbitrary host", async () => {
+    global.fetch = async () => {
+      throw new Error("should not fetch upstream");
+    };
+
+    const response = await worker.fetch(
+      new Request(
+        `https://proxy.example/?url=${encodeURIComponent(
+          "https://cloud.example.org/remote.php/dav/files/admin/secret.zip",
+        )}`,
+      ),
+      {},
+    );
+
+    assert.equal(response.status, 400);
+  });
+
+  it("rejects a Nextcloud-shaped path on a private host (SSRF guard)", async () => {
+    global.fetch = async () => {
+      throw new Error("should not fetch upstream");
+    };
+
+    const response = await worker.fetch(
+      new Request(
+        `https://proxy.example/?url=${encodeURIComponent(
+          "http://192.168.1.10/s/aB3xToken9/download",
+        )}`,
+      ),
+      {},
+    );
+
+    assert.equal(response.status, 400);
+  });
+});


### PR DESCRIPTION
## Why

The `github-proxy.exelearning.dev` worker (this `scripts/github-proxy-worker.js`) is the proxy eXeViewer relies on. Its generic `?url=` mode uses a fixed host allowlist, so it rejects Nextcloud/ownCloud public share links with `400: "The provided URL is not a supported direct GitHub/resource URL."`.

This breaks eXeViewer's advertised "Supports Nextcloud, ownCloud and Dropbox shared links" feature — see exelearning/exeviewer#35.

## What

Add Nextcloud/ownCloud public share support to the generic proxy mode:

- **Authorize by path shape, not host.** These instances are self-hosted on arbitrary domains, so they can't be matched by a host allowlist. Recognize the well-known public-share path shape `/s/{token}` and `/s/{token}/download` (plus the `/index.php/s/...` variant for instances without pretty URLs).
- **Normalize** a bare `/s/{token}` share page to `/s/{token}/download`.
- **Same-host redirect handling.** `GET /s/{token}/download` 303-redirects to a signed DAV URL on the *same* host (e.g. `/public.php/dav/files/{token}/?accept=zip`), which doesn't match the public-share shape. Redirects are therefore authorized when they stay on the original share's host.

## Security

- The SSRF guard (`isPrivateOrLocalHost`) still runs for the initial host **and every redirect hop** — private/loopback/link-local/metadata targets stay blocked.
- A Nextcloud share may **not** redirect off its original host (cross-host redirects are rejected), so this cannot be turned into an open redirect to arbitrary destinations.
- A Nextcloud-shaped path on a private host is rejected.

## Tests

7 new tests in `tests/shared/github-proxy-worker.test.js` cover: proxying `/s/{token}/download` on an arbitrary host, normalizing a bare share page, following the same-host DAV redirect, blocking cross-host and internal-IP redirects, rejecting non-share paths, and the private-host SSRF case. All 33 tests pass; `biome check` is clean.

## Deploy

This worker is deployed separately via `wrangler` — it must be redeployed after merge for the fix to take effect on `github-proxy.exelearning.dev`.

Companion client PR: exelearning/exeviewer#36