### PR TITLE
fix(persistence): collapse journal ops before hydrating to avoid flush OOM

### DIFF
--- a/src/runtime/fs-persistence.js
+++ b/src/runtime/fs-persistence.js
@@ -79,11 +79,23 @@ async function clearDb(name) {
   db.close();
 }
 
+// Collapse the raw journal ops, THEN hydrate only the survivors — the canonical
+// fs-journal order (WordPress Playground's hydrate-fs-writes middleware does
+// `hydrateUpdateFileOps(php, normalizeFilesystemOperations(ops))`). Hydrating the
+// raw, un-collapsed list reads every write's content into memory: a heavy install
+// rewrites the multi-MB SQLite DB hundreds of times within one flush window, so
+// hydrating each one OOMs ("Array buffer allocation failed"). Normalizing first
+// collapses the repeated same-path writes (and folds write-temp + rename) so each
+// changed file is read exactly once.
+export async function collapseAndHydrate(rawPhp, ops) {
+  return hydrateUpdateFileOps(rawPhp, normalizeFilesystemOperations(ops));
+}
+
 async function flushOps(rawPhp, db, pendingOps) {
   if (pendingOps.length === 0) return;
   const ops = pendingOps.splice(0);
   try {
-    const hydrated = await hydrateUpdateFileOps(rawPhp, ops);
+    const hydrated = await collapseAndHydrate(rawPhp, ops);
     const current = await loadOps(db);
     const merged = normalizeFilesystemOperations([...current, ...hydrated]);
     await replaceOps(db, merged);

--- a/tests/runtime/fs-persistence.test.js
+++ b/tests/runtime/fs-persistence.test.js
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { collapseAndHydrate } from "../../src/runtime/fs-persistence.js";
+
+// Regression guard for the journal-flush OOM: a heavy install rewrites the same
+// (multi-MB) SQLite DB hundreds of times within one debounce window. Hydrating
+// the raw, un-collapsed op list read every write's content into memory at once →
+// `RangeError: Array buffer allocation failed`. collapseAndHydrate must normalize
+// FIRST (collapsing same-path writes) so each changed file is read exactly once.
+test("collapseAndHydrate reads each changed file once, not once per write", async () => {
+  const path = "/persist/data.sq3";
+  const ops = Array.from({ length: 500 }, () => ({
+    operation: "WRITE",
+    path,
+    nodeType: "file",
+  }));
+
+  const reads = new Map();
+  const fakePhp = {
+    readFileAsBuffer(p) {
+      reads.set(p, (reads.get(p) || 0) + 1);
+      return new Uint8Array(8);
+    },
+  };
+
+  const hydrated = await collapseAndHydrate(fakePhp, ops);
+
+  // 500 writes to one path collapse to a single WRITE op...
+  const writes = hydrated.filter(
+    (op) => op.operation === "WRITE" && op.path === path,
+  );
+  assert.equal(writes.length, 1);
+  // ...and the file is read exactly once (the OOM guard), not 500 times.
+  assert.equal(reads.get(path), 1);
+});


### PR DESCRIPTION
## Problem (reported in prod)
Opening the playground with a heavy `?blueprint-url=` (e.g. exelearning/mod_exeweb) floods the console with hundreds of `Journal failed to hydrate a file on flush: ... no longer exists` warnings, then `RangeError: Array buffer allocation failed`, and persistence breaks during the install.

## Root cause
`flushOps` (Wave-4 persistence, identical in all 4 playgrounds) hydrated **before** deduping:
```js
const hydrated = await hydrateUpdateFileOps(rawPhp, ops);          // reads EVERY raw op's file
const merged   = normalizeFilesystemOperations([...current, ...hydrated]);
```
A heavy install rewrites the multi-MB SQLite DB hundreds of times per 1.5s flush window → thousands of same-path WRITE ops. `hydrateUpdateFileOps` reads each into a `Uint8Array` and retains all until `Promise.all` resolves → heap OOM. The "no longer exists" flood is transient SQLite-rename / `filedir/**/*.tmp` churn.

## Fix
Normalize **before** hydrate — the canonical fs-journal order, matching WordPress Playground's `hydrate-fs-writes` middleware (`hydrateUpdateFileOps(php, normalizeFilesystemOperations(ops))`). New `collapseAndHydrate` helper; same final op set, but each changed file is read **once per flush** instead of once per write.

## Test (TDD)
New `tests/runtime/fs-persistence.test.js`: 500 WRITE ops to one path ⇒ collapses to a single op and the file is read **once** (the OOM guard). Written failing first (helper missing), green after the fix.

`make test` 461/461 ✅ · `make lint` ✅. Reference for the identical fix in omeka / nextcloud / facturascripts.