### PR TITLE
feat(boot): consume the build-time localcache seed + fix the theme CSS warmup path bug

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,6 +248,13 @@ Current database assumptions:
   `synchronous=OFF`, `temp_store=MEMORY`, `cache_size=-8000`, `locking_mode=EXCLUSIVE`
 - A pre-built install snapshot (`assets/moodle/snapshot/install.sq3`) eliminates the
   3-8s CLI install phase. If unavailable, the full CLI install runs as a fallback.
+- Snapshot v2 manifests additionally advertise `snapshot.drained` (the adhoc task
+  queue was executed at build time via `admin/cli/adhoc_task.php`) and
+  `snapshot.localcache` (a `localcache.zip` seed with the compiled theme candidate
+  sheets + DI container). Snapshot-origin boots extract the seed into
+  `/persist/moodledata/localcache` on EVERY boot (localcache is never journaled)
+  and skip the SCSS warmup and qbank drainer steps. Legacy manifests without
+  these fields keep the warmup/drainer behavior.
 
 When touching the migration/runtime path, preserve these invariants:
 

--- a/docs/decisions/0010-build-time-localcache-seed.md
+++ b/docs/decisions/0010-build-time-localcache-seed.md
@@ -1,0 +1,76 @@
+# 0010 — Build-time localcache seed (theme CSS + DI container)
+
+## Status
+
+Accepted (2026-06).
+
+## Context
+
+A fresh Moodle install leaves deterministic, per-bundle work to be done at
+runtime, and the playground paid for it in the browser on every boot:
+
+- The CLI install queues `\core\task\build_installed_themes_task`
+  (`upgrade_themes()`), which nobody ran — the playground has no cron — so the
+  boot pipeline compiled Boost's SCSS in WASM (1-3 s) as a "warmup".
+- The warmup wrote `localcache/theme/<rev>/<name>/all.css`, but
+  `theme/styles.php` serves `theme/<rev>/<name>/css/all_<subrev>.css`
+  (note the `css/` subdirectory and the `_<subrev>` suffix from
+  `theme_styles_get_filename()`). The warmed file was never found, so the
+  first page view recompiled the SCSS a second time inside the request.
+- The first request also compiled the DI container
+  (`localcache/di/CompiledContainer.php`, `\core\di`).
+
+All of this output is a pure function of the bundle, so it belongs on the
+build machine.
+
+## Decision
+
+`generate-install-snapshot.sh` now drains the adhoc queue with
+`admin/cli/adhoc_task.php --execute --force --ignorelimits` (after the qbank
+transfer-task DELETE, so those never execute), asserts `task_adhoc` is empty,
+pre-compiles the DI container, and packages
+`snapshot/localcache.zip` = `localcache/{theme,di}` (whitelist).
+The manifest advertises the artifacts via additive `snapshot.drained` and
+`snapshot.localcache {path,fileName,size,sha256}` fields (schemaVersion 1).
+
+At boot, snapshot-origin sessions download the seed (sha256-verified), extract
+it into `/persist/moodledata/localcache` with `ZipArchive`, and skip the SCSS
+warmup and the qbank drainer steps. The warmup remains for the CLI-install
+fallback and legacy manifests — fixed to call `theme_build_css_for_themes()`
+so the candidate sheet lands where `styles.php` actually looks.
+
+## Key constraints verified
+
+- **Cache keys**: the seed and the snapshot DB come from the same build run,
+  so `localcache/theme/<themerev>/<name>/css/all_<themesubrev>.css` matches
+  the DB's `themerev` / `theme_<name>.themerev` by construction. Runtime
+  validation (`min_is_revision_valid_and_current()`) only checks the rev is a
+  plausible timestamp.
+- **Path portability**: candidate sheets contain no host or filesystem paths
+  (`theme_config::post_process()` strips scheme+host) but keep the wwwroot
+  *path* prefix — the build uses `http://localhost` (empty prefix), so on
+  subpath deploys the extractor rewrites `/theme/image.php/` and
+  `/theme/font.php/` with the runtime base path. The compiled DI container is
+  generated PHP with no absolute paths; a grep tripwire in the build fails
+  loud if any build-machine path ever leaks into the seed.
+- **What must NOT ship**: `.lastpurged` (its absence skips the
+  purge-on-boot check in `make_localcache_directory()`), `bootstrap.php`
+  (bootstraphash embeds the build dbname), `core_component.php`
+  (build-machine classmap paths), and the `scsscache-*` dirs (designer-mode
+  only; deleted in normal mode). The whitelist packaging makes these
+  structurally impossible to include.
+- **Persistence interplay**: `fs-persistence.js` deliberately never journals
+  `/persist/moodledata/(cache|localcache|temp|muc)` — the seed is therefore
+  re-applied from the (HTTP-cached) artifact on every snapshot-origin boot,
+  including journaled reloads. If an in-session cache purge bumps `themerev`
+  (e.g. a plugin install), the seeded sheets simply go unused and Moodle
+  lazily recompiles, same as before.
+
+## Consequences
+
+- Boot skips 1-3 s of scssphp work; the first click no longer recompiles the
+  SCSS (~1.5-4 s) nor builds the DI container (~0.2-0.5 s) — the candidate
+  sheet is served at the `ABORT_AFTER_CONFIG` stage without a full bootstrap.
+- ~0.7 MB extra parallel download per cold boot (seed zip, Cache-API cached).
+- An advertised-but-broken seed fails the boot loudly (deploy bug); only
+  manifests without the fields fall back to the legacy path.

--- a/lib/moodle-loader.js
+++ b/lib/moodle-loader.js
@@ -92,7 +92,7 @@ async function fetchJsonWithCache(url, cacheName) {
   return response.json();
 }
 
-async function verifyBundle(bytes, expectedSha256) {
+export async function verifyBundle(bytes, expectedSha256) {
   if (!expectedSha256) {
     return;
   }

--- a/src/runtime/bootstrap.js
+++ b/src/runtime/bootstrap.js
@@ -3,6 +3,7 @@ import { setPhpIniEntries } from "@php-wasm/universal";
 import {
   buildCoreExtractScript,
   fetchBundleWithCache,
+  verifyBundle,
 } from "../../lib/moodle-loader.js";
 import { buildInstallConfig } from "../blueprint/index.js";
 import {
@@ -909,7 +910,7 @@ echo json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 `;
 }
 
-function createThemeCssWarmupPhp() {
+export function createThemeCssWarmupPhp() {
   return `<?php
 header('content-type: application/json; charset=utf-8');
 error_reporting(E_ALL);
@@ -926,23 +927,30 @@ try {
     require_once($CFG->libdir . '/outputlib.php');
 
     $themename = 'boost';
-    $type = 'all';
+    $direction = right_to_left() ? 'rtl' : 'ltr';
 
+    // theme_build_css_for_themes() writes the candidate sheet exactly where
+    // theme/styles.php serves it from at the ABORT_AFTER_CONFIG stage
+    // (localcache/theme/<rev>/<name>/css/all_<subrev>.css) and bumps the
+    // theme sub-revision config to match. Hand-rolling the path here used to
+    // miss the css/ subdirectory and the _<subrev> suffix, so styles.php
+    // never found the warmed sheet and recompiled the SCSS on first view.
     $theme = theme_config::load($themename);
+    theme_build_css_for_themes([$theme], [$direction]);
+
     $rev = theme_get_revision();
+    $subrev = theme_get_sub_revision_for_theme($themename);
+    $candidatesheet = theme_get_css_filename($themename, $rev, $subrev, $direction);
 
-    // Compile the full theme CSS (SCSS -> CSS).
-    $csscontent = $theme->get_css_content();
-
-    // Store in the local cache where theme/styles.php expects it.
-    $candidatedir = make_localcache_directory("theme/$rev/$themename", false);
-    file_put_contents("$candidatedir/$type.css", $csscontent);
+    if (!is_readable($candidatesheet)) {
+        throw new RuntimeException('candidate sheet missing after build: ' . $candidatesheet);
+    }
 
     $result = [
         'ok' => true,
         'rev' => (int) $rev,
-        'size' => strlen($csscontent),
-        'path' => "$candidatedir/$type.css",
+        'size' => (int) filesize($candidatesheet),
+        'path' => $candidatesheet,
     ];
 } catch (Throwable $error) {
     $result['error'] = [
@@ -2045,6 +2053,146 @@ async function loadInstallSnapshot(
   return true;
 }
 
+/**
+ * Builds the PHP script that extracts the build-time localcache seed
+ * (compiled theme candidate sheets + DI container) into the runtime
+ * localcache directory.
+ *
+ * The candidate sheets are compiled with wwwroot http://localhost at build
+ * time, so their [[pix:]]/[[font:]] URLs are host-relative WITHOUT a path
+ * prefix; on subpath deploys the runtime wwwroot path must be prepended or
+ * theme images and fonts would 404.
+ */
+export function buildLocalcacheSeedExtractScript(zipPath, wwwrootPath) {
+  const zip = escapePhpSingleQuoted(zipPath);
+  const prefix = escapePhpSingleQuoted(wwwrootPath || "");
+  return `<?php
+error_reporting(E_ALL);
+$result = ['ok' => false];
+try {
+    $zipPath = '${zip}';
+    $target = '${MOODLEDATA_ROOT}/localcache';
+    if (!class_exists('ZipArchive')) {
+        throw new RuntimeException('ext/zip is not available');
+    }
+    if (!is_dir($target) && !mkdir($target, 0777, true)) {
+        throw new RuntimeException('cannot create ' . $target);
+    }
+    $archive = new ZipArchive();
+    $code = $archive->open($zipPath);
+    if ($code !== true) {
+        throw new RuntimeException('seed zip open failed (code ' . var_export($code, true) . ')');
+    }
+    if (!$archive->extractTo($target)) {
+        $archive->close();
+        throw new RuntimeException('seed zip extraction failed');
+    }
+    $entries = $archive->numFiles;
+    $archive->close();
+    @unlink($zipPath);
+
+    $rewritten = 0;
+    $prefix = '${prefix}';
+    if ($prefix !== '') {
+        $sheets = glob($target . '/theme/*/*/css/*.css') ?: [];
+        foreach ($sheets as $sheet) {
+            $css = file_get_contents($sheet);
+            if ($css === false) {
+                throw new RuntimeException('cannot read ' . $sheet);
+            }
+            $patched = str_replace(
+                ['/theme/image.php/', '/theme/font.php/'],
+                [$prefix . '/theme/image.php/', $prefix . '/theme/font.php/'],
+                $css,
+                $count
+            );
+            if ($count > 0) {
+                file_put_contents($sheet, $patched);
+                $rewritten++;
+            }
+        }
+    }
+
+    $result = ['ok' => true, 'entries' => $entries, 'rewritten' => $rewritten];
+} catch (Throwable $error) {
+    $result['error'] = [
+        'type' => get_class($error),
+        'message' => $error->getMessage(),
+    ];
+}
+echo json_encode($result, JSON_UNESCAPED_SLASHES);
+`;
+}
+
+/**
+ * Downloads and extracts the build-time localcache seed advertised by the
+ * manifest (snapshot.localcache). Returns false only when the manifest does
+ * not advertise a seed (legacy manifests keep today's behavior); an
+ * advertised-but-broken seed (fetch error, checksum mismatch, extraction
+ * failure) throws — a deploy that ships a bad artifact must fail loud.
+ *
+ * Must run on EVERY snapshot-origin boot, including journaled reloads:
+ * fs-persistence deliberately never journals localcache, so the seed is
+ * re-applied from the (Cache API cached) artifact each time.
+ */
+async function loadLocalcacheSeed(
+  php,
+  { manifest, appBaseUrl, publish, moodleBranch, wwwroot },
+) {
+  const seedInfo = manifest?.snapshot?.localcache;
+  if (!seedInfo) {
+    return false;
+  }
+
+  const branch = moodleBranch || DEFAULT_MOODLE_BRANCH;
+  const meta = getBranchMetadata(branch);
+  const fileName = seedInfo.fileName || "localcache.zip";
+  const seedPath = meta
+    ? `assets/moodle/${meta.snapshotDir}/${fileName}`
+    : `assets/moodle/snapshot/${fileName}`;
+
+  publish("Downloading pre-built localcache seed (theme CSS + DI).", 0.911);
+  const seedUrl = new URL(`./${seedPath}`, appBaseUrl);
+  const response = await fetch(seedUrl);
+  if (!response?.ok) {
+    throw new Error(
+      `Manifest advertises a localcache seed but ${seedPath} returned HTTP ${response?.status}.`,
+    );
+  }
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  await verifyBundle(bytes, seedInfo.sha256);
+
+  const zipPath = `${TEMP_ROOT}/moodle-localcache-seed.zip`;
+  await php.writeFile(zipPath, bytes);
+  const wwwrootPath = new URL(wwwroot).pathname.replace(/\/$/u, "");
+  const result = await php.run(
+    buildLocalcacheSeedExtractScript(zipPath, wwwrootPath),
+  );
+
+  const text = result.text ?? "";
+  const jsonStart = text.lastIndexOf("\n{");
+  const candidate = jsonStart >= 0 ? text.slice(jsonStart + 1) : text.trim();
+  let payload = null;
+  try {
+    payload = JSON.parse(candidate);
+  } catch {
+    throw new Error(
+      `Localcache seed extraction returned non-JSON output: ${text}`,
+    );
+  }
+  if (!payload?.ok) {
+    throw new Error(
+      `Localcache seed extraction failed: ${payload?.error?.message || "unknown error"}`,
+    );
+  }
+
+  publish(
+    `Localcache seed applied (${payload.entries} entries, ${payload.rewritten} stylesheet(s) rewritten for base path).`,
+    0.913,
+  );
+  return true;
+}
+
 async function runProvisioningCheck(php, webRoot) {
   const payload = await requestRuntimeScript(
     php,
@@ -2666,6 +2814,8 @@ export async function bootstrapMoodle({
     }
   }
 
+  let localcacheSeeded = false;
+
   if (!installMarkerMatches && !installState?.installed) {
     const tInstall = performance.now();
 
@@ -2690,6 +2840,13 @@ export async function bootstrapMoodle({
         `Install snapshot loaded in ${snapshotMs}ms (skipped full install).`,
         0.91,
       );
+      localcacheSeeded = await loadLocalcacheSeed(php, {
+        manifest: archive.manifest,
+        appBaseUrl: appBaseUrl || origin,
+        publish,
+        moodleBranch: resolvedBranch,
+        wwwroot,
+      });
     } else {
       // Fallback: run the full Moodle CLI installer
       publish("Running Moodle installation inside the CGI runtime.", 0.89);
@@ -2755,6 +2912,20 @@ export async function bootstrapMoodle({
       "Moodle database already installed, skipping CLI provisioning.",
       0.89,
     );
+    // Journaled reloads of a snapshot-origin install: localcache is never
+    // journaled (fs-persistence excludes caches by design), so the seed must
+    // be re-applied from the build artifact on every such boot. CLI-origin
+    // installs are not seeded — their themerev values differ from the
+    // snapshot's, so the seeded sheets would just be dead files.
+    if (savedInstallState?.source === "snapshot") {
+      localcacheSeeded = await loadLocalcacheSeed(php, {
+        manifest: archive.manifest,
+        appBaseUrl: appBaseUrl || origin,
+        publish,
+        moodleBranch: resolvedBranch,
+        wwwroot,
+      });
+    }
   }
   phases.install.finish();
 
@@ -2796,57 +2967,77 @@ export async function bootstrapMoodle({
   // Clear Moodle 5.0+ qbank transfer adhoc tasks queued during install — the
   // playground has no cron and no legacy question data to migrate, so leaving
   // them queued only serves to block /question/banks.php.  Non-fatal.
-  const tAdhoc = performance.now();
-  try {
-    publish("Clearing qbank transfer ad-hoc tasks.", 0.9195);
-    const adhoc = await runAdhocTasksDrainer(php, webRoot);
-    const adhocMs = Math.round(performance.now() - tAdhoc);
-    if (adhoc?.ok) {
-      const cleared = Object.values(adhoc.cleared || {}).filter(Boolean).length;
+  // Skipped when the snapshot was drained at build time: its task_adhoc table
+  // is provably empty, so there is nothing to clear.
+  if (localcacheSeeded && archive.manifest?.snapshot?.drained === true) {
+    publish(
+      "Ad-hoc task queue drained at build time — skipping runtime drainer.",
+      0.9197,
+    );
+  } else {
+    const tAdhoc = performance.now();
+    try {
+      publish("Clearing qbank transfer ad-hoc tasks.", 0.9195);
+      const adhoc = await runAdhocTasksDrainer(php, webRoot);
+      const adhocMs = Math.round(performance.now() - tAdhoc);
+      if (adhoc?.ok) {
+        const cleared = Object.values(adhoc.cleared || {}).filter(
+          Boolean,
+        ).length;
+        publish(
+          `Cleared ${cleared} blocking qbank task entry/entries. [${adhocMs}ms]`,
+          0.9197,
+        );
+      } else {
+        publish(
+          `Ad-hoc task drainer reported failure: ${adhoc?.error?.message || "unknown error"}. [${adhocMs}ms]`,
+          0.9197,
+        );
+      }
+    } catch (adhocError) {
+      const adhocMs = Math.round(performance.now() - tAdhoc);
       publish(
-        `Cleared ${cleared} blocking qbank task entry/entries. [${adhocMs}ms]`,
-        0.9197,
-      );
-    } else {
-      publish(
-        `Ad-hoc task drainer reported failure: ${adhoc?.error?.message || "unknown error"}. [${adhocMs}ms]`,
+        `Ad-hoc task drainer crashed (${adhocError.message}). [${adhocMs}ms]`,
         0.9197,
       );
     }
-  } catch (adhocError) {
-    const adhocMs = Math.round(performance.now() - tAdhoc);
-    publish(
-      `Ad-hoc task drainer crashed (${adhocError.message}). [${adhocMs}ms]`,
-      0.9197,
-    );
   }
 
   // Pre-compile theme CSS so that theme/styles.php can serve it from cache.
   // SCSS compilation is memory-intensive and can crash the WASM runtime if
   // triggered lazily on the first HTTP request.  Warming the cache here
   // (during the loading screen) avoids that runtime crash.
-  const tThemeCss = performance.now();
-  try {
-    publish("Compiling theme CSS (this may take a moment).", 0.92);
-    const themeCss = await runThemeCssWarmup(php, webRoot);
-    const themeCssMs = Math.round(performance.now() - tThemeCss);
-    if (themeCss?.ok) {
+  // Skipped when the localcache seed already provided the candidate sheets
+  // compiled at build time (1-3s of scssphp work saved per boot).
+  if (localcacheSeeded) {
+    publish(
+      "Theme CSS pre-compiled at build time — skipping SCSS warmup.",
+      0.925,
+    );
+  } else {
+    const tThemeCss = performance.now();
+    try {
+      publish("Compiling theme CSS (this may take a moment).", 0.92);
+      const themeCss = await runThemeCssWarmup(php, webRoot);
+      const themeCssMs = Math.round(performance.now() - tThemeCss);
+      if (themeCss?.ok) {
+        publish(
+          `Theme CSS compiled and cached (${themeCss.size} bytes, rev ${themeCss.rev}). [${themeCssMs}ms]`,
+          0.925,
+        );
+      } else {
+        publish(
+          `Theme CSS warmup failed: ${themeCss?.error?.message || "unknown error"}. [${themeCssMs}ms]`,
+          0.925,
+        );
+      }
+    } catch (themeCssError) {
+      const themeCssMs = Math.round(performance.now() - tThemeCss);
       publish(
-        `Theme CSS compiled and cached (${themeCss.size} bytes, rev ${themeCss.rev}). [${themeCssMs}ms]`,
-        0.925,
-      );
-    } else {
-      publish(
-        `Theme CSS warmup failed: ${themeCss?.error?.message || "unknown error"}. [${themeCssMs}ms]`,
+        `Theme CSS warmup crashed (${themeCssError.message}). Pages may be unstyled. [${themeCssMs}ms]`,
         0.925,
       );
     }
-  } catch (themeCssError) {
-    const themeCssMs = Math.round(performance.now() - tThemeCss);
-    publish(
-      `Theme CSS warmup crashed (${themeCssError.message}). Pages may be unstyled. [${themeCssMs}ms]`,
-      0.925,
-    );
   }
 
   // Persist the blueprint-configured site language before the langpack

--- a/tests/e2e/moodle-boot.spec.mjs
+++ b/tests/e2e/moodle-boot.spec.mjs
@@ -13,6 +13,44 @@ test("Moodle dashboard loads after boot", async ({ page, playground }) => {
   expect(address).toMatch(/^\//);
 });
 
+// Invariant: when the manifest advertises a build-time localcache seed
+// (snapshot.localcache, see ADR 0010), every snapshot-origin boot must apply
+// it and skip the in-browser SCSS warmup — including journaled reloads, since
+// fs-persistence never journals localcache. Legacy manifests (no seed field)
+// must keep the warmup behavior.
+test("boot consumes the localcache seed when the manifest advertises it", async ({
+  page,
+  playground,
+}) => {
+  await playground.open();
+
+  const manifest = await page.evaluate(async () => {
+    const response = await fetch("assets/manifests/latest.json", {
+      cache: "no-store",
+    });
+    return response.ok ? response.json() : null;
+  });
+
+  const logText = (await page.locator("#log-panel").textContent()) || "";
+  const seeded = Boolean(manifest?.snapshot?.localcache);
+
+  if (seeded) {
+    expect(logText).toContain("Localcache seed applied");
+    expect(logText).toContain("skipping SCSS warmup");
+    expect(logText).not.toContain("Compiling theme CSS");
+
+    // A reload boots from the journaled DB (source: "snapshot") and must
+    // re-apply the seed — localcache is rebuilt from the artifact each boot.
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await playground.open();
+    const reloadLog = (await page.locator("#log-panel").textContent()) || "";
+    expect(reloadLog).toContain("Localcache seed applied");
+    expect(reloadLog).not.toContain("Compiling theme CSS");
+  } else {
+    expect(logText).toContain("Compiling theme CSS");
+  }
+});
+
 test("PHP Info tab captures runtime diagnostics", async ({
   page,
   playground,

--- a/tests/runtime/localcache-seed.test.js
+++ b/tests/runtime/localcache-seed.test.js
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  buildLocalcacheSeedExtractScript,
+  createThemeCssWarmupPhp,
+} from "../../src/runtime/bootstrap.js";
+
+describe("buildLocalcacheSeedExtractScript", () => {
+  it("extracts into the runtime localcache via ZipArchive", () => {
+    const script = buildLocalcacheSeedExtractScript(
+      "/tmp/moodle/moodle-localcache-seed.zip",
+      "",
+    );
+    assert.ok(script.includes("new ZipArchive()"));
+    assert.ok(script.includes("'/persist/moodledata/localcache'"));
+    assert.ok(script.includes("'/tmp/moodle/moodle-localcache-seed.zip'"));
+    assert.ok(script.includes("json_encode($result"));
+  });
+
+  it("keeps the CSS rewrite inert on root deploys (empty prefix)", () => {
+    const script = buildLocalcacheSeedExtractScript("/tmp/seed.zip", "");
+    assert.ok(script.includes("$prefix = '';"));
+    assert.ok(script.includes("if ($prefix !== '')"));
+  });
+
+  it("rewrites theme image/font URLs with the deploy base path", () => {
+    const script = buildLocalcacheSeedExtractScript(
+      "/tmp/seed.zip",
+      "/moodle-playground",
+    );
+    assert.ok(script.includes("$prefix = '/moodle-playground';"));
+    assert.ok(script.includes("'/theme/image.php/'"));
+    assert.ok(script.includes("'/theme/font.php/'"));
+    // Only candidate sheets are touched.
+    assert.ok(script.includes("/theme/*/*/css/*.css"));
+  });
+});
+
+describe("createThemeCssWarmupPhp", () => {
+  it("builds the candidate sheet via theme_build_css_for_themes", () => {
+    const script = createThemeCssWarmupPhp();
+    assert.ok(script.includes("theme_build_css_for_themes([$theme]"));
+    // The sheet styles.php actually serves: css/ subdir + _<subrev> suffix,
+    // resolved through core's own helper rather than a hand-rolled path.
+    assert.ok(script.includes("theme_get_css_filename("));
+    assert.ok(script.includes("theme_get_sub_revision_for_theme("));
+  });
+
+  it("no longer hand-writes the broken candidate path", () => {
+    const script = createThemeCssWarmupPhp();
+    // The old implementation wrote localcache/theme/<rev>/<name>/all.css
+    // (missing the css/ subdir and the _<subrev> suffix), which styles.php
+    // never found — the first page view recompiled the SCSS again.
+    assert.ok(!script.includes('make_localcache_directory("theme/'));
+    assert.ok(!script.includes("$candidatedir/$type.css"));
+  });
+});


### PR DESCRIPTION
## Why

Two findings from profiling why this playground boots heavier than its siblings:

1. **The theme warmup never worked.** It wrote `localcache/theme/<rev>/boost/all.css`, but `theme/styles.php` serves `theme/<rev>/boost/css/all_<subrev>.css` (`theme_styles_get_filename()` — note the `css/` subdir and `_<subrev>` suffix). The warmed file was never found, so we paid the 1-3s SCSS compile **twice**: once at boot (wasted) and again inside the first page request.
2. With #142 the compiled theme CSS + DI container ship as a build artifact (`snapshot/localcache.zip`), so snapshot boots don't need to compile anything at all.

## What

- New `loadLocalcacheSeed()`: on snapshot-origin boots (fresh **and** journaled reloads — fs-persistence deliberately never journals localcache), download the seed advertised by `manifest.snapshot.localcache`, verify sha256, extract into `/persist/moodledata/localcache` via ZipArchive, and skip the SCSS warmup. With `snapshot.drained` the qbank drainer step is skipped too (the snapshot's `task_adhoc` is provably empty).
- Subpath deploys: candidate sheets are compiled against `http://localhost` at build time, so the extractor rewrites `/theme/image.php/` + `/theme/font.php/` with the runtime base path.
- **Fail loud**: an advertised-but-broken seed (fetch/sha/extract) aborts boot — that's a deploy bug. Only manifests *without* the field fall back to the legacy path (CLI installs and old bundles keep today's behavior).
- **Warmup fix** (benefits every non-seeded boot, including this PR before #142 lands): `createThemeCssWarmupPhp` now calls `theme_build_css_for_themes()`, which writes the sheet exactly where `styles.php` looks.
- ADR 0010 documents the cache-key + path-portability analysis; AGENTS.md updated.

## Measured locally (MOODLE_500_STABLE, chromium, trimmed bundle from #141 + seed from #142)

| | before | after |
|---|---|---|
| Boot total | ~11-13s (typical) | **5.1-6.7s** |
| SCSS at boot | 3.2-3.8s (and never served) | **0s** (seed) |
| First click | recompiled SCSS in-request | served at ABORT_AFTER_CONFIG |

## Tests

- `tests/runtime/localcache-seed.test.js`: extract-script + fixed-warmup unit tests (563/563 green).
- New e2e guard in `moodle-boot.spec.mjs`: seeded manifests must apply the seed on cold boot AND reload and must not compile SCSS; legacy manifests must keep the warmup. Conditional on the served manifest, so it's green both before and after #142 merges.
- Full boot e2e green on chromium + firefox with both seeded and legacy (stripped-manifest) assets; the fixed fallback warmup verified working in WASM (`Theme CSS compiled and cached (1051974 bytes)`).

Depends on #142 for the seed to exist (gracefully degrades to legacy behavior without it).