### PR TITLE
feat(blueprint): {{REPO}}/{{REF}} context constants + github-proxy ?path= (fix PR-preview 414)

### DIFF
--- a/docs/blueprint-json.md
+++ b/docs/blueprint-json.md
@@ -160,6 +160,50 @@ all string values in the blueprint before execution:
 }
 ```
 
+### Context constants (`{{REPO}}` / `{{REF}}`)
+
+When a blueprint is loaded through `?blueprint-url=`, the playground derives a
+few **context constants** from that URL and merges them *over* the blueprint's
+own `constants`. This lets a single committed `blueprint.json` install the
+plugin from whatever branch it is being previewed for — without hard-coding
+`main`:
+
+| Constant     | Value                                                        |
+| ------------ | ----------------------------------------------------------- |
+| `{{REPO}}`   | `owner/repo` the blueprint was fetched for                  |
+| `{{OWNER}}`  | the owner segment of `{{REPO}}`                             |
+| `{{REF}}` / `{{BRANCH}}` | the branch / tag / commit the blueprint was fetched at |
+
+They are derived, in increasing priority, from:
+
+1. the `?blueprint-url=` value's own query — the github-proxy form
+   `…/?repo={owner/repo}&branch={ref}&path=blueprint.json` (slash-safe, since
+   the ref is a query param);
+2. a `raw.githubusercontent.com/{owner}/{repo}/{ref}/…` `?blueprint-url=`;
+3. explicit `?repo=` / `?ref=` (or `?owner=` / `?branch=`) on the playground URL.
+
+Author your blueprint with safe defaults so direct opens still work, and let the
+context override them for previews:
+
+```json
+{
+  "constants": { "REPO": "ateeducacion/mod_exelearning", "REF": "main" },
+  "steps": [
+    {
+      "step": "installMoodlePlugin",
+      "pluginType": "mod",
+      "pluginName": "exelearning",
+      "url": "https://github.com/{{REPO}}/archive/refs/heads/{{REF}}.zip"
+    }
+  ]
+}
+```
+
+> The `?path=` mode of the github-proxy serves a single raw repo file (e.g. the
+> branch's `blueprint.json`) with CORS, so the preview link can stay short
+> (`?blueprint-url=` instead of a giant base64 `?blueprint=`):
+> `https://github-proxy.exelearning.dev/?repo={owner/repo}&branch={ref}&path=blueprint.json`.
+
 ## Resources
 
 Named resources can be defined once and referenced from steps using `@name`:

--- a/scripts/github-proxy-worker.js
+++ b/scripts/github-proxy-worker.js
@@ -8,14 +8,19 @@
 //    omeka.org / dev.omeka.org resources (plugin/module pages and downloads), and
 //    Nextcloud / ownCloud public share links (/s/{token}[/download]) on any host.
 //
-// 2. GitHub proxy mode: ?repo={owner/repo}[&branch=...][&pr=...][&commit=...][&release=...][&asset=...][&atom=...]
+// 2. GitHub proxy mode: ?repo={owner/repo}[&branch=...][&pr=...][&commit=...][&release=...][&asset=...][&atom=...][&path=...]
 //    Builds the correct GitHub URL from semantic parameters and proxies the response.
+//    With &path={file} it serves a single raw file at the given ref (default
+//    branch when no ref is given) with CORS — e.g. a blueprint.json living in
+//    the repo. The ref travels as a query param, so refs with slashes
+//    (feat/x) are handled losslessly.
 //
 // Environment variables (optional):
 //   GITHUB_TOKEN – A GitHub personal access token to raise API rate limits from 60 to 5000 req/hour.
 
 const GITHUB_API = "https://api.github.com";
 const GITHUB_BASE = "https://github.com";
+const GITHUB_RAW = "https://raw.githubusercontent.com";
 
 export default {
   async fetch(request, env) {
@@ -66,6 +71,7 @@ export default {
           commit: "?repo={owner/repo}&commit={sha}",
           release: "?repo={owner/repo}&release={tag}",
           asset: "?repo={owner/repo}&release={tag}&asset={filename}",
+          raw_file: "?repo={owner/repo}&path={path}[&branch={branch}]",
           atom_releases: "?repo={owner/repo}&atom=releases",
           atom_tags: "?repo={owner/repo}&atom=tags",
         },
@@ -84,6 +90,20 @@ async function handleGitHubProxy(params, env) {
 
   if (!repo?.includes("/")) {
     return jsonResponse({ error: "Invalid repo format. Use owner/repo." }, 400);
+  }
+
+  // Raw file at a ref (e.g. a blueprint.json checked into the repo), served
+  // with CORS. The ref is a query param, so refs with slashes work. Resolves
+  // the ref from branch/ref/commit/release, falling back to the default branch.
+  if (params.has("path")) {
+    const ref =
+      params.get("branch") ||
+      params.get("ref") ||
+      params.get("commit") ||
+      params.get("release") ||
+      (await getDefaultBranch(repo, env)) ||
+      "main";
+    return proxyRawFile(repo, ref, params.get("path"));
   }
 
   // Atom feeds
@@ -215,6 +235,62 @@ async function handleAtomFeed(repo, type) {
     }
     return jsonResponse(
       { error: "Failed to fetch Atom feed.", details: error.message },
+      502,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Raw file resolution
+// ---------------------------------------------------------------------------
+
+// Fetches a single raw file from raw.githubusercontent.com and returns it with
+// CORS headers. Used to serve a repo's blueprint.json (or any small text/JSON
+// asset) cross-origin to the browser playground without inlining it in the URL.
+async function proxyRawFile(repo, ref, rawPath) {
+  const path = String(rawPath).replace(/^\/+/, "");
+  const url = `${GITHUB_RAW}/${repo}/${ref}/${path}`;
+
+  try {
+    // raw.githubusercontent.com serves directly (no redirect in practice), but
+    // validate any redirect hop against the GitHub host allowlist just in case.
+    const upstream = await fetchWithValidatedRedirects(
+      url,
+      { method: "GET", headers: { "User-Agent": "github-proxy-worker" } },
+      (candidate) =>
+        candidate.hostname === "raw.githubusercontent.com" ||
+        isGitHubDirectProxyUrl(candidate),
+    );
+
+    if (!upstream.ok) {
+      return jsonResponse(
+        {
+          error: "Upstream server returned an error.",
+          status: upstream.status,
+          statusText: upstream.statusText,
+        },
+        upstream.status === 404 ? 404 : 502,
+      );
+    }
+
+    const headers = new Headers();
+
+    applyCorsHeaders(headers);
+    headers.set(
+      "Content-Type",
+      path.toLowerCase().endsWith(".json")
+        ? "application/json; charset=utf-8"
+        : upstream.headers.get("Content-Type") || "text/plain; charset=utf-8",
+    );
+    headers.set("Cache-Control", "public, max-age=60");
+
+    return new Response(upstream.body, { status: 200, headers });
+  } catch (error) {
+    if (error instanceof RedirectBlockedError) {
+      return redirectBlockedResponse(error);
+    }
+    return jsonResponse(
+      { error: "Failed to fetch raw file.", details: error.message },
       502,
     );
   }

--- a/src/blueprint/resolver.js
+++ b/src/blueprint/resolver.js
@@ -23,6 +23,27 @@ export async function resolveBlueprint({
   const loc =
     location || (typeof window !== "undefined" ? window.location : null);
 
+  // Context constants derived from the URL (repo/ref of the branch this preview
+  // is for). Merged over the blueprint's own `constants` so a committed
+  // blueprint can use {{REPO}}/{{REF}} placeholders that resolve to the PR
+  // branch, instead of hard-coding `main`. See deriveContextConstants().
+  const blueprintUrlParam = loc
+    ? new URL(loc.href).searchParams.get("blueprint-url")
+    : null;
+  const contextConstants = deriveContextConstants(loc, blueprintUrlParam);
+
+  const finalize = (blueprint) => {
+    const merged =
+      contextConstants && Object.keys(contextConstants).length
+        ? {
+            ...blueprint,
+            constants: { ...(blueprint.constants || {}), ...contextConstants },
+          }
+        : blueprint;
+    saveBlueprint(scopeId, merged);
+    return merged;
+  };
+
   if (loc) {
     const url = new URL(loc.href);
 
@@ -32,8 +53,7 @@ export async function resolveBlueprint({
       try {
         const blueprint = parseBlueprint(blueprintParam);
         console.log("[blueprint] Resolved from ?blueprint= param (inline).");
-        saveBlueprint(scopeId, blueprint);
-        return blueprint;
+        return finalize(blueprint);
       } catch (error) {
         console.warn(
           "[blueprint] Failed to parse ?blueprint= param:",
@@ -43,7 +63,6 @@ export async function resolveBlueprint({
     }
 
     // 2. ?blueprint-url= (remote)
-    const blueprintUrlParam = url.searchParams.get("blueprint-url");
     if (blueprintUrlParam) {
       try {
         const response = await fetch(new URL(blueprintUrlParam, loc.href), {
@@ -58,8 +77,7 @@ export async function resolveBlueprint({
           throw new Error(`Invalid blueprint: ${validation.errors.join(", ")}`);
         }
         console.log("[blueprint] Resolved from ?blueprint-url= param.");
-        saveBlueprint(scopeId, blueprint);
-        return blueprint;
+        return finalize(blueprint);
       } catch (error) {
         console.warn(
           "[blueprint] Failed to fetch ?blueprint-url=:",
@@ -90,8 +108,7 @@ export async function resolveBlueprint({
           );
         }
         console.log("[blueprint] Resolved from defaultBlueprintUrl.");
-        saveBlueprint(scopeId, blueprint);
-        return blueprint;
+        return finalize(blueprint);
       }
     } catch (error) {
       console.warn(
@@ -103,9 +120,82 @@ export async function resolveBlueprint({
 
   // 5. Built-in minimal default
   console.log("[blueprint] Using built-in default.");
-  const fallback = buildMinimalDefault();
-  saveBlueprint(scopeId, fallback);
-  return fallback;
+  return finalize(buildMinimalDefault());
+}
+
+/**
+ * Derive `{{REPO}}` / `{{REF}}` / `{{OWNER}}` constants from the request URL so
+ * a committed blueprint can install the plugin from the branch it is being
+ * previewed for, without hard-coding `main`.
+ *
+ * Sources, lowest to highest precedence:
+ *   1. The `?blueprint-url=` value's own query (`repo`, `branch`/`ref`/
+ *      `commit`/`release`) — e.g. the github-proxy `?repo=o/r&branch=feat/x&path=blueprint.json`
+ *      form. Slash-safe because the ref is a query param.
+ *   2. The `?blueprint-url=` value's path when it is a raw.githubusercontent.com
+ *      URL (`/{owner}/{repo}/{ref}/...`). Best-effort; assumes a single-segment ref.
+ *   3. Explicit `?repo=` / `?ref=` (or `?owner=` / `?branch=`) on the playground URL.
+ *
+ * @param {Location|URL|null} loc
+ * @param {string|null} blueprintUrlParam
+ * @returns {Record<string, string>}
+ */
+function deriveContextConstants(loc, blueprintUrlParam) {
+  const out = {};
+
+  const setRepo = (repo) => {
+    if (typeof repo !== "string" || !repo.includes("/")) return;
+    const [owner, ...rest] = repo.split("/");
+    if (!owner || rest.length === 0 || !rest[0]) return;
+    out.REPO = `${owner}/${rest.join("/")}`;
+    out.OWNER = owner;
+  };
+  const setRef = (ref) => {
+    if (typeof ref === "string" && ref) {
+      out.REF = ref;
+      out.BRANCH = ref;
+    }
+  };
+
+  // 1 & 2. From the ?blueprint-url= value itself.
+  if (blueprintUrlParam) {
+    try {
+      const bu = new URL(blueprintUrlParam, loc?.href ? loc.href : undefined);
+      setRepo(bu.searchParams.get("repo"));
+      setRef(
+        bu.searchParams.get("branch") ||
+          bu.searchParams.get("ref") ||
+          bu.searchParams.get("commit") ||
+          bu.searchParams.get("release"),
+      );
+      if (!out.REPO && bu.hostname === "raw.githubusercontent.com") {
+        const seg = bu.pathname.split("/").filter(Boolean);
+        if (seg.length >= 3) {
+          setRepo(`${seg[0]}/${seg[1]}`);
+          setRef(seg[2]);
+        }
+      }
+    } catch {
+      // Ignore an unparseable blueprint-url; explicit params may still apply.
+    }
+  }
+
+  // 3. Explicit overrides on the playground URL.
+  if (loc?.href) {
+    try {
+      const u = new URL(loc.href);
+      const repo = u.searchParams.get("repo");
+      const owner = u.searchParams.get("owner");
+      const ref = u.searchParams.get("ref") || u.searchParams.get("branch");
+      if (repo) setRepo(repo);
+      if (owner) out.OWNER = owner;
+      if (ref) setRef(ref);
+    } catch {
+      // Ignore.
+    }
+  }
+
+  return out;
 }
 
 function buildMinimalDefault() {

--- a/src/blueprint/resolver.js
+++ b/src/blueprint/resolver.js
@@ -169,10 +169,21 @@ function deriveContextConstants(loc, blueprintUrlParam) {
           bu.searchParams.get("release"),
       );
       if (!out.REPO && bu.hostname === "raw.githubusercontent.com") {
+        // raw URLs come in two shapes:
+        //   /{owner}/{repo}/{ref}/{path}
+        //   /{owner}/{repo}/refs/heads|tags/{ref}/{path}  (explicit form)
         const seg = bu.pathname.split("/").filter(Boolean);
         if (seg.length >= 3) {
           setRepo(`${seg[0]}/${seg[1]}`);
-          setRef(seg[2]);
+          if (
+            seg[2] === "refs" &&
+            (seg[3] === "heads" || seg[3] === "tags") &&
+            seg.length >= 5
+          ) {
+            setRef(seg[4]);
+          } else {
+            setRef(seg[2]);
+          }
         }
       }
     } catch {

--- a/tests/blueprint/resolver.test.js
+++ b/tests/blueprint/resolver.test.js
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 
 // resolveBlueprint depends on window/fetch — test the parser-level fallback path
 import { parseBlueprint } from "../../src/blueprint/parser.js";
+import { resolveBlueprint } from "../../src/blueprint/resolver.js";
 
 describe("resolver: parseBlueprint integration", () => {
   it("parses inline JSON from what ?blueprint= would provide", () => {
@@ -23,5 +24,52 @@ describe("resolver: parseBlueprint integration", () => {
     const b64 = Buffer.from(JSON.stringify(obj)).toString("base64");
     const result = parseBlueprint(`data:application/json;base64,${b64}`);
     assert.strictEqual(result.steps[0].step, "login");
+  });
+});
+
+describe("resolver: context constants (REPO/REF) from URL", () => {
+  // A committed blueprint authored with defaults that should be overridable.
+  const authored = JSON.stringify({
+    constants: { REPO: "ateeducacion/mod_exelearning", REF: "main" },
+    steps: [{ step: "login", username: "admin" }],
+  });
+  const inlineHref = (qs) =>
+    `https://moodle-playground.com/?blueprint=${encodeURIComponent(authored)}${qs}`;
+
+  it("injects REPO/REF/OWNER/BRANCH from explicit ?repo=&ref= (overriding defaults)", async () => {
+    const href = inlineHref("&repo=fork-owner/mod_exelearning&ref=feat/x");
+    const bp = await resolveBlueprint({ scopeId: "t", location: { href } });
+    assert.equal(bp.constants.REPO, "fork-owner/mod_exelearning");
+    assert.equal(bp.constants.OWNER, "fork-owner");
+    assert.equal(bp.constants.REF, "feat/x");
+    assert.equal(bp.constants.BRANCH, "feat/x");
+  });
+
+  it("derives REPO/REF from a github-proxy ?blueprint-url= (slash-safe ref)", async () => {
+    const bpurl =
+      "https://github-proxy.exelearning.dev/?repo=ateeducacion/mod_exelearning&branch=feat/playground&path=blueprint.json";
+    const href = inlineHref(`&blueprint-url=${encodeURIComponent(bpurl)}`);
+    const bp = await resolveBlueprint({ scopeId: "t", location: { href } });
+    assert.equal(bp.constants.REPO, "ateeducacion/mod_exelearning");
+    assert.equal(bp.constants.REF, "feat/playground");
+  });
+
+  it("derives REPO/REF from a raw.githubusercontent ?blueprint-url=", async () => {
+    const bpurl =
+      "https://raw.githubusercontent.com/owner/repo/branchx/blueprint.json";
+    const href = inlineHref(`&blueprint-url=${encodeURIComponent(bpurl)}`);
+    const bp = await resolveBlueprint({ scopeId: "t", location: { href } });
+    assert.equal(bp.constants.REPO, "owner/repo");
+    assert.equal(bp.constants.REF, "branchx");
+  });
+
+  it("leaves authored constants untouched when no context is present", async () => {
+    const bp = await resolveBlueprint({
+      scopeId: "t",
+      location: { href: inlineHref("") },
+    });
+    assert.equal(bp.constants.REPO, "ateeducacion/mod_exelearning");
+    assert.equal(bp.constants.REF, "main");
+    assert.equal(bp.constants.OWNER, undefined);
   });
 });

--- a/tests/blueprint/resolver.test.js
+++ b/tests/blueprint/resolver.test.js
@@ -63,6 +63,15 @@ describe("resolver: context constants (REPO/REF) from URL", () => {
     assert.equal(bp.constants.REF, "branchx");
   });
 
+  it("derives REF from the explicit raw refs/heads/<branch> shape (not 'refs')", async () => {
+    const bpurl =
+      "https://raw.githubusercontent.com/ateeducacion/mod_exelearning/refs/heads/main/blueprint.json";
+    const href = inlineHref(`&blueprint-url=${encodeURIComponent(bpurl)}`);
+    const bp = await resolveBlueprint({ scopeId: "t", location: { href } });
+    assert.equal(bp.constants.REPO, "ateeducacion/mod_exelearning");
+    assert.equal(bp.constants.REF, "main");
+  });
+
   it("leaves authored constants untouched when no context is present", async () => {
     const bp = await resolveBlueprint({
       scopeId: "t",

--- a/tests/shared/github-proxy-worker.test.js
+++ b/tests/shared/github-proxy-worker.test.js
@@ -1193,3 +1193,72 @@ describe("github-proxy-worker Dropbox shared links", () => {
     assert.equal(response.status, 400);
   });
 });
+
+describe("github-proxy-worker ?path= raw file mode", () => {
+  it("serves a raw repo file at a branch ref with CORS (slash-safe ref)", async () => {
+    const calls = [];
+    global.fetch = async (url, init = {}) => {
+      calls.push({ url: String(url), init });
+      return new Response('{"steps":[]}', {
+        status: 200,
+        headers: { "Content-Type": "text/plain; charset=utf-8" },
+      });
+    };
+
+    const response = await worker.fetch(
+      new Request(
+        "https://proxy.example/?repo=owner/repo&branch=feat/x&path=blueprint.json",
+      ),
+      {},
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(calls.length, 1);
+    assert.equal(
+      calls[0].url,
+      "https://raw.githubusercontent.com/owner/repo/feat/x/blueprint.json",
+    );
+    assert.equal(response.headers.get("X-Playground-Cors-Proxy"), "true");
+    assert.match(response.headers.get("Content-Type"), /application\/json/i);
+    assert.equal(await response.text(), '{"steps":[]}');
+  });
+
+  it("strips leading slashes from the path", async () => {
+    let captured;
+    global.fetch = async (url) => {
+      captured = String(url);
+      return new Response("x", {
+        status: 200,
+        headers: { "Content-Type": "text/plain" },
+      });
+    };
+
+    await worker.fetch(
+      new Request(
+        "https://proxy.example/?repo=owner/repo&branch=main&path=/a/b.json",
+      ),
+      {},
+    );
+
+    assert.equal(
+      captured,
+      "https://raw.githubusercontent.com/owner/repo/main/a/b.json",
+    );
+  });
+
+  it("returns 404 when the raw file is missing", async () => {
+    global.fetch = async () =>
+      new Response("Not Found", { status: 404, statusText: "Not Found" });
+
+    const response = await worker.fetch(
+      new Request(
+        "https://proxy.example/?repo=owner/repo&branch=main&path=missing.json",
+      ),
+      {},
+    );
+
+    assert.equal(response.status, 404);
+    const body = await response.json();
+    assert.equal(body.error, "Upstream server returned an error.");
+  });
+});


### PR DESCRIPTION
## Problem

PR-preview links (from `action-moodle-playground-pr-preview`) **inline the whole blueprint as base64 in `?blueprint=`**. For rich blueprints (several `runPhpCode` steps, seeded content) the URL overflows the length limit and the host returns **HTTP 414 "URI Too Long"**.

The natural alternative — `?blueprint-url=` pointing at the branch's own committed `blueprint.json` (a short link) — does not work on its own: that file hard-codes the plugin install ref (`main`), so a preview could not test the PR branch.

## Solution

1. **Context constants in the resolver** (`src/blueprint/resolver.js`): when resolving a blueprint, derive `REPO`, `OWNER`, `REF`, `BRANCH` and merge them **over** the blueprint's own `constants`. This lets a committed `blueprint.json` use `{{REPO}}`/`{{REF}}` placeholders that resolve to the branch being previewed, while keeping safe `main` defaults for direct opens. Sources, by increasing priority:
   - the `?blueprint-url=` value's own query — the github-proxy form `…/?repo={owner/repo}&branch={ref}&path=blueprint.json` (slash-safe, the ref is a query param);
   - a `raw.githubusercontent.com/{owner}/{repo}/{ref}/…` `?blueprint-url=` (handles both the plain `/{ref}/` and the explicit `/refs/heads|tags/{ref}/` shapes);
   - explicit `?repo=` / `?ref=` (or `?owner=` / `?branch=`) on the playground URL.

2. **`?path=` mode in the github-proxy worker** (`scripts/github-proxy-worker.js`): serves a single raw repo file (e.g. the branch's `blueprint.json`) **with CORS**, so the preview can fetch it cross-origin without inlining. The ref travels as a query param, so refs with slashes (`feat/x`) work losslessly.

With this, the preview link becomes:
`https://moodle-playground.com/?blueprint-url=https://github-proxy.exelearning.dev/?repo=<owner/repo>&branch=<branch>&path=blueprint.json`
— short (no 414), CORS-clean, and the plugin installs from the PR branch via `{{REPO}}`/`{{REF}}`.

## Tests

- `tests/blueprint/resolver.test.js`: constant injection (explicit params, proxy-form and raw `?blueprint-url=`, the explicit `refs/heads/<branch>` shape, and the no-context no-op).
- `tests/shared/github-proxy-worker.test.js`: `?path=` mode (branch ref, leading-slash trim, 404).
- Full blueprint suite (165) + worker suite (41) green; biome clean.

## Deployment

Requires **deploying the updated worker** (`?path=`) and publishing the front-end (resolver) so the consumer side (`mod_exelearning`) can point `blueprint-url` at the proxy form. Backward compatible: blueprints without `{{REPO}}`/`{{REF}}` and existing links keep working unchanged.
