### PR TITLE
fix(persistence): reset persisted env when the blueprint changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -473,3 +473,32 @@ Useful helpers in `tests/e2e/helpers.mjs`:
 is enabled outside CI (`playwright.config.mjs`), so two playground checkouts started
 at the same time can share a dev-server port and cross-contaminate each other's app.
 Run each sibling playground's e2e suite on its own.
+
+## Persistence model (per-tab storage + blueprint reset)
+
+Mutable state under `/persist` is journaled to IndexedDB (`moodle-fs-journal:<scope>`) via
+`@php-wasm/fs-journal`, so it survives reloads. Key facts for future work:
+
+- **Per-tab, within-session.** `scopeId` lives in `sessionStorage`, so each
+  browser tab/window has its own environment. Opening the playground in a new tab
+  starts clean — nothing is shared (only *duplicating* a tab copies
+  `sessionStorage`). State is lost when the tab closes.
+- **A different blueprint starts fresh.** The persisted env is keyed by the
+  blueprint *source* — `blueprintSourceKey(href)` in `src/shared/paths.js`
+  (`url:<value>` for `?blueprint-url=`, `inline:<hash>` for `?blueprint=` /
+  `?blueprint-data=`, else `default`) — remembered per scope in `sessionStorage`
+  (`blueprint-source:<scope>`). Loading a **different** blueprint in the same tab
+  forces a clean boot (discards the previous `/persist` and installs fresh);
+  **reloading the same blueprint keeps the data.** (Same intent as WordPress
+  Playground, which serves URL blueprints as temporary by default and keys
+  persisted sites per site-slug.)
+- **Clean boot wiring.** On a clean boot the shell adds `&clean=1` to the
+  `#site-frame` remote URL; the worker then `clearJournal`s and **re-starts
+  journaling** (`initFsPersistence` runs after the clear in
+  `src/runtime/php-loader.js`) so the fresh env persists on later reloads. The
+  `#reset-button` triggers the same path.
+- **Flush.** On each debounced flush the journal collapses ops *before* hydrating
+  (`collapseAndHydrate` = `hydrateUpdateFileOps(php, normalizeFilesystemOperations(ops))`)
+  so a heavy install that rewrites the SQLite DB hundreds of times doesn't OOM.
+- **Inspect:** `await indexedDB.databases()` → open `moodle-fs-journal:<scope>` → read the
+  `ops` object store.

--- a/src/runtime/php-loader.js
+++ b/src/runtime/php-loader.js
@@ -148,11 +148,15 @@ export function createPhpRuntime(
         const { clearJournal, initFsPersistence } = await import(
           "./fs-persistence.js"
         );
+        // On a clean boot (reset / blueprint change), wipe the old journal first;
+        // then ALWAYS start journaling — replaying whatever remains (nothing,
+        // after a wipe) and recording new writes — so the fresh env is persisted
+        // and a later reload of the same blueprint reuses it instead of
+        // reinstalling.
         if (forceCleanBoot) {
           await clearJournal(scopeId);
-        } else {
-          await initFsPersistence(php, scopeId);
         }
+        await initFsPersistence(php, scopeId);
       }
 
       // Write glob polyfill + chdir fix into WP Playground's preload dir

--- a/src/shared/paths.js
+++ b/src/shared/paths.js
@@ -59,3 +59,29 @@ export function buildScopedSitePath(scopeId, runtimeId, path = "/") {
     `playground/${scopeId}/${runtimeId}${normalized}`,
   ).replace(/\/{2,}/gu, "/");
 }
+
+function djb2(value) {
+  let hash = 5381;
+  for (let i = 0; i < value.length; i += 1) {
+    hash = ((hash << 5) + hash + value.charCodeAt(i)) | 0;
+  }
+  return (hash >>> 0).toString(36);
+}
+
+// Stable identity of the blueprint a URL points at. The shell compares it across
+// reloads to decide whether to reset the persisted env: a different blueprint
+// source => different key => clean boot; the same source => same key => keep the
+// persisted data. Keyed by the source (URL value / inline param), not the
+// resolved object, so it stays stable across reloads.
+export function blueprintSourceKey(href = window.location.href) {
+  const params = new URL(href).searchParams;
+  const url = params.get("blueprint-url");
+  if (url) {
+    return `url:${url}`;
+  }
+  const inline = params.get("blueprint") ?? params.get("blueprint-data");
+  if (inline) {
+    return `inline:${djb2(inline)}`;
+  }
+  return "default";
+}

--- a/src/shell/main.js
+++ b/src/shell/main.js
@@ -5,7 +5,7 @@ import {
   validateBlueprint,
 } from "../blueprint/index.js";
 import { loadPlaygroundConfig } from "../shared/config.js";
-import { resolveRemoteUrl } from "../shared/paths.js";
+import { blueprintSourceKey, resolveRemoteUrl } from "../shared/paths.js";
 import { createShellChannel, SNAPSHOT_VERSION } from "../shared/protocol.js";
 import { registerVersionedServiceWorker } from "../shared/service-worker-version.js";
 import {
@@ -550,6 +550,18 @@ async function main() {
     defaultBlueprintUrl: config.defaultBlueprintUrl,
   });
   updateBlueprintTextarea();
+
+  // Reset the persisted env when the blueprint changed since the last boot in
+  // this tab: a different blueprint must install fresh, not replay the previous
+  // env (which the install gate would otherwise reuse). Reloading the same
+  // blueprint keeps the data; a different tab is already clean (per-tab scopeId).
+  const blueprintKey = blueprintSourceKey(window.location.href);
+  const blueprintStoreKey = `blueprint-source:${scopeId}`;
+  const previousBlueprintKey = window.sessionStorage.getItem(blueprintStoreKey);
+  if (previousBlueprintKey !== null && previousBlueprintKey !== blueprintKey) {
+    pendingCleanBoot = true;
+  }
+  window.sessionStorage.setItem(blueprintStoreKey, blueprintKey);
 
   // Resolve versions from URL params > blueprint > defaults
   const urlParams = parseQueryParams(window.location);

--- a/tests/shared/blueprint-source-key.test.js
+++ b/tests/shared/blueprint-source-key.test.js
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { blueprintSourceKey } from "../../src/shared/paths.js";
+
+// The shell resets the persisted /persist when the blueprint *source* changes, so
+// loading a different blueprint in a tab installs fresh instead of replaying the
+// previous env. blueprintSourceKey is the stable per-source identity it compares.
+test("blueprintSourceKey: different blueprint => different key, same => same, bare => default", () => {
+  const a = "https://x/?blueprint-url=https://h/a.json";
+  const b = "https://x/?blueprint-url=https://h/b.json";
+
+  // A different blueprint-url => different key (triggers a clean boot).
+  assert.notEqual(blueprintSourceKey(a), blueprintSourceKey(b));
+  // The same blueprint-url => same key (keeps the persisted env).
+  assert.equal(blueprintSourceKey(a), blueprintSourceKey(a));
+  // No blueprint param => the default env.
+  assert.equal(blueprintSourceKey("https://x/"), "default");
+
+  // Inline blueprints are distinguished by content too.
+  const i1 = "https://x/?blueprint-data=AAAA";
+  const i2 = "https://x/?blueprint-data=BBBB";
+  assert.notEqual(blueprintSourceKey(i1), blueprintSourceKey(i2));
+  assert.notEqual(blueprintSourceKey(i1), blueprintSourceKey(a));
+});


### PR DESCRIPTION
## Problem
In a tab with a persisted env, loading a **different** `?blueprint-url=` (e.g. mod_exeweb) didn't load the new blueprint — the old `/persist` was replayed and the install gate skipped re-provisioning. `scopeId` is per-tab and blueprint-independent, so the journal was reused; moodle additionally never forced a clean boot on a blueprint change.

## Fix (Option 1 — reset only when the blueprint changes)
- **Part A (shell):** `blueprintSourceKey(href)` = stable identity of the blueprint source (`url:<value>` / `inline:<hash>` / `default`), stored per scope in sessionStorage. If it changed since the last boot in this tab → force a clean boot. So: **different blueprint = fresh**, **reload same = persists**, **different tab = clean** (per-tab scopeId).
- **Part B (runtime):** on a clean boot, `php-loader` wiped the journal but never started journaling → the fresh env wasn't persisted and reloads reinstalled. Now it always `initFsPersistence` after the optional `clearJournal`, so a clean-booted env (blueprint change or reset) persists on subsequent reloads. (Also fixes the latent reset-button non-persistence quirk.)

## Test (TDD)
`tests/shared/blueprint-source-key.test.js`: different blueprint ⇒ different key, same ⇒ same, bare ⇒ default. Written failing first, green after.

`make test` 465/465 ✅ · `make lint` ✅ (only pre-existing warnings). Reference for the same fix in omeka / nextcloud / facturascripts.