### PR TITLE
feat(blueprint): add restoreCourse step for .mbz course backups

### DIFF
--- a/.agents/skills/blueprint-provisioning/SKILL.md
+++ b/.agents/skills/blueprint-provisioning/SKILL.md
@@ -116,6 +116,15 @@ Blueprint JSON
 | `createCourses` | Create multiple courses |
 | `createSection` | Add a section to a course |
 | `createSections` | Add multiple sections |
+| `restoreCourse` | Restore a `.mbz` course backup via `restore_controller` |
+
+`restoreCourse` (`steps/moodle-restore.js` → `phpRestoreCourse` in `php/helpers.js`) takes one
+source — `url` (downloaded inside PHP via `download_file_content($tofile)`, streamed to MEMFS, best
+for large files), `path` (an `.mbz` already in MEMFS), or `data` (embedded, small only) — plus
+`category` (name, auto-created), `fullname`/`shortname`/`visible`. It raises memory, guards Moodle's
+`exit(1)` handler (ADR-0005), and restores into a new course (`TARGET_NEW_COURSE`). Large/complex
+backups can fail (memory / SQLite-WASM limits) but fail gracefully. See
+`docs/decisions/0007-course-restore-step.md`.
 
 #### Activities and modules
 | Step | Description |

--- a/.agents/skills/moodle-internals/SKILL.md
+++ b/.agents/skills/moodle-internals/SKILL.md
@@ -118,6 +118,23 @@ and `$plugin->requires`. The component name must match the directory path.
 - Section sequence (`mdl_course_sections.sequence`) is a comma-separated list of
   `course_modules.id` values — must be updated when adding modules
 
+### Backup / restore (.mbz)
+
+- Restore via `restore_controller` (`backup/util/includes/restore_includes.php`). A `.mbz` is a ZIP
+  with mimetype `application/vnd.moodle.backup`; extract with
+  `get_file_packer('application/vnd.moodle.backup')->extract_to_pathname($mbz, $path)`. A valid
+  backup has `moodle_backup.xml` at the root.
+- New-course restore flow: `restore_controller::get_tempdir_name` + `make_backup_temp_directory` →
+  validate `TYPE_1COURSE` → `restore_dbops::calculate_course_names` (ensures a unique short name) →
+  `restore_dbops::create_new_course` → `new restore_controller(..., TARGET_NEW_COURSE, INTERACTIVE_NO)`
+  → `execute_precheck()` / `execute_plan()` / `destroy()`. Set `$USER = get_admin()` first.
+- **WASM caveats:** restore is memory-heavy → `raise_memory_limit(MEMORY_EXTRA)`. It uses delegated
+  transactions; nested savepoints can crash SQLite-WASM (ADR-0003), and a thrown error hits Moodle's
+  `default_exception_handler` (`exit(1)`, kills `php.run`) — override it with a `set_exception_handler`
+  that does `exit(0)` (ADR-0005). Large/complex backups may still fail; treat failure as graceful.
+- Implemented as the `restoreCourse` step (`src/blueprint/steps/moodle-restore.js`,
+  `phpRestoreCourse` in `php/helpers.js`). See `docs/decisions/0007-course-restore-step.md`.
+
 ### User and enrollment
 
 - Users in `mdl_user`, roles in `mdl_role`, assignments in `mdl_role_assignments`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -381,6 +381,7 @@ so that future contributors (human or AI) understand **why** a choice was made â
 | [0004](docs/decisions/0004-opcache-tuning-and-runtime-ux-defaults.md) | OPcache tuning and runtime UX defaults | Accepted |
 | [0005](docs/decisions/0005-resilient-blueprint-step-execution.md) | Resilient blueprint step execution with graceful errors | Accepted |
 | [0006](docs/decisions/0006-moodle-langpack-proxy-allowance.md) | Language pack install via the CORS proxy + Moodle's lang_installer | Accepted |
+| [0007](docs/decisions/0007-course-restore-step.md) | Course backup (.mbz) restore step (PHP streaming download + restore_controller) | Accepted |
 
 ## Debugging
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -281,6 +281,31 @@ Files:
 - `src/runtime/bootstrap.js` (`runLanguageAutoInstall`)
 - `docs/decisions/0006-moodle-langpack-proxy-allowance.md`
 
+### Course restore (`restoreCourse`) fails or the course is missing
+
+Likely cause:
+
+- The `.mbz` is large/complex. Restore runs entirely in the WASM runtime, which has limited memory
+  and a SQLite driver that crashes on nested savepoints (ADR-0003). Big backups (many activities,
+  large files, completion/calendar data) can exceed memory or hit transaction limits and fail.
+- The `url` is not reachable: the host must be CORS-accessible (e.g. `raw.githubusercontent.com`) or
+  proxy-allowlisted, otherwise the in-PHP download fails.
+
+What to expect / do:
+
+- A failed restore is reported in the boot log and is **non-fatal** — the rest of the blueprint still
+  runs (ADR-0005). The course simply won't be created.
+- Prefer smaller course backups. Host large `.mbz` at a CORS URL so it **streams** into the runtime
+  (the `url` source) instead of being buffered (the `data` source).
+- The download is a GET over `tcpOverFetch`, so it works in Chromium, Firefox and Safari (unlike
+  streaming-upload POSTs). If it fails only in one browser, check the URL's CORS headers.
+
+Files:
+
+- `src/blueprint/steps/moodle-restore.js`
+- `src/blueprint/php/helpers.js` (`phpRestoreCourse`)
+- `docs/decisions/0007-course-restore-step.md`
+
 ### `PHP worker bridge timed out`
 
 Likely cause:

--- a/docs/blueprint-json.md
+++ b/docs/blueprint-json.md
@@ -261,6 +261,7 @@ Named resources can be defined once and referenced from steps using `@name`:
 | `createCategory` / `createCategories` | Create course categories |
 | `createCourse` / `createCourses` | Create courses |
 | `createSection` / `createSections` | Add sections to courses |
+| `restoreCourse` | Restore a Moodle course backup (`.mbz`) into a category |
 
 ### Enrolment
 
@@ -594,6 +595,38 @@ and the matching pack is installed automatically on boot:
 
 Use `installLanguagePack` when you want **additional** languages available in the language menu,
 or to install a pack without making it the default.
+
+### restoreCourse
+
+Restore a Moodle course backup (`.mbz`) into a category, using Moodle's own `restore_controller`.
+
+```json
+{
+  "step": "restoreCourse",
+  "url": "https://raw.githubusercontent.com/owner/repo/main/course.mbz",
+  "category": "PRUEBAS"
+}
+```
+
+Provide exactly one **source** (precedence `url` > `path` > `data`):
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `url` | one source | URL of the `.mbz`. Downloaded **inside PHP** and streamed straight to disk (memory-efficient — best for large files). The host must be CORS-reachable (e.g. `raw.githubusercontent.com`) or proxy-allowlisted. |
+| `path` | one source | Path to an `.mbz` already in the runtime filesystem (e.g. written by a previous `writeFile` step). |
+| `data` | one source | Embedded backup (string `@resourceName` or a resource descriptor). Buffered in memory — **only for small backups**; prefer `url` for large ones. |
+| `category` | no | Target category **name**. Auto-created if missing (set `createCategory: false` to require it). Defaults to the top category (id 1) when omitted. |
+| `createCategory` | no | `false` to error instead of creating a missing category. Defaults to `true`. |
+| `fullname` | no | Override the restored course full name (otherwise the backup's name is kept). |
+| `shortname` | no | Preferred course short name. Applied only if free; Moodle keeps the backup's name on a clash (short names are unique). |
+| `visible` | no | Course visibility. Defaults to `true`. |
+
+> **⚠️ Large backups may fail.** The playground runs Moodle entirely in the browser via
+> WebAssembly, with limited memory. Restoring a large or complex `.mbz` (many activities, big
+> files, completion/calendar data) can exceed the runtime's memory or hit SQLite-in-WASM
+> transaction limits and fail. A failed restore is reported in the boot log and does **not** abort
+> the rest of the blueprint. Prefer smaller course backups, and host large `.mbz` files at a
+> CORS-accessible URL (e.g. GitHub raw) so they stream into the runtime instead of being buffered.
 
 ## Naming Conventions
 

--- a/docs/decisions/0007-course-restore-step.md
+++ b/docs/decisions/0007-course-restore-step.md
@@ -1,0 +1,84 @@
+# ADR-0007 Course backup (.mbz) restore blueprint step
+
+* Status: Accepted
+* Date: 2026-06-08
+
+## Context and Problem
+
+Restoring a Moodle course backup (`.mbz`) into a playground required a large, fragile hand-written
+`runPhpCode` block: download the file into a blueprint resource, `writeFile` it to disk, then ~40
+lines of `restore_controller` orchestration. We want a first-class `restoreCourse` step (same
+productization as `installLanguagePack`).
+
+Two constraints shape the design:
+
+1. **`.mbz` files can be large.** The blueprint resource `url` type caps at 50MB
+   (`src/blueprint/resources.js`) and buffers the whole file into a JS `arrayBuffer` — a large
+   `arrayBuffer` is exactly what caused the past *"RangeError: Array buffer allocation failed"*
+   (`docs/TROUBLESHOOTING.md`).
+2. **Restore is memory-heavy and can hit SQLite-WASM limits.** Nested savepoints crash the runtime
+   (ADR-0003), and Moodle's `default_exception_handler` does `exit(1)` on error, which kills
+   `php.run` (ADR-0005).
+
+## Options Considered
+
+* **Resource (`@name`) + `writeFile` + `runPhpCode`** (status quo) — verbose, error-prone, capped at
+  50MB, double-buffers the file in JS.
+* **JS download (`fetch` → `arrayBuffer` → `writeFile`)** like the plugin installer — bypasses the
+  50MB cap but still allocates a full `arrayBuffer` (OOM risk on large files).
+* **PHP-side streaming download + `restore_controller`** — PHP downloads the `.mbz` with
+  `download_file_content($url, …, $tofile)`, which streams straight into the MEMFS file (no JS
+  buffer, no cap), then restores. The download is a GET over `tcpOverFetch` (cross-browser — same
+  path `lang_installer` uses, verified in Firefox).
+
+## Decision
+
+Add a `restoreCourse` step (`src/blueprint/steps/moodle-restore.js`) that supports three sources —
+`url` (PHP streaming download, recommended for large files), `path` (an `.mbz` already in MEMFS),
+and `data` (embedded resource, small backups) — and restores via Moodle's `restore_controller` using
+a new `phpRestoreCourse()` generator in `php/helpers.js`. The generated PHP:
+
+- `raise_memory_limit(MEMORY_EXTRA)` and a `set_exception_handler` that reports JSON and `exit(0)`
+  (never `exit(1)`), so a restore crash is graceful and the blueprint continues (ADR-0005).
+- Resolves the target category by name, auto-creating it (`createCategory: false` to require it),
+  defaulting to category id 1.
+- Validates the backup is a `TYPE_1COURSE`, creates a course shell with a unique short name
+  (`restore_dbops::calculate_course_names`), runs the restore into it (`TARGET_NEW_COURSE`), then
+  optionally enforces `fullname`/`shortname` (short name only if free) and `visible`.
+
+The JS handler resolves `data` via the resource registry and writes it to a temp MEMFS path; for
+`url`/`path` it passes the source straight to PHP. `php.run` is wrapped in try/catch and reports via
+`publish()` (graceful, ADR-0005).
+
+## Consequences
+
+### Positive
+* **Memory-efficient for large files** — `url` streams into MEMFS with no JS `arrayBuffer` and no
+  50MB cap.
+* **Cross-browser** — the download is a GET over `tcpOverFetch` (works in Chromium, Firefox, Safari).
+* **Minimal, declarative blueprint** — replaces ~40 lines of `runPhpCode` with one step.
+* **Resilient** — a failed/oversized restore is reported, not fatal; the blueprint keeps going.
+
+### Negative / Risks
+* **Large/complex backups can still fail** — in-browser memory and SQLite-WASM transaction limits.
+  Documented as an explicit warning; outcome is a graceful error, not a crash loop.
+* **`url` host must be CORS-reachable / proxy-allowlisted** — arbitrary hosts may not be fetchable.
+* **Relies on Moodle `download_file_content($tofile)` streaming in WASM** — if it proves unreliable,
+  fall back to a JS streaming fetch → chunked MEMFS write (`php._php.FS`).
+
+## Implementation Notes
+
+### Files
+- `src/blueprint/steps/moodle-restore.js` — new `restoreCourse` handler.
+- `src/blueprint/php/helpers.js` — `phpRestoreCourse()` generator.
+- `src/blueprint/steps/index.js`, `src/blueprint/schema.js` — register the step.
+- `tests/blueprint/restore-course.test.js`, `tests/blueprint/steps.test.js` — coverage.
+- `docs/blueprint-json.md` — step docs + large-file warning.
+
+## Review Criteria
+- If `download_file_content($tofile)` streaming is unreliable in the WASM runtime, switch the `url`
+  path to a JS streaming download.
+- If a future Moodle changes the backup/restore API (`restore_controller`, `restore_dbops`) or the
+  `.mbz` format, re-verify the generator.
+- If restore reliability for larger courses matters, investigate chunked/lower-memory restore modes
+  or pre-flighting the backup size.

--- a/src/blueprint/php/helpers.js
+++ b/src/blueprint/php/helpers.js
@@ -259,6 +259,143 @@ echo json_encode(['ok' => empty($failed), 'installed' => $installed, 'failed' =>
 `;
 }
 
+// Restore a single Moodle course backup (.mbz) using Moodle's own
+// restore_controller. The .mbz is either downloaded inside PHP (streamed
+// straight to a MEMFS file via download_file_content's $tofile, so no large JS
+// arrayBuffer is allocated and no 50MB resource cap applies) or read from an
+// existing MEMFS path. Restore is memory-heavy and can hit SQLite-WASM limits
+// (nested savepoints, see ADR-0003), so large/complex backups may fail — the
+// exception-handler override turns that into a graceful JSON error (exit(0),
+// not exit(1)) instead of killing the runtime (ADR-0005).
+//
+// String options are interpolated into single-quoted PHP literals via escapePhp;
+// none is used as a PHP identifier.
+export function phpRestoreCourse({
+  downloadUrl = null,
+  localPath = null,
+  category = null,
+  createCategory = true,
+  fullname = null,
+  shortname = null,
+  visible = true,
+} = {}) {
+  const visibleInt = visible === false ? 0 : 1;
+
+  const sourceBlock = downloadUrl
+    ? `$mbz = make_request_directory() . '/source.mbz';
+$dlok = download_file_content('${escapePhp(downloadUrl)}', null, null, false, 600, 30, false, $mbz);
+if ($dlok === false || !is_file($mbz) || filesize($mbz) < 1000) {
+    fail('Could not download the course backup. The URL must be reachable and CORS-accessible (e.g. raw.githubusercontent.com) or proxy-allowlisted.');
+}`
+    : `$mbz = '${escapePhp(localPath)}';
+if (!is_file($mbz) || filesize($mbz) < 1000) {
+    fail('Course backup file is missing or too small: ' . $mbz);
+}`;
+
+  const categoryExpr = category ? `'${escapePhp(category)}'` : "null";
+  const categoryBlock = `$categoryname = ${categoryExpr};
+if ($categoryname === null || $categoryname === '') {
+    $categoryid = 1;
+} else {
+    $cat = $DB->get_record('course_categories', ['name' => $categoryname], 'id');
+    if ($cat) {
+        $categoryid = $cat->id;
+    } else if (${createCategory ? "true" : "false"}) {
+        $newcat = new stdClass();
+        $newcat->name = $categoryname;
+        $newcat->descriptionformat = FORMAT_HTML;
+        $categoryid = core_course_category::create($newcat)->id;
+    } else {
+        fail('Target category does not exist: ' . $categoryname);
+    }
+}`;
+
+  const fullnameExpr = fullname ? `'${escapePhp(fullname)}'` : "null";
+  const shortnameExpr = shortname ? `'${escapePhp(shortname)}'` : "null";
+
+  return `${CLI_HEADER}
+raise_memory_limit(MEMORY_EXTRA);
+@set_time_limit(0);
+require_once($CFG->dirroot . '/backup/util/includes/restore_includes.php');
+require_once($CFG->dirroot . '/course/lib.php');
+global $CFG, $DB, $USER;
+
+// Report failures as JSON and exit(0). Moodle's default_exception_handler would
+// otherwise exit(1) on a DB/restore error and kill the WASM runtime (ADR-0005).
+function fail($msg) {
+    while (ob_get_level()) { ob_end_clean(); }
+    echo json_encode(['ok' => false, 'error' => $msg]);
+    exit(0);
+}
+set_exception_handler(function($e) { fail($e->getMessage()); });
+
+$admin = get_admin();
+if (!$admin) { fail('Administrator account not found.'); }
+$USER = $admin;
+
+${sourceBlock}
+
+${categoryBlock}
+
+// Extract the .mbz into a Moodle backup temp dir and validate it is a course backup.
+$backupdir = restore_controller::get_tempdir_name(SITEID, $admin->id);
+$path = make_backup_temp_directory($backupdir);
+$packer = get_file_packer('application/vnd.moodle.backup');
+if (!$packer->extract_to_pathname($mbz, $path)) {
+    fulldelete($path);
+    fail('Could not extract the Moodle backup (.mbz).');
+}
+if (!is_file($path . '/moodle_backup.xml')) {
+    fulldelete($path);
+    fail('The .mbz does not contain moodle_backup.xml (not a valid Moodle backup).');
+}
+$tmprc = new restore_controller($backupdir, SITEID, backup::INTERACTIVE_NO, backup::MODE_GENERAL, $admin->id, backup::TARGET_EXISTING_ADDING);
+$backuptype = $tmprc->get_type();
+$tmprc->destroy();
+if ($backuptype !== backup::TYPE_1COURSE) {
+    fulldelete($path);
+    fail('The supplied .mbz is not a single-course backup.');
+}
+
+// Create the destination course shell with a guaranteed-unique shortname, then
+// restore the backup into it.
+$wantfullname = ${fullnameExpr};
+$wantshortname = ${shortnameExpr};
+list($newfullname, $newshortname) = restore_dbops::calculate_course_names(
+    0,
+    $wantfullname !== null ? $wantfullname : 'Restored course',
+    $wantshortname !== null ? $wantshortname : 'restored'
+);
+$courseid = restore_dbops::create_new_course($newfullname, $newshortname, $categoryid);
+$rc = new restore_controller($backupdir, $courseid, backup::INTERACTIVE_NO, backup::MODE_GENERAL, $admin->id, backup::TARGET_NEW_COURSE);
+try {
+    $rc->execute_precheck();
+    $rc->execute_plan();
+    $rc->destroy();
+} catch (\\Throwable $e) {
+    $rc->destroy();
+    fulldelete($path);
+    fail('Course restore failed: ' . $e->getMessage());
+}
+
+// Enforce the requested name/visibility (the backup may have set its own).
+$course = $DB->get_record('course', ['id' => $courseid], '*', MUST_EXIST);
+if ($wantfullname !== null) {
+    $course->fullname = $wantfullname;
+}
+if ($wantshortname !== null &&
+    !$DB->record_exists_select('course', 'shortname = ? AND id <> ?', [$wantshortname, $courseid])) {
+    $course->shortname = $wantshortname;
+}
+$course->visible = ${visibleInt};
+update_course($course);
+rebuild_course_cache($courseid, true);
+fulldelete($path);
+purge_all_caches();
+echo json_encode(['ok' => true, 'courseid' => $courseid, 'shortname' => $course->shortname, 'fullname' => $course->fullname]);
+`;
+}
+
 export function phpCreateUser(user) {
   return phpCreateUsers([user]);
 }

--- a/src/blueprint/schema.js
+++ b/src/blueprint/schema.js
@@ -20,6 +20,7 @@ const KNOWN_STEP_NAMES = new Set([
   "installMoodlePlugin",
   "installTheme",
   "installLanguagePack",
+  "restoreCourse",
   "mkdir",
   "rmdir",
   "writeFile",

--- a/src/blueprint/steps/index.js
+++ b/src/blueprint/steps/index.js
@@ -7,6 +7,7 @@ import { registerMoodleInstallSteps } from "./moodle-install.js";
 import { registerMoodleLanguageSteps } from "./moodle-language.js";
 import { registerMoodleModuleSteps } from "./moodle-modules.js";
 import { registerMoodlePluginSteps } from "./moodle-plugins.js";
+import { registerMoodleRestoreSteps } from "./moodle-restore.js";
 import { registerMoodleUserSteps } from "./moodle-users.js";
 import { registerRequestSteps } from "./request.js";
 
@@ -36,4 +37,5 @@ registerMoodleCourseSteps(registerStep);
 registerMoodleEnrolSteps(registerStep);
 registerMoodleModuleSteps(registerStep);
 registerMoodleLanguageSteps(registerStep);
+registerMoodleRestoreSteps(registerStep);
 registerMoodlePluginSteps(registerStep);

--- a/src/blueprint/steps/moodle-restore.js
+++ b/src/blueprint/steps/moodle-restore.js
@@ -1,0 +1,101 @@
+/**
+ * Course restore step: restoreCourse.
+ *
+ * Restores a Moodle course backup (.mbz) into a category using Moodle's own
+ * restore_controller. The backup can come from a URL (downloaded inside PHP,
+ * streamed straight to MEMFS — the memory-efficient path for large files), an
+ * existing MEMFS path, or embedded resource data.
+ *
+ * Large/complex backups can fail (in-browser memory limits and SQLite-WASM
+ * transaction limits); failures are reported gracefully and never abort the
+ * blueprint. See docs/decisions/0007-course-restore-step.md.
+ */
+
+import { phpRestoreCourse } from "../php/helpers.js";
+
+// Per-session counter for unique temp paths when restoring from embedded data.
+let embeddedRestoreCounter = 0;
+
+export function registerMoodleRestoreSteps(register) {
+  register("restoreCourse", handleRestoreCourse);
+}
+
+function trimmedString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+async function handleRestoreCourse(step, context) {
+  const { php, publish, resources } = context;
+
+  const url = trimmedString(step.url);
+  const path = trimmedString(step.path);
+  const hasData =
+    step.data !== undefined && step.data !== null && step.data !== "";
+
+  if (!url && !path && !hasData) {
+    throw new Error(
+      "restoreCourse: one of 'url', 'path', or 'data' is required.",
+    );
+  }
+  if (url && !/^https?:\/\//iu.test(url)) {
+    throw new Error("restoreCourse: 'url' must be an http(s) URL.");
+  }
+
+  if (publish) {
+    publish(
+      "Restoring course backup — large or complex backups may exceed the in-browser runtime and fail.",
+      0.93,
+    );
+  }
+
+  // Resolve the backup source into options for the PHP generator. Precedence:
+  // url > path > embedded data.
+  const opts = {
+    category: trimmedString(step.category),
+    createCategory: step.createCategory !== false,
+    fullname: trimmedString(step.fullname),
+    shortname: trimmedString(step.shortname),
+    visible: step.visible !== false,
+  };
+
+  if (url) {
+    opts.downloadUrl = url;
+  } else if (path) {
+    opts.localPath = path;
+  } else {
+    // Embedded backup: resolve via the resource registry and write to MEMFS.
+    // This buffers the whole file in JS, so it is only suitable for small
+    // backups — large ones should use `url`.
+    const bytes = await resources.resolve(step.data);
+    const tempPath = `/tmp/restore_${++embeddedRestoreCounter}.mbz`;
+    await php.writeFile(tempPath, bytes);
+    opts.localPath = tempPath;
+  }
+
+  let result;
+  try {
+    result = await php.run(phpRestoreCourse(opts));
+  } catch (err) {
+    // A hard failure (e.g. OOM, nested-savepoint crash) can throw. Don't abort
+    // the blueprint — the course is a non-critical add-on.
+    if (publish) {
+      publish(
+        `Course restore crashed: ${String(err.message || err).slice(0, 200)}`,
+        0.94,
+      );
+    }
+    return;
+  }
+
+  const text = result?.text || "";
+  if (publish) {
+    if (text.includes('"ok":true')) {
+      const idMatch = text.match(/"courseid":(\d+)/u);
+      publish(`Course restored${idMatch ? ` (id ${idMatch[1]})` : ""}.`, 0.94);
+    } else {
+      publish(`Course restore reported issues: ${text.slice(0, 200)}`, 0.94);
+    }
+  }
+}
+
+export const __testables = { trimmedString };

--- a/tests/blueprint/restore-course.test.js
+++ b/tests/blueprint/restore-course.test.js
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { getStepHandler } from "../../src/blueprint/steps/index.js";
+
+function createPhpMock() {
+  const runCalls = [];
+  const writes = [];
+  return {
+    runCalls,
+    writes,
+    php: {
+      async run(code) {
+        runCalls.push(code);
+        return { text: '{"ok":true,"courseid":7,"shortname":"PENSAR"}' };
+      },
+      async writeFile(path, data) {
+        writes.push([path, data]);
+      },
+    },
+  };
+}
+
+describe("restoreCourse: handler", () => {
+  const handler = getStepHandler("restoreCourse");
+
+  it("is registered", () => {
+    assert.strictEqual(typeof handler, "function");
+  });
+
+  it("throws when no source is provided", async () => {
+    const { php, runCalls } = createPhpMock();
+    await assert.rejects(
+      () => handler({ category: "PRUEBAS" }, { php }),
+      /one of 'url', 'path', or 'data' is required/i,
+    );
+    assert.strictEqual(runCalls.length, 0);
+  });
+
+  it("rejects a non-http url before running PHP", async () => {
+    const { php, runCalls } = createPhpMock();
+    await assert.rejects(
+      () => handler({ url: "ftp://example.com/x.mbz" }, { php }),
+      /must be an http\(s\) URL/i,
+    );
+    assert.strictEqual(runCalls.length, 0);
+  });
+
+  it("downloads inside PHP (streamed to a file) for a url source", async () => {
+    const { php, runCalls } = createPhpMock();
+    await handler(
+      {
+        url: "https://raw.githubusercontent.com/owner/repo/main/course.mbz",
+        category: "PRUEBAS",
+      },
+      { php },
+    );
+    assert.strictEqual(runCalls.length, 1);
+    const code = runCalls[0];
+    // Streamed download into a MEMFS file (download_file_content with $tofile).
+    assert.ok(code.includes("download_file_content("));
+    assert.ok(code.includes("make_request_directory()"));
+    assert.ok(
+      code.includes(
+        "https://raw.githubusercontent.com/owner/repo/main/course.mbz",
+      ),
+    );
+    // Restores via Moodle's restore_controller into a new course.
+    assert.ok(code.includes("new restore_controller"));
+    assert.ok(code.includes("backup::TARGET_NEW_COURSE"));
+    assert.ok(code.includes("raise_memory_limit(MEMORY_EXTRA)"));
+    // Exception-handler guard (exit(0), not exit(1)).
+    assert.ok(code.includes("set_exception_handler"));
+  });
+
+  it("uses an existing MEMFS path without downloading", async () => {
+    const { php, runCalls } = createPhpMock();
+    await handler({ path: "/tmp/my.mbz" }, { php });
+    const code = runCalls[0];
+    assert.ok(code.includes("$mbz = '/tmp/my.mbz';"));
+    assert.ok(!code.includes("download_file_content("));
+  });
+
+  it("resolves embedded data to a temp MEMFS file then restores from it", async () => {
+    const { php, runCalls, writes } = createPhpMock();
+    const resources = {
+      async resolve() {
+        return new Uint8Array([0x50, 0x4b, 0x03, 0x04]);
+      },
+    };
+    await handler({ data: "@courseBackup" }, { php, resources });
+    assert.strictEqual(writes.length, 1);
+    const [writtenPath] = writes[0];
+    assert.match(writtenPath, /^\/tmp\/restore_\d+\.mbz$/u);
+    assert.ok(runCalls[0].includes(`$mbz = '${writtenPath}';`));
+    assert.ok(!runCalls[0].includes("download_file_content("));
+  });
+
+  it("auto-creates the category by default and falls back to id 1 when omitted", async () => {
+    const { php, runCalls } = createPhpMock();
+    await handler({ url: "https://h/x.mbz", category: "PRUEBAS" }, { php });
+    const withCat = runCalls[0];
+    assert.ok(withCat.includes("$categoryname = 'PRUEBAS';"));
+    assert.ok(withCat.includes("core_course_category::create"));
+
+    const mock2 = createPhpMock();
+    await handler({ url: "https://h/x.mbz" }, { php: mock2.php });
+    assert.ok(mock2.runCalls[0].includes("$categoryname = null;"));
+    assert.ok(mock2.runCalls[0].includes("$categoryid = 1;"));
+  });
+
+  it("requires an existing category when createCategory is false", async () => {
+    const { php, runCalls } = createPhpMock();
+    await handler(
+      { url: "https://h/x.mbz", category: "PRUEBAS", createCategory: false },
+      { php },
+    );
+    assert.ok(runCalls[0].includes("fail('Target category does not exist: '"));
+  });
+
+  it("escapes a malicious shortname/category into the single-quoted literal", async () => {
+    const { php, runCalls } = createPhpMock();
+    await handler(
+      {
+        url: "https://h/x.mbz",
+        shortname: "x'); system('id'); //",
+        category: "a'b",
+      },
+      { php },
+    );
+    const code = runCalls[0];
+    // The single quote must be backslash-escaped, never closing the literal.
+    assert.ok(code.includes("x\\'); system(\\'id\\'); //"));
+    assert.ok(code.includes("'a\\'b'"));
+  });
+
+  it("sets visibility to 0 when visible is false", async () => {
+    const { php, runCalls } = createPhpMock();
+    await handler({ url: "https://h/x.mbz", visible: false }, { php });
+    assert.ok(runCalls[0].includes("$course->visible = 0;"));
+  });
+
+  it("does not throw when php.run crashes (graceful)", async () => {
+    const runCalls = [];
+    const php = {
+      async run(code) {
+        runCalls.push(code);
+        throw new Error("memory access out of bounds");
+      },
+    };
+    await handler({ url: "https://h/x.mbz" }, { php });
+    assert.strictEqual(runCalls.length, 1);
+  });
+});

--- a/tests/blueprint/steps.test.js
+++ b/tests/blueprint/steps.test.js
@@ -40,6 +40,7 @@ describe("step registry", () => {
       "installMoodlePlugin",
       "installTheme",
       "installLanguagePack",
+      "restoreCourse",
       "mkdir",
       "rmdir",
       "writeFile",


### PR DESCRIPTION
## What

Adds a first-class **`restoreCourse`** blueprint step so people stop hand-writing a large
`runPhpCode` block to restore a Moodle course backup (`.mbz`).

```json
{ "step": "restoreCourse", "url": "https://raw.githubusercontent.com/owner/repo/main/course.mbz", "category": "PRUEBAS" }
```

### Sources (precedence `url` > `path` > `data`)
- **`url`** — downloaded **inside PHP** via `download_file_content($url, …, $tofile)`, streamed
  straight into the MEMFS file. No giant JS `arrayBuffer` (which caused past *"Array buffer
  allocation failed"*), no 50MB resource cap. Cross-browser GET over `tcpOverFetch` (same path
  `lang_installer` uses, verified in Firefox).
- **`path`** — an `.mbz` already in MEMFS (e.g. from a prior `writeFile`).
- **`data`** — embedded resource (small backups; buffered in JS).

### Other fields
`category` (name, **auto-created** if missing; default id 1), `createCategory`, `fullname`,
`shortname` (applied only if free), `visible`.

### Robustness
`raise_memory_limit(MEMORY_EXTRA)` + a `set_exception_handler` that `exit(0)`s with JSON, so a
restore crash (memory / SQLite-WASM nested savepoints, ADR-0003) is **graceful** and never aborts
the blueprint (ADR-0005). Restores into a new course (`TARGET_NEW_COURSE`) after validating
`TYPE_1COURSE`.

> ⚠️ Documented warning: **large/complex backups may fail** in the in-browser runtime.

## Tests
`make test`: **491 passing** (11 new in `tests/blueprint/restore-course.test.js`): source
validation/precedence, generated-PHP assertions (streaming download, `restore_controller`,
`TARGET_NEW_COURSE`, category auto-create), shortname/category escaping, graceful crash.

## Docs
ADR-0007, `blueprint-json.md` (fields + large-file warning), `blueprint-provisioning` +
`moodle-internals` skills, `TROUBLESHOOTING.md`.

App-only — no proxy/worker changes.