### PR TITLE
feat(shell): move version config into the Info panel, drop the gear popover

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,9 +114,6 @@
               <rect x="13" y="0.5" width="4.5" height="15" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/>
             </svg>
           </button>
-          <button type="button" id="settings-button" class="icon-button" aria-label="Open settings" aria-expanded="false" title="Settings">
-            <span aria-hidden="true">&#9881;</span>
-          </button>
         </div>
       </header>
 
@@ -141,20 +138,52 @@
           </div>
 
           <section id="info-panel" class="side-panel__content" role="tabpanel" aria-labelledby="info-tab" data-panel-view="info">
-            <div class="settings-field">
-              <span>Moodle version</span>
-              <span id="current-moodle-label" class="settings-value">-</span>
-            </div>
-            <div class="settings-field">
-              <span>PHP version</span>
-              <span id="current-php-label" class="settings-value">-</span>
-            </div>
-            <div class="settings-field">
-              <span>Runtime ID</span>
-              <span id="current-runtime-label" class="settings-value">-</span>
-            </div>
-            <div class="settings-actions">
-              <button type="button" id="reset-button" class="danger">Reset Playground</button>
+            <div class="info-stack">
+              <div class="info-section">
+                <div class="section-label">
+                  <span>Configuration</span>
+                  <span id="config-status" class="status-pill"><span class="dot"></span>Running</span>
+                </div>
+                <div class="field">
+                  <label for="info-moodle-version">Moodle version</label>
+                  <select id="info-moodle-version"></select>
+                </div>
+                <div class="field">
+                  <label for="info-php-version">PHP version</label>
+                  <select id="info-php-version"></select>
+                </div>
+                <div id="config-warning" class="warn-banner is-hidden" role="alert">
+                  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+                    <path d="M8 1.6 1 14h14L8 1.6Z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/>
+                    <path d="M8 6.4v3.3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+                    <circle cx="8" cy="11.7" r="0.6" fill="currentColor"/>
+                  </svg>
+                  <span>Applying will reset Moodle to a clean install. All current data will be lost.</span>
+                </div>
+                <div class="action-row">
+                  <button type="button" id="config-apply" class="danger grow is-hidden">Apply &amp; Reset</button>
+                </div>
+              </div>
+
+              <hr class="divider">
+
+              <div class="info-section">
+                <div class="section-label"><span>Runtime</span></div>
+                <div class="value-row">
+                  <span class="vr-key">Runtime ID</span>
+                  <button type="button" id="runtime-id-chip" class="copy-chip" title="Copy runtime ID">
+                    <span id="runtime-id-value">-</span>
+                    <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+                      <rect x="5" y="5" width="8" height="9" rx="1.5" stroke="currentColor" stroke-width="1.3"/>
+                      <path d="M11 5V3.5A1.5 1.5 0 0 0 9.5 2h-5A1.5 1.5 0 0 0 3 3.5v7A1.5 1.5 0 0 0 4.5 12H5" stroke="currentColor" stroke-width="1.3" fill="none"/>
+                    </svg>
+                  </button>
+                </div>
+                <div class="action-row">
+                  <button type="button" id="reset-button" class="danger grow">Reset Playground</button>
+                </div>
+                <p class="muted-help">Reset reinstalls the current configuration from scratch. Your courses and data are wiped.</p>
+              </div>
             </div>
           </section>
 
@@ -209,30 +238,6 @@
             </a>
           </footer>
         </aside>
-      </div>
-    </div>
-
-    <div id="settings-overlay" class="settings-popover-overlay" aria-hidden="true"></div>
-    <div id="settings-popover" class="settings-popover" role="dialog" aria-label="Playground Settings">
-      <h2 class="settings-popover__title">Playground Settings</h2>
-
-      <label class="settings-popover__field">
-        <span>Moodle Version</span>
-        <select id="settings-moodle-version"></select>
-      </label>
-
-      <label class="settings-popover__field">
-        <span>PHP Version</span>
-        <select id="settings-php-version"></select>
-      </label>
-
-      <div class="settings-popover__warning">
-        Applying new settings will reset the Moodle site to its initial state. All current data will be lost.
-      </div>
-
-      <div class="settings-popover__actions">
-        <button type="button" id="settings-cancel">Cancel</button>
-        <button type="button" id="settings-apply" class="danger">Apply &amp; Reset</button>
       </div>
     </div>
 

--- a/src/shell/main.js
+++ b/src/shell/main.js
@@ -45,16 +45,13 @@ const els = {
   home: document.querySelector("#home-button"),
   refresh: document.querySelector("#refresh-button"),
   reset: document.querySelector("#reset-button"),
-  settingsButton: document.querySelector("#settings-button"),
-  settingsPopover: document.querySelector("#settings-popover"),
-  settingsOverlay: document.querySelector("#settings-overlay"),
-  settingsMoodleVersion: document.querySelector("#settings-moodle-version"),
-  settingsPhpVersion: document.querySelector("#settings-php-version"),
-  settingsApply: document.querySelector("#settings-apply"),
-  settingsCancel: document.querySelector("#settings-cancel"),
-  currentMoodleLabel: document.querySelector("#current-moodle-label"),
-  currentPhpLabel: document.querySelector("#current-php-label"),
-  currentRuntimeLabel: document.querySelector("#current-runtime-label"),
+  infoMoodleVersion: document.querySelector("#info-moodle-version"),
+  infoPhpVersion: document.querySelector("#info-php-version"),
+  configStatus: document.querySelector("#config-status"),
+  configWarning: document.querySelector("#config-warning"),
+  configApply: document.querySelector("#config-apply"),
+  runtimeIdChip: document.querySelector("#runtime-id-chip"),
+  runtimeIdValue: document.querySelector("#runtime-id-value"),
   infoPanel: document.querySelector("#info-panel"),
   infoTab: document.querySelector("#info-tab"),
   sidePanel: document.querySelector("#side-panel"),
@@ -451,105 +448,92 @@ function bindServiceWorkerMessages() {
   });
 }
 
-function populateSettingsModal() {
-  if (!els.settingsMoodleVersion || !els.settingsPhpVersion) {
+function populateConfigSelects() {
+  if (!els.infoMoodleVersion || !els.infoPhpVersion) {
     return;
   }
 
   // Populate Moodle version dropdown
-  els.settingsMoodleVersion.innerHTML = "";
+  els.infoMoodleVersion.innerHTML = "";
   for (const branch of MOODLE_BRANCHES) {
     const option = document.createElement("option");
     option.value = branch.branch;
     option.textContent = branch.label;
-    els.settingsMoodleVersion.append(option);
+    els.infoMoodleVersion.append(option);
   }
-  els.settingsMoodleVersion.value = currentMoodleBranch;
+  els.infoMoodleVersion.value = currentMoodleBranch;
 
   // Populate PHP version dropdown based on selected Moodle branch
   updatePhpVersionDropdown(currentMoodleBranch);
-  els.settingsPhpVersion.value = currentPhpVersion;
+  els.infoPhpVersion.value = currentPhpVersion;
 }
 
 function updatePhpVersionDropdown(branch) {
-  if (!els.settingsPhpVersion) {
+  if (!els.infoPhpVersion) {
     return;
   }
 
   const compatibleVersions = getCompatiblePhpVersions(branch);
-  const previousValue = els.settingsPhpVersion.value;
-  els.settingsPhpVersion.innerHTML = "";
+  const previousValue = els.infoPhpVersion.value;
+  els.infoPhpVersion.innerHTML = "";
   for (const version of compatibleVersions) {
     const option = document.createElement("option");
     option.value = version;
     option.textContent = `PHP ${version}`;
-    els.settingsPhpVersion.append(option);
+    els.infoPhpVersion.append(option);
   }
 
   // Keep current selection if still compatible, otherwise fall back
   if (compatibleVersions.includes(previousValue)) {
-    els.settingsPhpVersion.value = previousValue;
+    els.infoPhpVersion.value = previousValue;
   } else if (compatibleVersions.includes(DEFAULT_PHP_VERSION)) {
-    els.settingsPhpVersion.value = DEFAULT_PHP_VERSION;
+    els.infoPhpVersion.value = DEFAULT_PHP_VERSION;
   } else {
-    els.settingsPhpVersion.value = compatibleVersions[0];
+    els.infoPhpVersion.value = compatibleVersions[0];
   }
 }
 
-function updateCurrentVersionLabels() {
-  const branchInfo = MOODLE_BRANCHES.find(
-    (b) => b.branch === currentMoodleBranch,
-  );
-  if (els.currentMoodleLabel) {
-    els.currentMoodleLabel.textContent = branchInfo
-      ? branchInfo.label
-      : currentMoodleBranch;
-  }
-  if (els.currentPhpLabel) {
-    els.currentPhpLabel.textContent = `PHP ${currentPhpVersion}`;
-  }
-  if (els.currentRuntimeLabel) {
-    els.currentRuntimeLabel.textContent = currentRuntimeId;
-  }
-}
-
-function openSettingsPopover() {
-  if (!els.settingsPopover) {
+// Reflect the applied runtime in the Info panel: when the selected versions
+// differ from what is actually running the config is "dirty". Changing a version
+// is destructive (it resets the site), so the Apply button stays inert and the
+// warning stays hidden until the selection actually differs.
+function refreshDirtyState() {
+  if (!els.infoMoodleVersion || !els.infoPhpVersion) {
     return;
   }
-  populateSettingsModal();
-  els.settingsPopover.classList.add("is-open");
-  els.settingsOverlay.classList.add("is-open");
-  els.settingsOverlay.setAttribute("aria-hidden", "false");
-  els.settingsButton.setAttribute("aria-expanded", "true");
-  // Focus the first select for keyboard users
-  const firstInput = els.settingsPopover.querySelector("select");
-  if (firstInput) {
-    firstInput.focus();
+  const dirty =
+    els.infoMoodleVersion.value !== currentMoodleBranch ||
+    els.infoPhpVersion.value !== currentPhpVersion;
+
+  if (els.configStatus) {
+    els.configStatus.className = dirty ? "dirty-note" : "status-pill";
+    els.configStatus.innerHTML = dirty
+      ? '<span class="dot"></span>Unsaved'
+      : '<span class="dot"></span>Running';
   }
+  // Changing a version is destructive; the Apply button and warning only appear
+  // once the selection differs from what is running. To revert, reselect the
+  // original version — the dirty state clears itself.
+  els.configWarning?.classList.toggle("is-hidden", !dirty);
+  els.configApply?.classList.toggle("is-hidden", !dirty);
 }
 
-function closeSettingsPopover() {
-  if (!els.settingsPopover) {
-    return;
+function updateConfigState() {
+  if (els.runtimeIdValue) {
+    els.runtimeIdValue.textContent = currentRuntimeId;
   }
-  els.settingsPopover.classList.remove("is-open");
-  els.settingsOverlay.classList.remove("is-open");
-  els.settingsOverlay.setAttribute("aria-hidden", "true");
-  els.settingsButton.setAttribute("aria-expanded", "false");
-  els.settingsButton.focus();
+  refreshDirtyState();
 }
 
-function applySettingsAndReset() {
-  const newBranch = els.settingsMoodleVersion?.value;
-  const newPhp = els.settingsPhpVersion?.value;
-  closeSettingsPopover();
+function applyConfigAndReset() {
+  const newBranch = els.infoMoodleVersion?.value;
+  const newPhp = els.infoPhpVersion?.value;
 
   if (newBranch === currentMoodleBranch && newPhp === currentPhpVersion) {
     return;
   }
 
-  // Update URL params and reload
+  // Update URL params and reload — a fresh runtime + scope for the new versions.
   const url = new URL(window.location.href);
   url.searchParams.set("php", newPhp);
   const branchInfo = MOODLE_BRANCHES.find((b) => b.branch === newBranch);
@@ -602,43 +586,36 @@ async function main() {
       : previous?.path || preferredPath;
   els.address.value = currentPath;
 
-  updateCurrentVersionLabels();
+  populateConfigSelects();
+  updateConfigState();
 
-  // Settings popover event listeners
-  if (els.settingsButton) {
-    els.settingsButton.addEventListener("click", () => {
-      const isOpen = els.settingsPopover?.classList.contains("is-open");
-      if (isOpen) {
-        closeSettingsPopover();
-      } else {
-        openSettingsPopover();
+  // Configuration (Info panel) event listeners
+  if (els.infoMoodleVersion) {
+    els.infoMoodleVersion.addEventListener("change", () => {
+      updatePhpVersionDropdown(els.infoMoodleVersion.value);
+      refreshDirtyState();
+    });
+  }
+  if (els.infoPhpVersion) {
+    els.infoPhpVersion.addEventListener("change", refreshDirtyState);
+  }
+  if (els.configApply) {
+    els.configApply.addEventListener("click", applyConfigAndReset);
+  }
+  if (els.runtimeIdChip) {
+    els.runtimeIdChip.addEventListener("click", () => {
+      navigator.clipboard?.writeText(currentRuntimeId || "");
+      const label = els.runtimeIdValue;
+      if (!label) {
+        return;
       }
+      const original = label.textContent;
+      label.textContent = "✓ copied";
+      setTimeout(() => {
+        label.textContent = original;
+      }, 1400);
     });
   }
-  if (els.settingsOverlay) {
-    els.settingsOverlay.addEventListener("click", closeSettingsPopover);
-  }
-  if (els.settingsCancel) {
-    els.settingsCancel.addEventListener("click", closeSettingsPopover);
-  }
-  if (els.settingsApply) {
-    els.settingsApply.addEventListener("click", applySettingsAndReset);
-  }
-  if (els.settingsMoodleVersion) {
-    els.settingsMoodleVersion.addEventListener("change", () => {
-      updatePhpVersionDropdown(els.settingsMoodleVersion.value);
-    });
-  }
-
-  // Close popover on Escape
-  document.addEventListener("keydown", (event) => {
-    if (
-      event.key === "Escape" &&
-      els.settingsPopover?.classList.contains("is-open")
-    ) {
-      closeSettingsPopover();
-    }
-  });
 
   bindShellChannel();
   bindServiceWorkerMessages();

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -30,6 +30,9 @@
   --chrome-active: rgba(255, 255, 255, 0.25);
   --color-danger: #dc3545;
   --color-danger-hover: #c82333;
+  --color-danger-light: rgba(220, 53, 69, 0.08);
+  --color-danger-border: rgba(220, 53, 69, 0.25);
+  --color-success: #2f9e44;
 
   /* Semantic */
   --bg-page: var(--color-gray-100);
@@ -672,88 +675,6 @@ button.danger:hover {
   }
 }
 
-/* ── Settings popover (replaces modal) ────────────── */
-.settings-popover {
-  position: fixed;
-  top: calc(var(--navbar-height) + var(--space-sm));
-  right: var(--space-lg);
-  z-index: 100;
-  width: 360px;
-  max-width: calc(100vw - 32px);
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-popover);
-  padding: var(--space-xl);
-  display: none;
-}
-
-.settings-popover.is-open {
-  display: block;
-}
-
-.settings-popover__title {
-  margin: 0 0 var(--space-lg);
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--text-heading);
-}
-
-.settings-popover__field {
-  display: grid;
-  gap: var(--space-xs);
-  margin-bottom: var(--space-lg);
-}
-
-.settings-popover__field span {
-  color: var(--text-muted);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.settings-popover__field select {
-  padding: 7px 12px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  background: var(--bg-input);
-  color: var(--text);
-  font: inherit;
-}
-
-.settings-popover__field select:focus {
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px var(--color-orange-light);
-}
-
-.settings-popover__warning {
-  padding: var(--space-md);
-  border-radius: var(--radius-md);
-  background: var(--color-orange-light);
-  border: 1px solid var(--color-orange-border);
-  color: var(--color-orange-hover);
-  font-size: 13px;
-  line-height: 1.45;
-  margin-bottom: var(--space-lg);
-}
-
-.settings-popover__actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--space-sm);
-}
-
-/* Overlay behind popover for outside-click dismiss */
-.settings-popover-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 99;
-  display: none;
-}
-
-.settings-popover-overlay.is-open {
-  display: block;
-}
-
 /* ── Responsive ───────────────────────────────────── */
 @media (max-width: 1080px) {
   .workspace {
@@ -794,10 +715,176 @@ button.danger:hover {
   .browser-toolbar__actions {
     justify-content: flex-end;
   }
+}
 
-  .settings-popover {
-    right: var(--space-sm);
-    left: var(--space-sm);
-    width: auto;
+/* ── Config / Info building blocks (sidebar redesign) ── */
+.info-stack {
+  display: grid;
+  gap: var(--space-xl);
+}
+.info-section {
+  display: grid;
+  gap: var(--space-md);
+}
+
+.section-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.field {
+  display: grid;
+  gap: var(--space-xs);
+}
+.field > label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+.field select {
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-input);
+  color: var(--text);
+}
+.field select:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--color-orange-light);
+  outline: none;
+}
+.field select:disabled {
+  background: var(--bg-surface-muted);
+  color: var(--text-muted);
+  cursor: not-allowed;
+}
+
+.value-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-md);
+  padding: 9px 0;
+  border-bottom: 1px solid var(--border-light);
+}
+.value-row:last-child {
+  border-bottom: 0;
+}
+.value-row .vr-key {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-success);
+}
+.status-pill .dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--color-success);
+}
+
+.dirty-note {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent);
+}
+.dirty-note .dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+.warn-banner {
+  display: flex;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  border-radius: var(--radius-md);
+  background: var(--color-orange-light);
+  border: 1px solid var(--color-orange-border);
+  color: var(--color-orange-hover);
+  font-size: 12.5px;
+  line-height: 1.45;
+}
+.warn-banner svg {
+  flex: 0 0 auto;
+  margin-top: 1px;
+}
+
+.action-row {
+  display: flex;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+.action-row .grow {
+  flex: 1;
+}
+
+.copy-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: ui-monospace, "SFMono-Regular", monospace;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text-heading);
+  background: var(--bg-surface-muted);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-sm);
+  padding: 4px 8px;
+  cursor: pointer;
+}
+.copy-chip:hover {
+  border-color: var(--color-gray-400);
+  background: var(--color-gray-100);
+}
+
+.divider {
+  height: 1px;
+  background: var(--border-light);
+  border: 0;
+  margin: 0;
+}
+
+.muted-help {
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.45;
+  margin: 0;
+}
+
+.reveal {
+  animation: reveal 0.18s ease;
+}
+@keyframes reveal {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
   }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* generic hide utility (used by the Info-panel config: warning + apply button) */
+.is-hidden {
+  display: none;
 }

--- a/tests/e2e/helpers.mjs
+++ b/tests/e2e/helpers.mjs
@@ -88,8 +88,7 @@ export async function captureDiagnostics(page, testInfo, diagnostics) {
           addressInput instanceof HTMLInputElement
             ? addressInput.disabled
             : null,
-        runtimeLabel: document.querySelector("#current-runtime-label")
-          ?.textContent,
+        runtimeLabel: document.querySelector("#runtime-id-value")?.textContent,
         logPanel: document.querySelector("#log-panel")?.textContent || "",
         siteFrameSrc:
           document.querySelector("#site-frame")?.getAttribute("src") || null,
@@ -193,7 +192,7 @@ export async function openPlayground(page) {
  * Use for tests that only interact with the shell, not Moodle content inside the iframe.
  */
 export async function waitForShellReady(page) {
-  await expect(page.locator("#current-runtime-label")).not.toHaveText("-", {
+  await expect(page.locator("#runtime-id-value")).not.toHaveText("-", {
     timeout: readyTimeoutMs,
   });
   await expect(page.locator("#address-input")).toBeEnabled({
@@ -202,7 +201,7 @@ export async function waitForShellReady(page) {
 }
 
 async function waitForRuntimeSelectionReady(page, timeout = readyTimeoutMs) {
-  await expect(page.locator("#current-runtime-label")).not.toHaveText("-", {
+  await expect(page.locator("#runtime-id-value")).not.toHaveText("-", {
     timeout,
   });
 }

--- a/tests/e2e/shell.spec.mjs
+++ b/tests/e2e/shell.spec.mjs
@@ -124,9 +124,9 @@ test("side panel opens and shows tabs", async ({ page, playground }) => {
   );
   await expect(page.locator("#side-panel")).not.toHaveClass(/is-collapsed/);
 
-  await expect(page.locator("#current-moodle-label")).not.toHaveText("-");
-  await expect(page.locator("#current-php-label")).not.toHaveText("-");
-  await expect(page.locator("#current-runtime-label")).not.toHaveText("-");
+  await expect(page.locator("#info-moodle-version")).toBeVisible();
+  await expect(page.locator("#info-php-version")).toBeVisible();
+  await expect(page.locator("#runtime-id-value")).not.toHaveText("-");
 });
 
 test("logs tab displays runtime log entries", async ({ page, playground }) => {
@@ -155,22 +155,48 @@ test("blueprint tab shows the active blueprint JSON", async ({
   expect(blueprintText).toContain('"installMoodle"');
 });
 
-test("settings popover opens and shows version selectors", async ({
+test("info panel hosts the version config with a dirty-state apply", async ({
   page,
   playground,
 }) => {
   await playground.open();
 
-  await page.locator("#settings-button").click();
-  await expect(page.locator("#settings-popover")).toHaveClass(/is-open/);
+  // The floating settings popover and gear button are gone — the version config
+  // now lives in the Info panel (single source of truth).
+  await expect(page.locator("#settings-button")).toHaveCount(0);
+  await expect(page.locator("#settings-popover")).toHaveCount(0);
+
+  await page.locator("#panel-toggle-button").click();
 
   const moodleOptions = await page
-    .locator("#settings-moodle-version option")
+    .locator("#info-moodle-version option")
     .count();
   expect(moodleOptions).toBeGreaterThan(0);
-
-  const phpOptions = await page.locator("#settings-php-version option").count();
+  const phpOptions = await page.locator("#info-php-version option").count();
   expect(phpOptions).toBeGreaterThan(0);
+
+  // Clean state: no Apply button and no destructive warning.
+  await expect(page.locator("#config-apply")).toBeHidden();
+  await expect(page.locator("#config-warning")).toBeHidden();
+
+  // Changing a version reveals the Apply button + the warning. Reselecting the
+  // original value clears the dirty state (no Discard button needed).
+  const current = await page.locator("#info-moodle-version").inputValue();
+  const other = await page
+    .locator("#info-moodle-version option")
+    .evaluateAll(
+      (opts, cur) => opts.find((o) => o.value !== cur)?.value,
+      current,
+    );
+  if (other) {
+    await page.locator("#info-moodle-version").selectOption(other);
+    await expect(page.locator("#config-apply")).toBeVisible();
+    await expect(page.locator("#config-warning")).toBeVisible();
+
+    await page.locator("#info-moodle-version").selectOption(current);
+    await expect(page.locator("#config-apply")).toBeHidden();
+    await expect(page.locator("#config-warning")).toBeHidden();
+  }
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Unifies the PHP/version configuration: removes the floating **Playground Settings** popover and the ⚙ gear button, integrating the version controls into the sidebar **Info** panel (single source of truth). Only the sidebar toggle remains in the toolbar.

Implements **variant A (inline dirty-state)** from the design handoff:
- **Configuration**: Moodle + PHP selects, always visible; a `Running` pill while the selection matches the live runtime.
- Changing a version is destructive, so **Apply & Reset** and the data-loss **warning only appear once the selection differs** (pill → `Unsaved`). Reselecting the original value hides them again — no Discard / no "No changes" button.
- **Runtime**: copyable Runtime ID chip + Reset Playground.

CSS: new building-block classes (status-pill, dirty-note, field, value-row, warn-banner, action-row, copy-chip, divider, muted-help, info-stack, reveal, `.is-hidden`); the old `.settings-popover*` styles removed. Tokens `--color-success`/`--color-danger-light`/`--color-danger-border` added.

**e2e:** readiness signal moved to the new `#runtime-id-value` chip; the popover test is now a config dirty-state test. `make lint` ✅ · `make test` (460) ✅ · redesign e2e (boot, side panel, config) ✅ locally.

This is the reference for the same change in the sibling playgrounds (omeka / nextcloud / facturascripts).