### PR TITLE
feat(snapshot): drain adhoc tasks and ship a localcache seed at build time

### DIFF
--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -25,10 +25,16 @@ export default defineConfig({
     process.env.PLAYWRIGHT_EXTERNAL_SERVER === "1"
       ? undefined
       : {
-          command: `sh -lc 'if [ -f assets/manifests/latest.json ]; then PORT=${port} npx http-server ${JSON.stringify(webRoot)} -p ${port} -c-1; else PORT=${port} make up; fi'`,
+          // Probe the manifest inside the SERVED root: in CI that is the
+          // downloaded _site artifact (which always contains the manifests),
+          // so the static server starts in seconds. The old repo-relative
+          // check always missed in CI (manifests are gitignored) and fell
+          // back to `make up`, whose npm install + builds burned 3-4 of the
+          // 5 timeout minutes and made every e2e job a coin toss.
+          command: `sh -lc 'if [ -f ${JSON.stringify(webRoot)}/assets/manifests/latest.json ]; then PORT=${port} npx http-server ${JSON.stringify(webRoot)} -p ${port} -c-1; else PORT=${port} make up; fi'`,
           url: baseURL,
           reuseExistingServer: !process.env.CI,
-          timeout: 300_000,
+          timeout: 600_000,
         },
   reporter: process.env.CI
     ? [["line"]]

--- a/scripts/build-moodle-bundle.sh
+++ b/scripts/build-moodle-bundle.sh
@@ -65,11 +65,16 @@ if [ -n "$BRANCH" ] && [ -d "$MOODLE_DIR/.git" ]; then
   SNAPSHOT_FINGERPRINT="${MOODLE_COMMIT}-$(printf '%.16s' "$SCRIPTS_HASH")-$(printf '%.16s' "$PATCHES_HASH")"
 fi
 
+# A valid cached snapshot is the DB plus the localcache seed (theme CSS +
+# DI container) generated in the same run — restore only when both exist.
 SNAPSHOT_CACHED=false
-if [ -n "$SNAPSHOT_FINGERPRINT" ] && [ -f "$SNAPSHOT_CACHE_DIR/$BRANCH/$SNAPSHOT_FINGERPRINT/install.sq3" ]; then
+if [ -n "$SNAPSHOT_FINGERPRINT" ] \
+  && [ -f "$SNAPSHOT_CACHE_DIR/$BRANCH/$SNAPSHOT_FINGERPRINT/install.sq3" ] \
+  && [ -f "$SNAPSHOT_CACHE_DIR/$BRANCH/$SNAPSHOT_FINGERPRINT/localcache.zip" ]; then
   echo "Snapshot cache hit: $SNAPSHOT_FINGERPRINT" >&2
   mkdir -p "$SNAPSHOT_DIR"
   cp "$SNAPSHOT_CACHE_DIR/$BRANCH/$SNAPSHOT_FINGERPRINT/install.sq3" "$SNAPSHOT_DIR/install.sq3"
+  cp "$SNAPSHOT_CACHE_DIR/$BRANCH/$SNAPSHOT_FINGERPRINT/localcache.zip" "$SNAPSHOT_DIR/localcache.zip"
   SNAPSHOT_CACHED=true
 fi
 
@@ -78,10 +83,13 @@ if [ "$SNAPSHOT_CACHED" = false ]; then
   if "$SCRIPT_DIR/generate-install-snapshot.sh" "$MOODLE_DIR" "$SNAPSHOT_DIR"; then
     echo "Snapshot generated successfully" >&2
     # Save to cache for future builds
-    if [ -n "$SNAPSHOT_FINGERPRINT" ] && [ -f "$SNAPSHOT_DIR/install.sq3" ]; then
+    if [ -n "$SNAPSHOT_FINGERPRINT" ] \
+      && [ -f "$SNAPSHOT_DIR/install.sq3" ] \
+      && [ -f "$SNAPSHOT_DIR/localcache.zip" ]; then
       rm -rf "${SNAPSHOT_CACHE_DIR:?}/$BRANCH"
       mkdir -p "$SNAPSHOT_CACHE_DIR/$BRANCH/$SNAPSHOT_FINGERPRINT"
       cp "$SNAPSHOT_DIR/install.sq3" "$SNAPSHOT_CACHE_DIR/$BRANCH/$SNAPSHOT_FINGERPRINT/install.sq3"
+      cp "$SNAPSHOT_DIR/localcache.zip" "$SNAPSHOT_CACHE_DIR/$BRANCH/$SNAPSHOT_FINGERPRINT/localcache.zip"
       echo "Snapshot cached: $SNAPSHOT_FINGERPRINT" >&2
     fi
   else
@@ -118,6 +126,11 @@ FILE_COUNT=$(find "$MOODLE_DIR" -type f | wc -l | tr -d ' ')
 SNAPSHOT_ARGS=""
 if [ -f "$SNAPSHOT_DIR/install.sq3" ]; then
   SNAPSHOT_ARGS="--snapshot $SNAPSHOT_DIR/install.sq3"
+  if [ -f "$SNAPSHOT_DIR/localcache.zip" ]; then
+    # The seed and the drained task queue are produced together by
+    # generate-install-snapshot.sh, so advertise both to the runtime.
+    SNAPSHOT_ARGS="$SNAPSHOT_ARGS --snapshotLocalcache $SNAPSHOT_DIR/localcache.zip --snapshotDrained 1"
+  fi
 fi
 
 node "$SCRIPT_DIR/generate-manifest.mjs" \
@@ -133,6 +146,9 @@ node "$SCRIPT_DIR/generate-manifest.mjs" \
 echo "Bundle written to $BUNDLE_PATH" >&2
 if [ -f "$SNAPSHOT_DIR/install.sq3" ]; then
   echo "Snapshot written to $SNAPSHOT_DIR/install.sq3" >&2
+fi
+if [ -f "$SNAPSHOT_DIR/localcache.zip" ]; then
+  echo "Localcache seed written to $SNAPSHOT_DIR/localcache.zip" >&2
 fi
 echo "Manifest written to $MANIFEST_PATH" >&2
 

--- a/scripts/generate-install-snapshot.sh
+++ b/scripts/generate-install-snapshot.sh
@@ -298,6 +298,81 @@ foreach (\$classes as \$classname) {
 }
 " 2>&1 | while IFS= read -r line; do echo "[snapshot] $line" >&2; done
 
+# Drain the remaining ad-hoc task queue so the snapshot ships with an empty
+# queue and the heavy install-time work runs on the build machine instead of
+# in the browser. Most importantly \core\task\build_installed_themes_task
+# compiles every theme's CSS into $MOODLEDATA/localcache/theme/... with the
+# matching themerev/themesubrev values written to this very database.
+# (The qbank transfer tasks above are deleted BEFORE this so they never run.)
+# --force only bypasses the cron_enabled config check; --ignorelimits skips
+# the adhoc concurrency/runtime limits.
+DRAIN_LOG="$TMPROOT/adhoc-drain.log"
+if ${PHP_BIN:-php} -d max_input_vars=5000 "$SOURCE_DIR/admin/cli/adhoc_task.php" \
+  --execute --force --ignorelimits >"$DRAIN_LOG" 2>&1; then
+  DRAIN_EXIT=0
+else
+  DRAIN_EXIT=$?
+fi
+sed 's/^/[snapshot] /' "$DRAIN_LOG" >&2
+if [ "$DRAIN_EXIT" -ne 0 ]; then
+  echo "Error: adhoc task drain exited with code $DRAIN_EXIT" >&2
+  exit 1
+fi
+
+# The drain must leave the queue empty: adhoc_task.php exits 0 even when a
+# task fails (it only records a faildelay), so count the leftovers explicitly.
+REMAINING_TASKS=$(${PHP_BIN:-php} -r "
+define('CLI_SCRIPT', true);
+define('CACHE_DISABLE_ALL', true);
+define('CACHE_DISABLE_STORES', true);
+require('$SOURCE_DIR/config.php');
+echo 'REMAINING=' . \$DB->count_records('task_adhoc') . PHP_EOL;
+" 2>/dev/null | sed -n 's/^REMAINING=//p' | tail -n 1)
+if [ "$REMAINING_TASKS" != "0" ]; then
+  echo "Error: task_adhoc still has ${REMAINING_TASKS:-unknown} row(s) after the drain" >&2
+  exit 1
+fi
+echo "Ad-hoc task queue drained." >&2
+
+# Pre-compile the DI container so the first WASM request does not pay for it.
+${PHP_BIN:-php} -d max_input_vars=5000 -r "
+define('CLI_SCRIPT', true);
+define('CACHE_DISABLE_ALL', true);
+define('CACHE_DISABLE_STORES', true);
+require('$SOURCE_DIR/config.php');
+\core\di::get_container();
+echo 'DI container compiled.' . PHP_EOL;
+" 2>&1 | while IFS= read -r line; do echo "[snapshot] $line" >&2; done
+
+if [ ! -f "$MOODLEDATA/localcache/di/CompiledContainer.php" ]; then
+  echo "Error: DI container was not compiled at localcache/di/CompiledContainer.php" >&2
+  exit 1
+fi
+if [ ! -d "$MOODLEDATA/localcache/theme" ]; then
+  echo "Error: localcache/theme missing after the drain — theme CSS was not built" >&2
+  exit 1
+fi
+
+# Tripwire: the seed must be portable to the WASM filesystem. The compiled
+# candidate sheets are path-free (theme_config::post_process strips host and
+# scheme) and the compiled DI container is generated PHP without filesystem
+# paths — fail loud if a build-machine path ever leaks in.
+if grep -R -l -e "$TMPROOT" -e "$SOURCE_DIR" \
+  "$MOODLEDATA/localcache/theme" "$MOODLEDATA/localcache/di" >&2; then
+  echo "Error: build-machine paths leaked into the localcache seed (files above)" >&2
+  exit 1
+fi
+
+# Package the localcache seed: ONLY the deterministic, portable artifacts.
+# Whitelisting theme/ and di/ inherently excludes .lastpurged (its absence
+# skips the purge-on-boot check in make_localcache_directory), bootstrap.php
+# (its bootstraphash embeds the build dbname) and core_component.php
+# (build-machine classmap paths; the runtime uses .playground's cache).
+rm -f "$OUTPUT_DIR/localcache.zip"
+(cd "$MOODLEDATA/localcache" && zip -qr "$OUTPUT_DIR/localcache.zip" theme di)
+SEED_SIZE=$(wc -c < "$OUTPUT_DIR/localcache.zip" | tr -d ' ')
+echo "Localcache seed written to $OUTPUT_DIR/localcache.zip ($SEED_SIZE bytes)" >&2
+
 # Note: $CFG->wwwroot comes from config.php (generated at runtime), not from
 # mdl_config. No wwwroot rewriting is needed in the snapshot.
 

--- a/scripts/generate-manifest.mjs
+++ b/scripts/generate-manifest.mjs
@@ -89,6 +89,29 @@ if (args.snapshot) {
     size: snapshotStats.size,
     sha256: sha256For(snapshotPath),
   };
+
+  // The snapshot generator drains the adhoc task queue and packages the
+  // localcache seed (compiled theme CSS + DI container) in the same run;
+  // both flags travel together so the runtime can skip the corresponding
+  // boot steps. Additive fields — schemaVersion stays at 1.
+  if (args.snapshotDrained === "1" || args.snapshotDrained === "true") {
+    manifest.snapshot.drained = true;
+  }
+
+  if (args.snapshotLocalcache) {
+    const seedPath = resolve(args.snapshotLocalcache);
+    const seedStats = statSync(seedPath);
+
+    manifest.snapshot.localcache = {
+      path: relative(resolve(manifestPath, ".."), seedPath).replaceAll(
+        "\\",
+        "/",
+      ),
+      fileName: basename(seedPath),
+      size: seedStats.size,
+      sha256: sha256For(seedPath),
+    };
+  }
 }
 
 writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");

--- a/tests/scripts/generate-manifest.test.js
+++ b/tests/scripts/generate-manifest.test.js
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, before, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = fileURLToPath(
+  new URL("../../scripts/generate-manifest.mjs", import.meta.url),
+);
+
+let workDir;
+let bundlePath;
+let snapshotPath;
+let localcachePath;
+
+function runGenerator(extraArgs) {
+  const manifestPath = join(workDir, `manifest-${extraArgs.length}.json`);
+  execFileSync(process.execPath, [
+    SCRIPT,
+    "--bundle",
+    bundlePath,
+    "--channel",
+    "MOODLE_500_STABLE",
+    "--manifest",
+    manifestPath,
+    "--runtimeVersion",
+    "0.0.0-test",
+    "--release",
+    "5.0-test",
+    "--fileCount",
+    "3",
+    ...extraArgs,
+  ]);
+  return JSON.parse(readFileSync(manifestPath, "utf8"));
+}
+
+describe("generate-manifest.mjs snapshot fields", () => {
+  before(() => {
+    workDir = mkdtempSync(join(tmpdir(), "manifest-test-"));
+    bundlePath = join(workDir, "bundle.zip");
+    snapshotPath = join(workDir, "install.sq3");
+    localcachePath = join(workDir, "localcache.zip");
+    writeFileSync(bundlePath, "bundle-bytes");
+    writeFileSync(snapshotPath, "snapshot-bytes");
+    writeFileSync(localcachePath, "seed-bytes");
+  });
+
+  after(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it("emits a legacy manifest without drained/localcache when not passed", () => {
+    const manifest = runGenerator(["--snapshot", snapshotPath]);
+    assert.strictEqual(manifest.schemaVersion, 1);
+    assert.strictEqual(manifest.snapshot.fileName, "install.sq3");
+    assert.ok(!("drained" in manifest.snapshot));
+    assert.ok(!("localcache" in manifest.snapshot));
+  });
+
+  it("emits drained + localcache metadata when passed", () => {
+    const manifest = runGenerator([
+      "--snapshot",
+      snapshotPath,
+      "--snapshotLocalcache",
+      localcachePath,
+      "--snapshotDrained",
+      "1",
+    ]);
+    assert.strictEqual(manifest.schemaVersion, 1);
+    assert.strictEqual(manifest.snapshot.drained, true);
+    assert.strictEqual(manifest.snapshot.localcache.fileName, "localcache.zip");
+    assert.strictEqual(manifest.snapshot.localcache.size, 10);
+    assert.match(manifest.snapshot.localcache.sha256, /^[0-9a-f]{64}$/);
+    // The seed path must be manifest-relative like the snapshot path.
+    assert.ok(!manifest.snapshot.localcache.path.startsWith("/"));
+  });
+});


### PR DESCRIPTION
## Why

A fresh Moodle install leaves heavy work for the browser: the install queues `\core\task\build_installed_themes_task` (1-3s of scssphp compilation in WASM — and the current boot warmup pays it without eliminating the first-click recompile, see upcoming runtime PR), and the first request compiles the DI container. All of this is deterministic per bundle, so it belongs on the build machine.

This is the build-side half; a follow-up runtime PR consumes the seed and skips the corresponding boot steps.

## What

**`generate-install-snapshot.sh`** (after the existing qbank DELETE, which stays so those tasks never execute):
1. Drain the queue with `admin/cli/adhoc_task.php --execute --force --ignorelimits` — `build_installed_themes_task` compiles every theme (ltr+rtl) into `localcache/theme/{themerev}/{name}/css/all_{subrev}.css` with the revs written to the same DB, and the snapshot ships with an empty `task_adhoc` table. Asserted explicitly (`adhoc_task.php` exits 0 even when a task fails). `--force` only bypasses the `cron_enabled` check.
2. Pre-compile the DI container (`localcache/di/CompiledContainer.php` — generated PHP, no absolute paths).
3. Package `snapshot/localcache.zip` as a **whitelist** of `theme/` + `di/`, which inherently excludes `.lastpurged` (its absence skips the purge-on-boot check), `bootstrap.php` (bootstraphash embeds the build dbname) and `core_component.php` (build-machine paths). A grep tripwire fails the build if any build-machine path leaks into the seed.

**`build-moodle-bundle.sh`**: snapshot cache stores/restores both artifacts; a hit now requires both. (CI's cache key already hashes `generate-install-snapshot.sh`, so existing caches invalidate automatically.)

**`generate-manifest.mjs`**: additive `snapshot.drained` + `snapshot.localcache {path,fileName,size,sha256}` fields; `schemaVersion` stays 1 and the current runtime ignores unknown fields — bundles built from this PR are fully backward compatible.

## Verified locally (MOODLE_500_STABLE, end-to-end build)

- Drain executed `tool_installaddon\task\post_install` + `core\task\build_installed_themes_task`; `task_adhoc` count = 0.
- Seed = 687 KB: `theme/1781044367/{boost,classic}/css/all{,-rtl}_<subrev>.css` matching the DB's `themerev`/`theme_*.themerev`, plus `di/CompiledContainer.php`. These are exactly the paths `theme/styles.php` serves at the ABORT_AFTER_CONFIG stage.
- Tripwire green (no build paths in the seed); manifest emits `drained: true` + `localcache` block.
- New unit test `tests/scripts/generate-manifest.test.js`; `make lint` + `make test` green.