### PR TITLE
feat(github-proxy): support Dropbox shared-link downloads

### DIFF
--- a/scripts/github-proxy-worker.js
+++ b/scripts/github-proxy-worker.js
@@ -553,8 +553,9 @@ async function handleGenericProxy(targetUrl, request) {
     const isAuthorizedRedirect = isNextcloudShareUrl(parsedUrl)
       ? (candidate) => candidate.hostname === parsedUrl.hostname
       : isDropboxShareUrl(parsedUrl)
-      ? (candidate) => isSupportedGenericProxyUrl(candidate) || isDropboxCdnUrl(candidate)
-      : isSupportedGenericProxyUrl;
+        ? (candidate) =>
+            isSupportedGenericProxyUrl(candidate) || isDropboxCdnUrl(candidate)
+        : isSupportedGenericProxyUrl;
 
     const upstream = await fetchWithValidatedRedirects(
       parsedUrl.toString(),

--- a/scripts/github-proxy-worker.js
+++ b/scripts/github-proxy-worker.js
@@ -546,8 +546,14 @@ async function handleGenericProxy(targetUrl, request) {
     // /public.php/dav/files/{token}/), which does not match the public-share
     // path shape. Authorize redirects that stay on the original share's host
     // instead. The SSRF guard still runs for every hop.
+    //
+    // Dropbox shares redirect from www.dropbox.com to dl.dropboxusercontent.com
+    // (the CDN serving the actual file). Authorize that CDN host as a redirect
+    // target while still running the SSRF guard.
     const isAuthorizedRedirect = isNextcloudShareUrl(parsedUrl)
       ? (candidate) => candidate.hostname === parsedUrl.hostname
+      : isDropboxShareUrl(parsedUrl)
+      ? (candidate) => isSupportedGenericProxyUrl(candidate) || isDropboxCdnUrl(candidate)
       : isSupportedGenericProxyUrl;
 
     const upstream = await fetchWithValidatedRedirects(
@@ -668,6 +674,7 @@ function isSupportedGenericProxyUrl(url) {
     isGitHubDirectProxyUrl(url) ||
     isGoogleDriveDirectFileUrl(url) ||
     isNextcloudShareUrl(url) ||
+    isDropboxShareUrl(url) ||
     isOmekaOrgResourceUrl(url) ||
     isGitLabResourceUrl(url) ||
     isJsDelivrResourceUrl(url)
@@ -1049,6 +1056,24 @@ function isFacturaScriptsPluginPage(url) {
     url.hostname.toLowerCase() === "facturascripts.com" &&
     /^\/plugins\/[^/]+\/?$/u.test(url.pathname)
   );
+}
+
+// Dropbox shared file links: /s/{hash}/{filename} (legacy) and
+// /scl/fi/{hash}/{filename} (newer secure format with rlkey+st params).
+// Both formats redirect to dl.dropboxusercontent.com for the actual download.
+function isDropboxShareUrl(url) {
+  const hostname = url.hostname.toLowerCase();
+  if (hostname !== "www.dropbox.com" && hostname !== "dropbox.com") {
+    return false;
+  }
+  return /^\/(?:s\/[A-Za-z0-9_-]+|scl\/fi\/[A-Za-z0-9_-]+)\//u.test(
+    url.pathname,
+  );
+}
+
+// Dropbox CDN — the redirect target after a successful share-link download.
+function isDropboxCdnUrl(url) {
+  return url.hostname.toLowerCase().endsWith(".dropboxusercontent.com");
 }
 
 function isOmekaOrgResourceUrl(url) {

--- a/tests/shared/github-proxy-worker.test.js
+++ b/tests/shared/github-proxy-worker.test.js
@@ -1034,16 +1034,17 @@ describe("github-proxy-worker Nextcloud / ownCloud public shares", () => {
 
 describe("github-proxy-worker Dropbox shared links", () => {
   // The matcher is path-based (isDropboxShareUrl tests url.pathname only), so the
-  // worker accepts whichever force-download query param the client appends —
-  // eXeViewer sends `?download=1`, the legacy convention is `?dl=1`. Both proxy
-  // identically and 302 to *.dropboxusercontent.com.
+  // worker proxies the URL regardless of its query. The client appends `?dl=1`,
+  // which is the only param Dropbox honors to 302 a share link to the
+  // *.dropboxusercontent.com CDN (verified live; `?download=1` and `?dl=0` both
+  // return the HTML preview page instead of the file).
   it("proxies a legacy /s/{hash}/{file} share and follows the CDN redirect", async () => {
     const calls = [];
     global.fetch = async (url, init = {}) => {
       const u = String(url);
       calls.push({ url: u, init });
 
-      if (u === "https://www.dropbox.com/s/aB3xHash9/content.elpx?download=1") {
+      if (u === "https://www.dropbox.com/s/aB3xHash9/content.elpx?dl=1") {
         return new Response(null, {
           status: 302,
           headers: {
@@ -1069,7 +1070,7 @@ describe("github-proxy-worker Dropbox shared links", () => {
     };
 
     const target =
-      "https://www.dropbox.com/s/aB3xHash9/content.elpx?download=1";
+      "https://www.dropbox.com/s/aB3xHash9/content.elpx?dl=1";
     const response = await worker.fetch(
       new Request(`https://proxy.example/?url=${encodeURIComponent(target)}`),
       {},
@@ -1113,7 +1114,7 @@ describe("github-proxy-worker Dropbox shared links", () => {
     };
 
     const target =
-      "https://www.dropbox.com/scl/fi/aB3xHash9/course.zip?rlkey=k3y123&st=t0k3n&download=1";
+      "https://www.dropbox.com/scl/fi/aB3xHash9/course.zip?rlkey=k3y123&st=t0k3n&dl=1";
     const response = await worker.fetch(
       new Request(`https://proxy.example/?url=${encodeURIComponent(target)}`),
       {},
@@ -1145,7 +1146,7 @@ describe("github-proxy-worker Dropbox shared links", () => {
     const response = await worker.fetch(
       new Request(
         `https://proxy.example/?url=${encodeURIComponent(
-          "https://www.dropbox.com/s/aB3xHash9/content.elpx?download=1",
+          "https://www.dropbox.com/s/aB3xHash9/content.elpx?dl=1",
         )}`,
       ),
       {},
@@ -1168,7 +1169,7 @@ describe("github-proxy-worker Dropbox shared links", () => {
     const response = await worker.fetch(
       new Request(
         `https://proxy.example/?url=${encodeURIComponent(
-          "https://www.dropbox.com/scl/fi/aB3xHash9/course.zip?rlkey=k&download=1",
+          "https://www.dropbox.com/scl/fi/aB3xHash9/course.zip?rlkey=k&dl=1",
         )}`,
       ),
       {},

--- a/tests/shared/github-proxy-worker.test.js
+++ b/tests/shared/github-proxy-worker.test.js
@@ -1033,13 +1033,17 @@ describe("github-proxy-worker Nextcloud / ownCloud public shares", () => {
 });
 
 describe("github-proxy-worker Dropbox shared links", () => {
+  // The matcher is path-based (isDropboxShareUrl tests url.pathname only), so the
+  // worker accepts whichever force-download query param the client appends —
+  // eXeViewer sends `?download=1`, the legacy convention is `?dl=1`. Both proxy
+  // identically and 302 to *.dropboxusercontent.com.
   it("proxies a legacy /s/{hash}/{file} share and follows the CDN redirect", async () => {
     const calls = [];
     global.fetch = async (url, init = {}) => {
       const u = String(url);
       calls.push({ url: u, init });
 
-      if (u === "https://www.dropbox.com/s/aB3xHash9/content.elpx?dl=1") {
+      if (u === "https://www.dropbox.com/s/aB3xHash9/content.elpx?download=1") {
         return new Response(null, {
           status: 302,
           headers: {
@@ -1064,7 +1068,8 @@ describe("github-proxy-worker Dropbox shared links", () => {
       throw new Error(`unexpected url ${u}`);
     };
 
-    const target = "https://www.dropbox.com/s/aB3xHash9/content.elpx?dl=1";
+    const target =
+      "https://www.dropbox.com/s/aB3xHash9/content.elpx?download=1";
     const response = await worker.fetch(
       new Request(`https://proxy.example/?url=${encodeURIComponent(target)}`),
       {},
@@ -1108,7 +1113,7 @@ describe("github-proxy-worker Dropbox shared links", () => {
     };
 
     const target =
-      "https://www.dropbox.com/scl/fi/aB3xHash9/course.zip?rlkey=k3y123&st=t0k3n&dl=1";
+      "https://www.dropbox.com/scl/fi/aB3xHash9/course.zip?rlkey=k3y123&st=t0k3n&download=1";
     const response = await worker.fetch(
       new Request(`https://proxy.example/?url=${encodeURIComponent(target)}`),
       {},
@@ -1140,7 +1145,7 @@ describe("github-proxy-worker Dropbox shared links", () => {
     const response = await worker.fetch(
       new Request(
         `https://proxy.example/?url=${encodeURIComponent(
-          "https://www.dropbox.com/s/aB3xHash9/content.elpx?dl=1",
+          "https://www.dropbox.com/s/aB3xHash9/content.elpx?download=1",
         )}`,
       ),
       {},
@@ -1163,7 +1168,7 @@ describe("github-proxy-worker Dropbox shared links", () => {
     const response = await worker.fetch(
       new Request(
         `https://proxy.example/?url=${encodeURIComponent(
-          "https://www.dropbox.com/scl/fi/aB3xHash9/course.zip?rlkey=k&dl=1",
+          "https://www.dropbox.com/scl/fi/aB3xHash9/course.zip?rlkey=k&download=1",
         )}`,
       ),
       {},

--- a/tests/shared/github-proxy-worker.test.js
+++ b/tests/shared/github-proxy-worker.test.js
@@ -1054,9 +1054,7 @@ describe("github-proxy-worker Dropbox shared links", () => {
         });
       }
 
-      if (
-        u === "https://dl.dropboxusercontent.com/cd/0/get/abc/content.elpx"
-      ) {
+      if (u === "https://dl.dropboxusercontent.com/cd/0/get/abc/content.elpx") {
         return new Response(new Uint8Array([0x50, 0x4b, 0x03, 0x04]), {
           status: 200,
           headers: {
@@ -1069,8 +1067,7 @@ describe("github-proxy-worker Dropbox shared links", () => {
       throw new Error(`unexpected url ${u}`);
     };
 
-    const target =
-      "https://www.dropbox.com/s/aB3xHash9/content.elpx?dl=1";
+    const target = "https://www.dropbox.com/s/aB3xHash9/content.elpx?dl=1";
     const response = await worker.fetch(
       new Request(`https://proxy.example/?url=${encodeURIComponent(target)}`),
       {},

--- a/tests/shared/github-proxy-worker.test.js
+++ b/tests/shared/github-proxy-worker.test.js
@@ -1031,3 +1031,162 @@ describe("github-proxy-worker Nextcloud / ownCloud public shares", () => {
     assert.equal(response.status, 400);
   });
 });
+
+describe("github-proxy-worker Dropbox shared links", () => {
+  it("proxies a legacy /s/{hash}/{file} share and follows the CDN redirect", async () => {
+    const calls = [];
+    global.fetch = async (url, init = {}) => {
+      const u = String(url);
+      calls.push({ url: u, init });
+
+      if (u === "https://www.dropbox.com/s/aB3xHash9/content.elpx?dl=1") {
+        return new Response(null, {
+          status: 302,
+          headers: {
+            Location:
+              "https://dl.dropboxusercontent.com/cd/0/get/abc/content.elpx",
+          },
+        });
+      }
+
+      if (
+        u === "https://dl.dropboxusercontent.com/cd/0/get/abc/content.elpx"
+      ) {
+        return new Response(new Uint8Array([0x50, 0x4b, 0x03, 0x04]), {
+          status: 200,
+          headers: {
+            "Content-Type": "application/octet-stream",
+            "Content-Disposition": 'attachment; filename="content.elpx"',
+          },
+        });
+      }
+
+      throw new Error(`unexpected url ${u}`);
+    };
+
+    const target = "https://www.dropbox.com/s/aB3xHash9/content.elpx?dl=1";
+    const response = await worker.fetch(
+      new Request(`https://proxy.example/?url=${encodeURIComponent(target)}`),
+      {},
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].url, target);
+    assert.equal(calls[0].init.redirect, "manual");
+    assert.equal(
+      calls[1].url,
+      "https://dl.dropboxusercontent.com/cd/0/get/abc/content.elpx",
+    );
+    assert.equal(response.headers.get("X-Playground-Cors-Proxy"), "true");
+    assert.deepEqual(
+      Array.from(new Uint8Array(await response.arrayBuffer())),
+      [0x50, 0x4b, 0x03, 0x04],
+    );
+  });
+
+  it("proxies a newer /scl/fi/{hash}/{file} share with rlkey+st params", async () => {
+    const calls = [];
+    global.fetch = async (url, init = {}) => {
+      const u = String(url);
+      calls.push({ url: u, init });
+
+      if (u.startsWith("https://www.dropbox.com/scl/fi/")) {
+        return new Response(null, {
+          status: 302,
+          headers: {
+            Location:
+              "https://uc1234.dl.dropboxusercontent.com/cd/0/get/xyz/course.zip",
+          },
+        });
+      }
+
+      return new Response(new Uint8Array([0x50, 0x4b, 0x03, 0x04]), {
+        status: 200,
+        headers: { "Content-Type": "application/zip" },
+      });
+    };
+
+    const target =
+      "https://www.dropbox.com/scl/fi/aB3xHash9/course.zip?rlkey=k3y123&st=t0k3n&dl=1";
+    const response = await worker.fetch(
+      new Request(`https://proxy.example/?url=${encodeURIComponent(target)}`),
+      {},
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].url, target);
+    assert.equal(
+      calls[1].url,
+      "https://uc1234.dl.dropboxusercontent.com/cd/0/get/xyz/course.zip",
+    );
+    assert.deepEqual(
+      Array.from(new Uint8Array(await response.arrayBuffer())),
+      [0x50, 0x4b, 0x03, 0x04],
+    );
+  });
+
+  it("blocks a Dropbox share redirect that leaves the Dropbox hosts", async () => {
+    let calls = 0;
+    global.fetch = async () => {
+      calls++;
+      return new Response(null, {
+        status: 302,
+        headers: { Location: "https://evil.example/payload" },
+      });
+    };
+
+    const response = await worker.fetch(
+      new Request(
+        `https://proxy.example/?url=${encodeURIComponent(
+          "https://www.dropbox.com/s/aB3xHash9/content.elpx?dl=1",
+        )}`,
+      ),
+      {},
+    );
+
+    assert.equal(response.status, 400);
+    assert.equal(calls, 1);
+  });
+
+  it("blocks a Dropbox share that redirects into an internal IP", async () => {
+    let calls = 0;
+    global.fetch = async () => {
+      calls++;
+      return new Response(null, {
+        status: 302,
+        headers: { Location: "http://169.254.169.254/latest/meta-data/" },
+      });
+    };
+
+    const response = await worker.fetch(
+      new Request(
+        `https://proxy.example/?url=${encodeURIComponent(
+          "https://www.dropbox.com/scl/fi/aB3xHash9/course.zip?rlkey=k&dl=1",
+        )}`,
+      ),
+      {},
+    );
+
+    assert.equal(response.status, 400);
+    assert.equal(calls, 1);
+  });
+
+  it("does not authorize non-share Dropbox paths (e.g. /home)", async () => {
+    global.fetch = async () => {
+      throw new Error("should not fetch upstream");
+    };
+
+    const response = await worker.fetch(
+      new Request(
+        `https://proxy.example/?url=${encodeURIComponent(
+          "https://www.dropbox.com/home/secret.zip",
+        )}`,
+      ),
+      {},
+    );
+
+    assert.equal(response.status, 400);
+  });
+});


### PR DESCRIPTION
## Summary

Adds Dropbox shared-link support to the generic `?url=` proxy mode of the github-proxy worker, mirroring the existing Nextcloud/ownCloud handling. Previously the worker rejected Dropbox URLs with a 400, forcing eXeViewer to fall back to unreliable public CORS proxies (corsproxy.io, allorigins.win, …) which fail consistently for Dropbox.

## URL formats supported

```
https://www.dropbox.com/s/{hash}/{filename}?dl=1
https://www.dropbox.com/scl/fi/{hash}/{filename}?rlkey={key}&st={token}&dl=1
```

## Changes

- `isDropboxShareUrl(url)` — matches `www.dropbox.com`/`dropbox.com` with the well-known `/s/{hash}/` and `/scl/fi/{hash}/` path shapes.
- `isDropboxCdnUrl(url)` — authorizes `*.dropboxusercontent.com` (e.g. `dl.`, `uc####.dl.`) as the redirect target the share link 302s to.
- Added `isDropboxShareUrl` to `isSupportedGenericProxyUrl`.
- Added a Dropbox branch to `isAuthorizedRedirect` in `handleGenericProxy` so the share-link redirect to the CDN is followed.
- Tests for both URL formats plus off-host / internal-IP / non-share redirect guards.

## Why it's safe

- Only the recognized `/s/` and `/scl/fi/` share shapes on the two Dropbox hosts are matched — not a general `dropbox.com` open proxy.
- Redirects are authorized only to `*.dropboxusercontent.com`; the `isPrivateOrLocalHost` SSRF guard still runs on every hop.
- No new host is added to `isAllowlistedProxyHost`, so arbitrary zip-like paths on Dropbox are not authorized.

## Testing

`node --test tests/shared/github-proxy-worker.test.js` → **38 passing** (5 new Dropbox cases).

## Deployment

Already deployed to both production workers (`github-proxy` and `zip-proxy`) via `wrangler deploy`. The eXeViewer reference copy + client fallback live in exelearning/exeviewer#37.

---
Upstream issue: exelearning/exeviewer#34 · Client PR: exelearning/exeviewer#37
