### PR TITLE
fix(i18n): make blueprint language packs actually install and apply

### DIFF
--- a/docs/decisions/0006-moodle-langpack-proxy-allowance.md
+++ b/docs/decisions/0006-moodle-langpack-proxy-allowance.md
@@ -97,6 +97,47 @@ language features on top of Moodle's own `lang_installer`:
 - `src/runtime/bootstrap.js` — `runLanguageAutoInstall()` invoked before blueprint execution.
 - `tests/blueprint/language-pack.test.js`, `tests/blueprint/steps.test.js` — coverage.
 
+## Follow-up — fixes after end-to-end verification (2026-06-09)
+
+The proxy allowance shipped, but end-to-end the language never actually applied. Loading a
+Spanish blueprint left the UI in English. Investigation found the proxy and networking were
+fine (the worker already defaults `corsProxyUrl` to `config.phpCorsProxyUrl`, so
+`tcpOverFetch` routes langpack GETs through `github-proxy` even without a `?phpCorsProxyUrl=`
+URL param). Three separate problems, none of them networking, blocked it:
+
+1. **`lang_installer` failed its requisites check.** `component_installer::check_requisites()`
+   (`lib/componentlib.class.php`) returns `wrongdestpath` and throws
+   `installer_requisites_check_failed` unless `$CFG->dataroot/lang` already exists. On a fresh
+   WASM runtime that directory does not exist, so the install aborted in ~45ms **before any
+   download** — both for `runLanguageAutoInstall` and the `installLanguagePack` step. (Manual
+   install "worked" only because browsing the admin Language UI had already created the dir.)
+   **Fix:** call `make_upload_directory('lang')` before invoking `lang_installer` in both code
+   paths.
+2. **The snapshot boot never applied `installMoodle.options.locale`.** Only the full CLI
+   installer (`createInstallRunnerPhp`) writes `$CFG->lang`; the pre-built snapshot path skips
+   it, leaving `$CFG->lang = 'en'`. So `runLanguageAutoInstall` read `'en'` and skipped, and a
+   locale-only blueprint never localized. **Fix:** `runSiteLanguageConfigure()` persists the
+   configured locale (`set_config('lang', …)`) just before `runLanguageAutoInstall`.
+3. **Setting the site default was not enough for the logged-in admin.** The install snapshot
+   bakes `mdl_user.admin.lang = 'en'`, and a logged-in user's `lang` overrides `$CFG->lang`.
+   Since the playground auto-logs-in as admin, the dashboard stayed English even after
+   `set_config('lang','es')`. **Fix:** when applying a new default (both in
+   `runSiteLanguageConfigure` and the `setDefault` branch of `phpInstallLanguagePacks`),
+   repoint users still on the previous default with
+   `$DB->set_field_select('user', 'lang', <new>, 'lang = ? AND deleted = 0', [<old>])`. Users
+   provisioned by later blueprint steps inherit the new default at creation.
+
+Verified end-to-end: a blueprint with `locale: "es"` + `installLanguagePack {setDefault:true}`
+boots with `Installed site language pack 'es'`, and the auto-logged-in admin dashboard renders
+in Spanish (`<html lang="es">`, "Área personal", "Administración del sitio").
+
+### Additional files modified
+- `src/runtime/bootstrap.js` — `make_upload_directory('lang')` in `runLanguageAutoInstall`;
+  new `runSiteLanguageConfigure()` invoked before the auto-install.
+- `src/blueprint/php/helpers.js` — `make_upload_directory('lang')` + repoint-users logic in
+  the `setDefault` branch of `phpInstallLanguagePacks`.
+- `tests/blueprint/language-pack.test.js` — asserts for the dir creation and user repointing.
+
 ## Review Criteria
 - If `@php-wasm` changes `tcpOverFetch`'s CORS-proxy handling or a future Moodle changes the
   `lang_installer` API or langpack URL scheme, re-verify both the native flow and the step.

--- a/src/blueprint/php/helpers.js
+++ b/src/blueprint/php/helpers.js
@@ -413,11 +413,27 @@ export function phpInstallLanguagePacks(codes, setDefault = false) {
   const list = codes.map((c) => `'${escapePhp(c)}'`).join(", ");
   const setDefaultBlock = setDefault
     ? `if (!empty($installed)) {
+    $previousLang = get_config('moodle', 'lang') ?: 'en';
     set_config('lang', '${escapePhp(codes[0])}');
+    // Repoint users still on the previous site default to the new language.
+    // Setting only the site default is not enough: the install snapshot bakes
+    // admin.lang='en', and a logged-in user's lang overrides $CFG->lang, so the
+    // auto-logged-in admin would keep seeing English. Users provisioned by later
+    // blueprint steps inherit the new default at creation, so only pre-existing
+    // accounts (admin/guest) need repointing.
+    if ($previousLang !== '${escapePhp(codes[0])}') {
+        $DB->set_field_select('user', 'lang', '${escapePhp(codes[0])}', 'lang = ? AND deleted = 0', [$previousLang]);
+    }
 }`
     : "";
   return `${CLI_HEADER}
+global $DB;
 require_once($CFG->libdir . '/componentlib.class.php');
+// component_installer::check_requisites() (used by lang_installer) bails out with
+// 'installer_requisites_check_failed' unless $CFG->dataroot/lang already exists —
+// and on a fresh WASM runtime it does not, so the install would fail before any
+// download. Create it up front (idempotent).
+make_upload_directory('lang');
 $requested = [${list}];
 // lang_installer::set_queue() expects an array of codes; it also auto-queues
 // parent languages (e.g. pt_br pulls pt). Network/parse failures are caught so

--- a/src/runtime/bootstrap.js
+++ b/src/runtime/bootstrap.js
@@ -2220,6 +2220,11 @@ if ($lang !== 'en' && preg_match('/^[a-z][a-z0-9_]*$/', $lang)) {
         $result['action'] = 'already-installed';
     } else {
         try {
+            // component_installer::check_requisites() (used by lang_installer)
+            // fails with 'installer_requisites_check_failed' unless
+            // $CFG->dataroot/lang exists, which it does not on a fresh WASM
+            // runtime. Create it up front (idempotent).
+            make_upload_directory('lang');
             $installer = new lang_installer($lang);
             $installer->run();
             if (is_file($CFG->dataroot . '/lang/' . $lang . '/langconfig.php')) {
@@ -2234,6 +2239,48 @@ if ($lang !== 'en' && preg_match('/^[a-z][a-z0-9_]*$/', $lang)) {
             $result['action'] = 'error';
             $result['error'] = $e->getMessage();
         }
+    }
+}
+echo json_encode($result);
+`;
+  const output = await php.run(code);
+  const text = output?.text || "";
+  const jsonStart = text.indexOf("{");
+  return jsonStart >= 0 ? JSON.parse(text.slice(jsonStart)) : {};
+}
+
+// Persist the blueprint-configured site language ($CFG->lang) on the snapshot
+// boot path. The snapshot ships with lang='en' and only the full CLI installer
+// (createInstallRunnerPhp) ever applies installMoodle.options.locale, so a
+// snapshot boot would otherwise ignore the configured locale entirely. This runs
+// BEFORE runLanguageAutoInstall so a locale-only blueprint (no installLanguagePack
+// step) still triggers the langpack download. It also repoints users still on the
+// previous default — the snapshot bakes admin.lang='en', and a logged-in user's
+// lang overrides $CFG->lang, so without this the auto-logged-in admin keeps
+// seeing English even after the pack installs. Idempotent: a no-op when the
+// configured locale already matches. See docs/decisions/0006-*.
+async function runSiteLanguageConfigure(php, locale) {
+  const lang = typeof locale === "string" ? locale.trim().toLowerCase() : "";
+  // The code is interpolated into the PHP below, so validate strictly first
+  // (it is re-checked in PHP too). Nothing to do for English or invalid codes.
+  if (!lang || lang === "en" || !/^[a-z][a-z0-9_]*$/.test(lang)) {
+    return { ok: true, lang: lang || "en", action: "skipped" };
+  }
+  const code = `<?php
+define('CLI_SCRIPT', true);
+require('/www/moodle/config.php');
+global $DB;
+$lang = '${lang}';
+$result = ['ok' => true, 'lang' => $lang, 'action' => 'skipped'];
+if (preg_match('/^[a-z][a-z0-9_]*$/', $lang)) {
+    $old = isset($CFG->lang) ? (string) $CFG->lang : 'en';
+    if ($old !== $lang) {
+        set_config('lang', $lang);
+        $DB->set_field_select('user', 'lang', $lang, 'lang = ? AND deleted = 0', [$old]);
+        $result['action'] = 'applied';
+        $result['previous'] = $old;
+    } else {
+        $result['action'] = 'already-set';
     }
 }
 echo json_encode($result);
@@ -2800,6 +2847,33 @@ export async function bootstrapMoodle({
       `Theme CSS warmup crashed (${themeCssError.message}). Pages may be unstyled. [${themeCssMs}ms]`,
       0.925,
     );
+  }
+
+  // Persist the blueprint-configured site language before the langpack
+  // auto-install below reads $CFG->lang. The snapshot boot path otherwise never
+  // applies installMoodle.options.locale, leaving the site (and the snapshot's
+  // admin.lang='en') in English even for a locale-only blueprint.
+  if (effectiveConfig.locale) {
+    const tLocale = performance.now();
+    try {
+      const localeResult = await runSiteLanguageConfigure(
+        php,
+        effectiveConfig.locale,
+      );
+      const localeMs = Math.round(performance.now() - tLocale);
+      if (localeResult?.action === "applied") {
+        publish(
+          `Configured site language '${localeResult.lang}' (was '${localeResult.previous}'). [${localeMs}ms]`,
+          0.926,
+        );
+      }
+    } catch (localeError) {
+      const localeMs = Math.round(performance.now() - tLocale);
+      publish(
+        `Site language configuration failed (${localeError.message}). [${localeMs}ms]`,
+        0.926,
+      );
+    }
   }
 
   // Auto-install the configured site language pack (e.g. locale "es") before

--- a/tests/blueprint/language-pack.test.js
+++ b/tests/blueprint/language-pack.test.js
@@ -87,6 +87,9 @@ describe("installLanguagePack: handler", () => {
     assert.strictEqual(runCalls.length, 1);
     assert.ok(runCalls[0].includes("new lang_installer"));
     assert.ok(runCalls[0].includes("$requested = ['es', 'fr'];"));
+    // The dataroot/lang dir must be created up front, otherwise
+    // component_installer::check_requisites() throws installer_requisites_check_failed.
+    assert.ok(runCalls[0].includes("make_upload_directory('lang');"));
     // Without setDefault, the site language must not be changed.
     assert.ok(!runCalls[0].includes("set_config('lang'"));
   });
@@ -95,6 +98,28 @@ describe("installLanguagePack: handler", () => {
     const { php, runCalls } = createPhpMock();
     await handler({ language: "es", setDefault: true }, { php });
     assert.ok(runCalls[0].includes("set_config('lang', 'es');"));
+  });
+
+  it("repoints users on the previous default when setDefault is true", async () => {
+    const { php, runCalls } = createPhpMock();
+    await handler({ language: "es", setDefault: true }, { php });
+    // Setting only the site default is not enough — the snapshot bakes
+    // admin.lang='en' and a logged-in user's lang overrides $CFG->lang, so the
+    // step must also repoint pre-existing users still on the old default.
+    assert.ok(
+      runCalls[0].includes("$previousLang = get_config('moodle', 'lang')"),
+    );
+    assert.ok(
+      runCalls[0].includes(
+        "$DB->set_field_select('user', 'lang', 'es', 'lang = ? AND deleted = 0', [$previousLang]);",
+      ),
+    );
+  });
+
+  it("does not repoint users when setDefault is omitted", async () => {
+    const { php, runCalls } = createPhpMock();
+    await handler({ language: "es" }, { php });
+    assert.ok(!runCalls[0].includes("set_field_select"));
   });
 
   it("does not throw when lang_installer crashes the runtime", async () => {


### PR DESCRIPTION
## Problem

Loading a Spanish blueprint (e.g. `?blueprint-url=…adaptable_config_7_es_acc.json`) left the
UI in **English**, even though the blueprint sets both `installMoodle.options.locale: "es"`
and `installLanguagePack { language: "es", setDefault: true }` (the i18n feature from #135).

The proxy and outbound networking are **fine**: the worker already defaults
`corsProxyUrl` to `config.phpCorsProxyUrl` (`php-worker.js`), so `tcpOverFetch` routes the
langpack GETs through `github-proxy` without needing a `?phpCorsProxyUrl=` URL param. The
blocker was three separate, non-networking issues:

1. **`lang_installer` aborted before downloading.** `component_installer::check_requisites()`
   (`lib/componentlib.class.php`) returns `wrongdestpath` and throws
   `installer_requisites_check_failed` unless `$CFG->dataroot/lang` already exists. On a fresh
   WASM runtime that directory does not exist, so the install failed in ~45 ms **before any
   download** — for both the boot auto-install and the `installLanguagePack` step. (Installing
   manually from the admin UI appeared to work only because browsing it had already created
   the dir.)
2. **The snapshot boot never applied `installMoodle.options.locale`.** Only the full CLI
   installer writes `$CFG->lang`; the pre-built snapshot path skips it, leaving
   `$CFG->lang = 'en'`. So `runLanguageAutoInstall` read `'en'` and skipped, and a locale-only
   blueprint never localized.
3. **Setting the site default was not enough.** The install snapshot bakes
   `mdl_user.admin.lang = 'en'`, and a logged-in user's `lang` overrides `$CFG->lang`. Since
   the playground auto-logs-in as admin, the dashboard stayed English even after
   `set_config('lang','es')`.

## Fix

- **`make_upload_directory('lang')`** before running `lang_installer`, in both
  `runLanguageAutoInstall` (`src/runtime/bootstrap.js`) and `phpInstallLanguagePacks`
  (`src/blueprint/php/helpers.js`).
- **`runSiteLanguageConfigure()`** (new, `bootstrap.js`): when `effectiveConfig.locale` is a
  valid non-English code, persist it (`set_config('lang', …)`) just before the auto-install,
  so locale-only blueprints localize and the boot auto-install triggers.
- **Repoint users on the previous default** to the new language (admin/guest baked at `'en'`
  in the snapshot) when applying a new default — in `runSiteLanguageConfigure` and in the
  `setDefault` branch of `installLanguagePack`. Users created by later blueprint steps inherit
  the new default at creation, so only pre-existing accounts need repointing.

## Verification

Local end-to-end with a minimal blueprint (`locale: "es"` + `installLanguagePack{setDefault}`):

- Runtime log: `Configured site language 'es' (was 'en')` → `Installed site language pack 'es' [8598ms]` → `Language pack(s) installed: es` → `Auto-login session created for admin user`.
- The auto-logged-in admin dashboard renders in **Spanish**: `<html lang="es">`, "Área
  personal", "Administración del sitio", "¡Bienvenido/a, Admin!".

`make test` → 558 pass / 0 fail (incl. new `language-pack.test.js` asserts). `make lint` clean.

## Notes
- No snapshots are regenerated (the fix is at boot, not in the snapshot).
- `docs/decisions/0006-moodle-langpack-proxy-allowance.md` updated with a follow-up section.
- Touches `src/blueprint/**` and `bootstrap.js`, which are bundled into the worker — CI rebuilds `dist/`.
