### PR TITLE
Load ICU data from unpkg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ build-version:
 	npm run build:version
 
 build-worker:
-	npm run build:worker
+	npm run build-worker
 
 # Fast prepare for local iteration: install deps and rebuild the worker bundle only.
 prepare: deps build-version build-worker

--- a/esbuild.worker.mjs
+++ b/esbuild.worker.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { readFileSync } from "node:fs";
+import { readFileSync, rmSync } from "node:fs";
 import { createRequire } from "node:module";
 import { build } from "esbuild";
 import { ALL_PHP_VERSIONS as MOODLE_PHP_VERSIONS } from "./src/shared/version-resolver.js";
@@ -59,6 +59,8 @@ const phpWasmIcuDataPlugin = {
     }));
   },
 };
+
+rmSync("dist", { force: true, recursive: true });
 
 await Promise.all([
   // Bundle the PHP worker (Web Worker — uses @php-wasm dependencies)

--- a/esbuild.worker.mjs
+++ b/esbuild.worker.mjs
@@ -1,11 +1,7 @@
 #!/usr/bin/env node
 
-import { createRequire } from "node:module";
-import { dirname } from "node:path";
 import { build } from "esbuild";
 import { ALL_PHP_VERSIONS as MOODLE_PHP_VERSIONS } from "./src/shared/version-resolver.js";
-
-const require = createRequire(import.meta.url);
 
 // Only bundle the PHP runtime versions Moodle actually supports. @php-wasm/web's
 // loadWebRuntime() switch dynamically imports every @php-wasm/web-X-Y package,
@@ -39,17 +35,18 @@ const stripUnusedPhpVersions = {
   },
 };
 
-// @php-wasm/web 3.1.22+ references the ICU data file via the source-layout
-// path `../intl/shared/icu.dat`, but the published tarball ships the file at
-// `./shared/icu.dat` (no sibling `intl` package exists on npm). Without a
-// resolver hook, esbuild fails with "Could not resolve ../intl/shared/icu.dat"
-// when bundling the worker. See WordPress/wordpress-playground#2776.
-const phpWasmWebDir = dirname(require.resolve("@php-wasm/web/package.json"));
+const ICU_DATA_URL =
+  "https://unpkg.com/@php-wasm/web@3.1.36/shared/icu.dat";
 const phpWasmIcuDataPlugin = {
   name: "php-wasm-icu-data",
   setup(b) {
-    b.onResolve({ filter: /(^|\/)intl\/shared\/icu\.dat$/ }, () => ({
-      path: `${phpWasmWebDir}/shared/icu.dat`,
+    b.onResolve({ filter: /(^|\/)(?:intl\/shared|shared)\/icu\.dat$/ }, () => ({
+      path: "external-icu-data-url",
+      namespace: "external-icu-data-url",
+    }));
+    b.onLoad({ filter: /.*/, namespace: "external-icu-data-url" }, () => ({
+      loader: "js",
+      contents: `export default ${JSON.stringify(ICU_DATA_URL)};`,
     }));
   },
 };

--- a/esbuild.worker.mjs
+++ b/esbuild.worker.mjs
@@ -1,7 +1,11 @@
 #!/usr/bin/env node
 
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { build } from "esbuild";
 import { ALL_PHP_VERSIONS as MOODLE_PHP_VERSIONS } from "./src/shared/version-resolver.js";
+
+const require = createRequire(import.meta.url);
 
 // Only bundle the PHP runtime versions Moodle actually supports. @php-wasm/web's
 // loadWebRuntime() switch dynamically imports every @php-wasm/web-X-Y package,
@@ -35,15 +39,20 @@ const stripUnusedPhpVersions = {
   },
 };
 
-const ICU_DATA_URL =
-  "https://unpkg.com/@php-wasm/web@3.1.36/shared/icu.dat";
+const phpWasmWebPackage = JSON.parse(
+  readFileSync(require.resolve("@php-wasm/web/package.json"), "utf8"),
+);
+const ICU_DATA_URL = `https://unpkg.com/@php-wasm/web@${phpWasmWebPackage.version}/shared/icu.dat`;
 const phpWasmIcuDataPlugin = {
   name: "php-wasm-icu-data",
   setup(b) {
-    b.onResolve({ filter: /(^|\/)(?:intl\/shared|shared)\/icu\.dat$/ }, () => ({
-      path: "external-icu-data-url",
-      namespace: "external-icu-data-url",
-    }));
+    b.onResolve(
+      { filter: /(^|\/)(?:intl\/shared|shared)\/icu\.dat$/ },
+      () => ({
+        path: "external-icu-data-url",
+        namespace: "external-icu-data-url",
+      }),
+    );
     b.onLoad({ filter: /.*/, namespace: "external-icu-data-url" }, () => ({
       loader: "js",
       contents: `export default ${JSON.stringify(ICU_DATA_URL)};`,

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "type": "module",
   "scripts": {
     "build:version": "node scripts/write-build-version.mjs",
-    "build:worker": "node esbuild.worker.mjs",
+    "build-worker": "node esbuild.worker.mjs",
     "serve": "http-server . -p ${PORT:-8080} -c-1",
     "bundle:default": "sh -c 'BRANCH=\"${BRANCH:-MOODLE_500_STABLE}\" ./scripts/build-moodle-bundle.sh'",
-    "prepare:dev:pretty": "concurrently --names worker,bundle --prefix name --prefix-colors cyan,yellow \"npm:build:worker\" \"npm:bundle:default\"",
+    "prepare:dev:pretty": "concurrently --names worker,bundle --prefix name --prefix-colors cyan,yellow \"npm:build-worker\" \"npm:bundle:default\"",
     "bundle:all:pretty": "concurrently --names 404,405,500,501,502,main --prefix name --prefix-colors blue,magenta,green,yellow,red,cyan \"sh -c 'BRANCH=MOODLE_404_STABLE ./scripts/build-moodle-bundle.sh'\" \"sh -c 'BRANCH=MOODLE_405_STABLE ./scripts/build-moodle-bundle.sh'\" \"sh -c 'BRANCH=MOODLE_500_STABLE ./scripts/build-moodle-bundle.sh'\" \"sh -c 'BRANCH=MOODLE_501_STABLE ./scripts/build-moodle-bundle.sh'\" \"sh -c 'BRANCH=MOODLE_502_STABLE GIT_REF=v5.2.0 ./scripts/build-moodle-bundle.sh'\" \"sh -c 'BRANCH=main ./scripts/build-moodle-bundle.sh'\"",
     "bundle": "./scripts/build-moodle-bundle.sh",
     "test": "node --test tests/**/*.test.js",


### PR DESCRIPTION
Summary
- Resolve @php-wasm/web icu.dat imports to an unpkg URL built from the installed @php-wasm/web package version.
- Avoid emitting the local ~29 MB icu.dat asset in the worker build.
- Clean dist before rebuilding so stale icu-*.dat files do not get deployed accidentally.
- Keep both import shapes covered: ../intl/shared/icu.dat and ./shared/icu.dat.
- Rename Moodle's worker npm script to build-worker so all playgrounds use the same command.

Validation
- make lint
- node --check esbuild.worker.mjs
- npm run build-worker
- bundle contains https://unpkg.com/@php-wasm/web@<installed-version>/shared/icu.dat and no icu-*.dat reference
- find dist -type f -size +25M returns no files
- npm test