### PR TITLE
Compress inline blueprints in the URL with gzip

### DIFF
--- a/docs/blueprint-json.md
+++ b/docs/blueprint-json.md
@@ -27,7 +27,7 @@ Blueprints can be loaded from:
 
 | Source | Example |
 |--------|---------|
-| `?blueprint=` query param | Inline JSON, base64-encoded JSON, or `data:` URL |
+| `?blueprint=` query param | Inline JSON, base64-encoded JSON, gzip+base64url, or `data:` URL |
 | `?blueprint-url=` query param | URL to a remote `.blueprint.json` file |
 | sessionStorage | Persisted from a previous load in the same tab |
 | Default blueprint URL | Configured in `playground.config.json` |
@@ -40,6 +40,25 @@ Encode your blueprint as base64 and pass it as the `?blueprint=` parameter:
 ```
 https://example.com/moodle-playground/?blueprint=eyIkc2NoZW1hIjoi...
 ```
+
+### Compressed inline blueprint (gzip)
+
+`?blueprint=` also accepts a **gzip-compressed** blueprint encoded as base64url —
+the value starts with `H4sI` (the gzip magic bytes in base64). This keeps the link
+self-contained and shareable but much shorter: a typical blueprint shrinks ~70-90%
+versus plain base64, which matters because long URLs can break on some hosts/proxies.
+
+You don't build this by hand — the **Import** button in the Blueprint side panel
+produces it automatically: it gzip-compresses the imported `.blueprint.json` into the
+`?blueprint=` URL and reloads. Plain base64-JSON links keep working (the format is
+auto-detected), and browsers without `CompressionStream` fall back to plain base64.
+
+```
+https://example.com/moodle-playground/?blueprint=H4sIAAAAAAAAE...
+```
+
+For very large blueprints (or ones you want to version-control), prefer
+`?blueprint-url=` pointing at a hosted `.blueprint.json` instead of inlining it.
 
 ### Data URL
 

--- a/src/blueprint/index.js
+++ b/src/blueprint/index.js
@@ -1,6 +1,6 @@
 export { substituteConstants } from "./constants.js";
 export { executeBlueprint } from "./executor.js";
-export { parseBlueprint } from "./parser.js";
+export { compressBlueprint, parseBlueprint } from "./parser.js";
 export { resolveBlueprint } from "./resolver.js";
 export { ResourceRegistry } from "./resources.js";
 export { validateBlueprint } from "./schema.js";

--- a/src/blueprint/parser.js
+++ b/src/blueprint/parser.js
@@ -91,16 +91,110 @@ function normalizeBase64(str) {
 }
 
 function decodeBase64(str) {
+  return new TextDecoder().decode(decodeBase64ToBytes(str));
+}
+
+// Decode a base64 / base64url string to raw bytes (no UTF-8 decoding), so we can
+// inspect gzip magic bytes and feed DecompressionStream.
+function decodeBase64ToBytes(str) {
   const normalized = normalizeBase64(str);
   if (typeof atob === "function") {
-    // atob returns Latin-1; decode via Uint8Array for correct UTF-8 handling
     const binary = atob(normalized);
     const bytes = new Uint8Array(binary.length);
     for (let i = 0; i < binary.length; i++) {
       bytes[i] = binary.charCodeAt(i);
     }
-    return new TextDecoder().decode(bytes);
+    return bytes;
   }
   // Node.js fallback
-  return Buffer.from(normalized, "base64").toString("utf-8");
+  return new Uint8Array(Buffer.from(normalized, "base64"));
+}
+
+// Encode raw bytes to base64url (URL-safe, unpadded) for use in `?blueprint=`.
+function bytesToBase64Url(bytes) {
+  let b64;
+  if (typeof btoa === "function") {
+    let binary = "";
+    for (let i = 0; i < bytes.length; i++) {
+      binary += String.fromCharCode(bytes[i]);
+    }
+    b64 = btoa(binary);
+  } else {
+    b64 = Buffer.from(bytes).toString("base64");
+  }
+  return b64.replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/u, "");
+}
+
+// gzip / gunzip via the web Streams API (browsers + Node 18+). Portable: write
+// the bytes to the stream's writable end and read the result off the readable.
+async function gzip(bytes) {
+  const cs = new CompressionStream("gzip");
+  const writer = cs.writable.getWriter();
+  writer.write(bytes);
+  writer.close();
+  return new Uint8Array(await new Response(cs.readable).arrayBuffer());
+}
+
+async function gunzip(bytes) {
+  const ds = new DecompressionStream("gzip");
+  const writer = ds.writable.getWriter();
+  writer.write(bytes);
+  writer.close();
+  return new Uint8Array(await new Response(ds.readable).arrayBuffer());
+}
+
+/**
+ * Compress a blueprint to a short, URL-safe `?blueprint=` value: gzip(JSON) then
+ * base64url. A repetitive blueprint shrinks ~70-85% vs plain base64, keeping the
+ * shareable link self-contained but small. Throws if `CompressionStream` is
+ * unavailable so the caller can fall back to plain base64.
+ *
+ * @param {object} blueprint
+ * @returns {Promise<string>} base64url of gzipped JSON
+ */
+export async function compressBlueprint(blueprint) {
+  if (typeof CompressionStream === "undefined") {
+    throw new Error("CompressionStream is not available in this environment.");
+  }
+  const input = new TextEncoder().encode(JSON.stringify(blueprint));
+  return bytesToBase64Url(await gzip(input));
+}
+
+/**
+ * Async wrapper over {@link parseBlueprint} that also accepts a gzip+base64url
+ * value. Detection is by content, not by a new URL param: a base64 value whose
+ * decoded bytes start with the gzip magic `0x1f 0x8b` is decompressed; anything
+ * else (object, JSON string, data: URL, plain base64-JSON) falls through to the
+ * synchronous parser unchanged. A JSON document never starts with those bytes,
+ * so old `?blueprint=<base64-JSON>` links keep working.
+ *
+ * @param {*} value
+ * @returns {Promise<object>} Parsed blueprint object.
+ */
+export async function parseBlueprintParam(value) {
+  if (typeof value !== "string") {
+    return parseBlueprint(value);
+  }
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.startsWith("{") || trimmed.startsWith("data:")) {
+    return parseBlueprint(value);
+  }
+  if (trimmed.length >= 20 && /^[A-Za-z0-9+/=_-]+$/u.test(trimmed)) {
+    let bytes;
+    try {
+      bytes = decodeBase64ToBytes(trimmed);
+    } catch {
+      return parseBlueprint(value);
+    }
+    if (bytes.length >= 2 && bytes[0] === 0x1f && bytes[1] === 0x8b) {
+      if (typeof DecompressionStream === "undefined") {
+        throw new Error(
+          "DecompressionStream is required to read a gzipped blueprint.",
+        );
+      }
+      const json = new TextDecoder().decode(await gunzip(bytes));
+      return JSON.parse(json);
+    }
+  }
+  return parseBlueprint(value);
 }

--- a/src/blueprint/resolver.js
+++ b/src/blueprint/resolver.js
@@ -1,4 +1,4 @@
-import { parseBlueprint } from "./parser.js";
+import { parseBlueprintParam } from "./parser.js";
 import { validateBlueprint } from "./schema.js";
 import { saveBlueprint } from "./storage.js";
 
@@ -47,11 +47,11 @@ export async function resolveBlueprint({
   if (loc) {
     const url = new URL(loc.href);
 
-    // 1. ?blueprint= (inline)
+    // 1. ?blueprint= (inline — plain/base64 JSON or gzip+base64url, auto-detected)
     const blueprintParam = url.searchParams.get("blueprint");
     if (blueprintParam) {
       try {
-        const blueprint = parseBlueprint(blueprintParam);
+        const blueprint = await parseBlueprintParam(blueprintParam);
         console.log("[blueprint] Resolved from ?blueprint= param (inline).");
         return finalize(blueprint);
       } catch (error) {

--- a/src/shell/main.js
+++ b/src/shell/main.js
@@ -1,5 +1,6 @@
 import {
   clearBlueprint,
+  compressBlueprint,
   parseBlueprint,
   resolveBlueprint,
   validateBlueprint,
@@ -360,10 +361,17 @@ async function importPayload(file) {
     );
   }
 
-  // Encode the blueprint into the URL and trigger a full page reload,
-  // the same way version changes work. This ensures a clean WASM runtime
-  // with no stale state from the previous session.
-  const encoded = btoa(unescape(encodeURIComponent(JSON.stringify(blueprint))));
+  // Encode the blueprint into the URL and trigger a full page reload, the same
+  // way version changes work. This ensures a clean WASM runtime with no stale
+  // state from the previous session. Compress with gzip+base64url so large
+  // blueprints don't produce huge fragile URLs; fall back to plain base64 when
+  // CompressionStream is unavailable (the resolver auto-detects either form).
+  let encoded;
+  try {
+    encoded = await compressBlueprint(blueprint);
+  } catch {
+    encoded = btoa(unescape(encodeURIComponent(JSON.stringify(blueprint))));
+  }
   const url = new URL(window.location.href);
   url.searchParams.set("blueprint", encoded);
   url.searchParams.delete("blueprint-url");

--- a/tests/blueprint/parser.test.js
+++ b/tests/blueprint/parser.test.js
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { parseBlueprint } from "../../src/blueprint/parser.js";
+import {
+  compressBlueprint,
+  parseBlueprint,
+  parseBlueprintParam,
+} from "../../src/blueprint/parser.js";
 
 describe("parseBlueprint", () => {
   it("passes through plain objects", () => {
@@ -67,5 +71,63 @@ describe("parseBlueprint", () => {
 
   it("throws on non-object/non-string input", () => {
     assert.throws(() => parseBlueprint(42), /Unsupported/);
+  });
+});
+
+describe("compressBlueprint / parseBlueprintParam (gzip round-trip)", () => {
+  // A repetitive blueprint compresses well — mirrors a real heavy import.
+  const heavy = {
+    steps: Array.from({ length: 40 }, (_, i) => ({
+      step: "setConfig",
+      name: `setting_${i}`,
+      value: "a repeated value that gzip loves ".repeat(8),
+    })),
+  };
+
+  it("round-trips a blueprint through gzip+base64url", async () => {
+    const encoded = await compressBlueprint(heavy);
+    const decoded = await parseBlueprintParam(encoded);
+    assert.deepStrictEqual(decoded, heavy);
+  });
+
+  it("produces a gzip stream (decoded bytes start with 1f 8b)", async () => {
+    const encoded = await compressBlueprint({ steps: [] });
+    // base64url → base64 → bytes
+    const b64 = encoded.replaceAll("-", "+").replaceAll("_", "/");
+    const bytes = Buffer.from(b64, "base64");
+    assert.strictEqual(bytes[0], 0x1f);
+    assert.strictEqual(bytes[1], 0x8b);
+  });
+
+  it("is much shorter than plain base64 for a heavy blueprint", async () => {
+    const json = JSON.stringify(heavy);
+    const plain = Buffer.from(json).toString("base64");
+    const gz = await compressBlueprint(heavy);
+    assert.ok(
+      gz.length < plain.length / 2,
+      `expected gzip (${gz.length}) to be < half of base64 (${plain.length})`,
+    );
+  });
+
+  it("still accepts old plain base64-JSON values (backwards compatible)", async () => {
+    const obj = { steps: [{ step: "login" }] };
+    const b64 = Buffer.from(JSON.stringify(obj)).toString("base64");
+    const decoded = await parseBlueprintParam(b64);
+    assert.deepStrictEqual(decoded.steps, [{ step: "login" }]);
+  });
+
+  it("falls through to the sync parser for objects, JSON and data: URLs", async () => {
+    assert.deepStrictEqual(await parseBlueprintParam({ steps: [] }), {
+      steps: [],
+    });
+    assert.deepStrictEqual(
+      (await parseBlueprintParam('{"steps":[{"step":"login"}]}')).steps,
+      [{ step: "login" }],
+    );
+    const b64 = Buffer.from(JSON.stringify({ steps: [] })).toString("base64");
+    assert.deepStrictEqual(
+      await parseBlueprintParam(`data:application/json;base64,${b64}`),
+      { steps: [] },
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Importing a `.blueprint.json` now **gzip-compresses** the blueprint into `?blueprint=` (base64url) instead of plain base64, so large blueprints no longer produce huge, fragile URLs.
- The resolver **auto-detects** the format (by the gzip magic bytes `0x1f 0x8b`), so old `?blueprint=<base64-JSON>` links keep working — no new URL parameter.
- Graceful fallback to plain base64 when the browser lacks `CompressionStream`.

## Rationale

The previous Import flow base64-encoded the entire blueprint into the URL and reloaded. For large blueprints (many steps + embedded `runPhpCode`) this created enormous URLs that hit length limits and could break on GitHub Pages / proxies. The blueprint actually reaches the runtime via sessionStorage (`saveBlueprint`→`loadBlueprint`→postMessage to the worker); the URL only needs to survive the reload and key the clean-boot detection — so it can be compressed freely.

## What changed

- `src/blueprint/parser.js`: `compressBlueprint()` (gzip+base64url) and async `parseBlueprintParam()` (auto-detects gzip vs base64-JSON vs object/JSON/data-URL), using the web Streams API (`CompressionStream`/`DecompressionStream`, portable to Node 18+ for tests). `parseBlueprint()` stays synchronous and unchanged.
- `src/blueprint/resolver.js`: `?blueprint=` resolved via `parseBlueprintParam` (already async).
- `src/shell/main.js`: `importPayload()` compresses with a plain-base64 fallback.
- `src/blueprint/index.js`: re-export `compressBlueprint`.
- Tests + docs.

## Testing

- `make test` — full suite green (254 blueprint tests incl. new gzip round-trip, backwards-compat, size, and fall-through cases). `make lint` clean.
- **End-to-end in the browser (real `CompressionStream`/`DecompressionStream`):**
  - Importing a ~10 KB blueprint produced a **~990-char** `?blueprint=H4sI…` URL (vs **13,616** chars of plain base64 — a ~93% reduction).
  - Reloading that compressed URL reconstructed the **identical** 39-step blueprint (siteName, 30 `setConfig` + 6 `runPhpCode` steps all intact).
  - Backwards compatibility with old `?blueprint=<base64-JSON>` links covered by unit tests (the resolver's non-gzip path is unchanged).