### PR TITLE
perf: faster boot, fluider navigation and a smaller core bundle (Phases 1+2+3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,12 +249,18 @@ Current database assumptions:
 - A pre-built install snapshot (`assets/moodle/snapshot/install.sq3`) eliminates the
   3-8s CLI install phase. If unavailable, the full CLI install runs as a fallback.
 - Snapshot v2 manifests additionally advertise `snapshot.drained` (the adhoc task
-  queue was executed at build time via `admin/cli/adhoc_task.php`) and
+  queue was executed at build time via `admin/cli/adhoc_task.php`),
   `snapshot.localcache` (a `localcache.zip` seed with the compiled theme candidate
-  sheets + DI container). Snapshot-origin boots extract the seed into
-  `/persist/moodledata/localcache` on EVERY boot (localcache is never journaled)
-  and skip the SCSS warmup and qbank drainer steps. Legacy manifests without
-  these fields keep the warmup/drainer behavior.
+  sheets + DI container) and `snapshot.requirejs` (the seed also contains a
+  pre-built combined RequireJS bundle at `localcache/requirejs/<sha1(1)>`).
+  Snapshot-origin boots extract the seed into `/persist/moodledata/localcache` on
+  EVERY boot (localcache is never journaled) and skip the SCSS warmup and qbank
+  drainer steps. When `snapshot.requirejs` is set, the runtime re-enables
+  `$CFG->cachejs` (pinning `$CFG->jsrev = 1`) so the browser makes one combined JS
+  request per page instead of dozens; `lib/requirejs.php` is patched at build time
+  to never build the combine itself and to serve the seed only for `core/first`
+  (ADR 0013). Legacy manifests without these fields keep the
+  warmup/drainer/`cachejs = false` behavior.
 
 When touching the migration/runtime path, preserve these invariants:
 
@@ -406,6 +412,7 @@ so that future contributors (human or AI) understand **why** a choice was made â
 | [0010](docs/decisions/0010-build-time-localcache-seed.md) | Build-time localcache seed (theme CSS + DI container) | Accepted |
 | [0011](docs/decisions/0011-bundle-trim-and-runtime-tuning.md) | Bundle content trim + php.ini/runtime tuning (amends ADR 0004) | Accepted |
 | [0012](docs/decisions/0012-worker-static-fast-path.md) | Static-file fast path bypassing the serial PHP request queue | Accepted |
+| [0013](docs/decisions/0013-build-time-requirejs-combined-bundle-seed.md) | Build-time RequireJS combined-bundle seed (re-enable cachejs) | Accepted |
 
 ## Debugging
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -403,6 +403,9 @@ so that future contributors (human or AI) understand **why** a choice was made â
 | [0007](docs/decisions/0007-course-restore-step.md) | Course backup (.mbz) restore step (PHP streaming download + restore_controller) | Accepted |
 | [0008](docs/decisions/0008-blueprint-roles-scales-cohorts-provisioning.md) | Blueprint provisioning for roles, scales and cohorts (inline or by URL) | Accepted |
 | [0009](docs/decisions/0009-file-backed-config-settings-blueprint-steps.md) | File-backed Moodle config settings in blueprints (`setConfigFile` / `setConfigFiles`) | Accepted |
+| [0010](docs/decisions/0010-build-time-localcache-seed.md) | Build-time localcache seed (theme CSS + DI container) | Accepted |
+| [0011](docs/decisions/0011-bundle-trim-and-runtime-tuning.md) | Bundle content trim + php.ini/runtime tuning (amends ADR 0004) | Accepted |
+| [0012](docs/decisions/0012-worker-static-fast-path.md) | Static-file fast path bypassing the serial PHP request queue | Accepted |
 
 ## Debugging
 

--- a/docs/decisions/0004-opcache-tuning-and-runtime-ux-defaults.md
+++ b/docs/decisions/0004-opcache-tuning-and-runtime-ux-defaults.md
@@ -1,7 +1,13 @@
 # ADR-0004 OPcache tuning and runtime UX defaults for WASM
 
-* Status: Accepted
+* Status: Accepted (rationale amended by ADR-0011)
 * Date: 2026-03-27
+
+> **Note (ADR-0011):** with `opcache.file_cache_only=1` OPcache allocates no
+> shared-memory segment, so `opcache.max_accelerated_files`,
+> `memory_consumption` and `interned_strings_buffer` are inert in this mode.
+> They are retained only as future-proofing. See
+> [0011](0011-bundle-trim-and-runtime-tuning.md).
 
 ## Context and Problem
 

--- a/docs/decisions/0011-bundle-trim-and-runtime-tuning.md
+++ b/docs/decisions/0011-bundle-trim-and-runtime-tuning.md
@@ -1,0 +1,158 @@
+# 0011 — Bundle content trim and php.ini / runtime tuning
+
+## Status
+
+Accepted (2026-06).
+
+## Context and Problem
+
+The Moodle core bundle that the playground downloads and extracts into MEMFS on
+every cold boot was ~78 MB / ~24,600 files (after the existing `.git`,
+`*/tests/*`, `node_modules` exclusions). File **count** matters as much as MB:
+MEMFS extraction is per-entry, so trimming dead files speeds both the download
+and the in-WASM `ZipArchive::extractTo()` phase. Separately, a code audit found
+PHP runtime settings that were either missing (`realpath_cache_*`) or
+documented in a misleading way (OPcache shared-memory knobs that are inert
+under `opcache.file_cache_only=1`). This ADR records the trim policy and the
+tuning changes, and the explicit decisions to NOT pursue several
+single-process/concurrency "optimizations".
+
+## Options Considered
+
+* Leave the bundle as-is (only structural exclusions).
+* Trim safe, never-loaded files (docs, build/CI/IDE metadata, AMD sources,
+  source maps) with build-time tripwires to prevent over-matching.
+* Minify PHP (strip comments/whitespace) — rejected: high risk, complex to do
+  reliably, breaks stack-trace line numbers, marginal gain vs the targeted
+  exclusions.
+
+## Decision
+
+### Bundle exclusions (`scripts/build-moodle-bundle.sh`)
+
+The zip step uses an explicit, commented `set --` allowlist of `-x` patterns.
+Groups added on top of the structural exclusions:
+
+* **`*/amd/src/*`** (~845 files / ~13 MB): Moodle serves compiled
+  `amd/build/*.min.js`. The dev-mode fallback in `lib/requirejs.php` reads
+  `amd/src` ONLY when a module's `.min.js.map` is missing — and every bundled
+  `min.js` ships its map (verified across all CI branches). `core_requirejs`
+  scans `amd/build` only; `lib/jssourcemap.php` serves the `.map` (which embeds
+  `sourcesContent`), so DevTools still shows original sources.
+* **Root docs + build/CI/IDE metadata** (~65 files / ~1.1 MB): `UPGRADING.md`,
+  `CONTRIBUTING.md`, `README.md`, `INSTALL.txt`, `COPYING.txt`, `TRADEMARK.txt`,
+  `Gruntfile.js`, `package.json`, `npm-shrinkwrap.json`, `composer.{json,lock}`,
+  `.github/`, `.grunt/`, `.upgradenotes/`, `.esbuild/`, `.jest/`, and lint/IDE
+  dotfiles. `security.txt` is deliberately KEPT (servable).
+* **Vendor/plugin docs, tree-wide** (~344 files / ~4.6 MB): `README*`,
+  `CHANGELOG*`, `CHANGES*`, `AUTHORS*`, `CONTRIBUTING*`, `upgrade.txt`,
+  `UPGRADING*`. **`HISTORY*` is forbidden** — it would match real runtime code
+  (`mod/wiki/history.php`, `lib/aws-sdk/src/History.php`,
+  `question/bank/history/...`).
+
+`*.map` exclusion (~867 files / ~5.7 MB download) is **deferred to ADR 0013**:
+while `$CFG->cachejs` is false, `amd/src` XOR `*.map` must remain (removing both
+breaks dev-mode JS). Since `amd/src` is already removed here, maps can only go
+once cachejs is re-enabled by the RequireJS combined-seed work.
+
+`FILE_COUNT` is now derived from the artifact (`unzip -Z1 | grep -cv '/$'`)
+instead of a parallel `find`, so it can never drift from the real exclusion set.
+
+Two build-time **tripwires** fail the build loudly:
+1. **PHP-entry parity**: bundled `.php` count must equal the source tree's
+   `.php` count minus the two known non-runtime PHP locations
+   (`.phpstorm.meta.php`, root `.github/`). Guarantees no doc pattern ever
+   swallows runtime PHP.
+2. **Presence asserts** (tolerant of the 5.1+ `public/` layout) for
+   `lib/requirejs.php`, `lib/behat/lib.php`, `lang/en/moodle.php`.
+
+Exclusions are zip-time only (they never mutate `$MOODLE_DIR`) and run after
+snapshot generation in the pipeline ordering, but the files they remove are not
+DB-listed plugins, so removal is safe by construction.
+
+### php.ini (`src/runtime/config-template.js`)
+
+* Added `realpath_cache_size = 8M`, `realpath_cache_ttl = 86400`. Every include
+  resolves each path component via `lstat` through Emscripten's JS FS; the
+  bundle tree is immutable within a session and there is exactly ONE PHP
+  process, which self-invalidates its realpath cache on any internal
+  unlink/rename. All JS-side FS writes (journal hydration, boot patches) happen
+  before the first request, and PHP does not cache negative lookups, so a
+  long TTL is safe.
+* Corrected the OPcache comment: with `opcache.file_cache_only=1` OPcache
+  allocates NO shared-memory segment, so `max_accelerated_files`,
+  `memory_consumption` and `interned_strings_buffer` are **inert**. They are
+  kept (with `max_accelerated_files` bumped to `20000`, above Moodle's ~15k
+  bundled PHP files) only as future-proofing should `file_cache_only` ever be
+  revisited. This amends the rationale of ADR 0004.
+
+### Rejected (recorded so they are not re-proposed)
+
+* **`$CFG->langlist = 'en'`**: would permanently filter
+  `get_list_of_translations()`, hiding any pack installed at runtime by the
+  blueprint `installLanguagePack` step (ADR 0006) and breaking a
+  `setDefault:'es'` blueprint. Zero measurable gain (the lang dir is a trivial
+  MEMFS scan; `langmenu=0` is already seeded).
+* **`$CFG->enable_read_only_sessions` / `READ_ONLY_SESSION`**: solves session
+  write-lock contention between CONCURRENT requests. The playground has one PHP
+  instance behind a strictly serial request queue (`php-worker.js`) — contention
+  is structurally zero — and sessions live in MEMFS where a write costs
+  microseconds. Pure downside (RO-marked scripts that mutate `$SESSION` start
+  logging errors; the auto-login bootstrap becomes a new thing to keep
+  compatible).
+* **Alternative session handler**: files-on-MEMFS is already memory-backed and
+  optimal; a DB handler routes session I/O through SQLite (slower).
+
+### `@php-wasm` upgrade 3.1.36 → 3.1.38
+
+Between the two tags there are exactly two `packages/php-wasm` commits:
+`a2b8d3d3` ("[Web] Decline TLS session resumption for shared curl handles") —
+a pure fix on the `tcpOverFetch` HTTPS path the playground uses for langpack and
+plugin downloads — and `ccade0bd` (XDebug CDP, CLI-only, not consumed here).
+3.1.37 was an empty version bump. No API changes touch `php-loader.js`,
+`php-compat.js` or `fs-persistence.js`. Decision: **GO**.
+
+## Consequences
+
+### Positive
+* MOODLE_500_STABLE bundle: ~78 MB → ~73.8 MB, ~24,600 → ~23,324 files
+  (measured), with the same numbers proportionally across branches. Less to
+  download, decompress and write into MEMFS on every cold boot.
+* Realpath cache cuts repeated path-walk syscalls on the hot include path.
+* The misleading OPcache comment no longer implies the SHM knobs do anything.
+* The TLS fix makes repeated outbound HTTPS from PHP reliable.
+
+### Negative / Risks
+* `zip -x` over-matching is the main correctness risk; mitigated by the
+  PHP-parity tripwire + presence asserts (build fails, never ships). New
+  patterns require a per-branch audit and must never include `HISTORY*`.
+* DevTools step-debugging of core AMD modules now shows minified source mapped
+  back via the `.map` (full original source preserved); only `amd/src` raw files
+  are gone.
+* The `@php-wasm` TLS change must be exercised (langpack/plugin install) before
+  release — a regression surfaces as OpenSSL handshake errors inside PHP curl,
+  which `moodle-language.js` would mask as a soft failure.
+
+## Implementation Notes
+
+* `scripts/build-moodle-bundle.sh`: exclusion allowlist, `FILE_COUNT` from zip,
+  tripwires.
+* `src/runtime/config-template.js`: realpath cache + OPcache comment/bump.
+  Requires `npm run build-worker` (config-template.js is bundled into the
+  worker).
+* `package.json` / `package-lock.json`: `@php-wasm/*` ^3.1.38; `npm install`
+  then `npm run build-worker`.
+* New unit tests in `tests/runtime/config-template.test.js` (ini keys) and
+  `tests/shared/moodle-loader-asset-cache.test.js` (the Cache API helper added
+  for the boot work).
+
+## Review Criteria
+
+* Revisit the exclusion list whenever a new Moodle branch is added to CI (the
+  tripwires will fail loudly if a pattern over-matches on the new branch).
+* Revisit `opcache.file_cache_only` if WASM ever gains a usable shared-memory
+  OPcache — at which point the inert knobs become live.
+* Revisit `realpath_cache_ttl` if any future feature deletes MEMFS files from
+  the JS side between requests (stale positive realpath entries could surface).
+* Revisit the langlist/read-only-session rejections if the runtime ever moves
+  off a single serial PHP instance.

--- a/docs/decisions/0012-worker-static-fast-path.md
+++ b/docs/decisions/0012-worker-static-fast-path.md
@@ -1,0 +1,104 @@
+# 0012 — Static-file fast path bypassing the serial PHP request queue
+
+## Status
+
+Accepted (2026-06).
+
+## Context and Problem
+
+The PHP worker (`php-worker.js`) processes every scoped request through a single
+serial promise chain (`requestQueue`). This is correct for PHP execution — the
+WASM runtime is single-threaded and `php.run()` resets state — but it also
+serializes requests for **static** files (theme CSS/JS, images, fonts) that are
+served by a plain MEMFS read (`php.readFileAsBuffer`) with no `php.run()` at all
+(`php-compat.js` request() static branch). On first navigation a Moodle page
+pulls dozens of such assets; each waited behind every preceding request in the
+queue, even though answering it is a synchronous memory read.
+
+The SW already has a scoped-static Cache API layer (ADR 0001) that absorbs
+repeat visits, but the first request per asset per scope (and anything not yet
+cached) still queued through PHP.
+
+## Options Considered
+
+* Leave everything serialized (status quo).
+* Add a static fast path in the worker that answers non-`.php` GETs from MEMFS
+  immediately, before entering the queue.
+* Rework the SW↔worker transport to use transferable `ArrayBuffer`s via a
+  `MessagePort` to cut the body-copy cost.
+
+## Decision
+
+### Static fast path (implemented)
+
+`wrapPhpInstance` exposes a synchronous `serveStaticSync(urlPath)` that mirrors
+the static branch of `request()` (reuses `resolveScriptPath` / `isPhpScript` /
+`getMimeType`). It returns `{status, headers, bytes}` on a hit, or `null` when
+the caller must fall back to the queued path: the target is a `.php` script
+(including `.php/PATH_INFO` routes), a path traversal, or the file is missing.
+
+`php-worker.js` keeps a `readyPhp` reference (set when boot completes, cleared on
+`resetRuntime` and on a boot error). In `installBridgeListener`, for a `GET`
+with `readyPhp` set, it calls `serveStaticSync` and — on a hit — responds
+immediately, bypassing both the queue AND the redundant `Response→arrayBuffer`
+copy of `serializeResponse`. `requestCount` and `detectPluginInstall` are
+intentionally skipped (both are PHP-execution concerns). `HEAD`/`POST` keep
+queueing.
+
+This intentionally relaxes the "single serial promise chain" invariant for
+**read-only MEMFS GETs only**. It is safe because `readFileAsBuffer` is a
+pure-JS Emscripten MEMFS read (no WASM re-entry) and the worker is
+single-threaded, so a read is atomic with respect to PHP writes even while a
+`php.run()` is suspended (asyncify/JSPI). `moodledata` is not URL-addressable
+(`resolveScriptPath` only maps under `webRoot`), so dataroot files never take
+this path. Returning `null` (not 404) on a miss preserves today's semantics for
+boot races and files that appear mid-install.
+
+### Transferables / MessagePort transport (DEFERRED)
+
+Every response body crosses the BroadcastChannel via structured clone (a copy),
+and `serializeResponse` first does `response.arrayBuffer()` (another copy). For
+typical Moodle responses (HTML 50–300 KB, JSON a few KB) that is well under
+1–2 ms — dwarfed by 50–500 ms PHP execution. A `MessagePort`/transferable
+rework would add real failure modes the current design avoids (the SW can be
+killed at any time; ports die silently and need a client-mediated re-handshake;
+per-scope bridge bookkeeping must be reworked; Safari/Firefox MessagePort-in-SW
+behaviour is historically quirky). The only realistic beneficiaries are
+multi-MB downloads (course backups, large `pluginfile` media), which are rare
+and tolerate +10–30 ms. The fast path above already elides the extra copy for
+statics.
+
+**Decision: defer.** Re-open only if measured p95 bridge overhead for dynamic
+responses exceeds ~5 ms (instrument behind the existing debug/profile flag
+before committing to the rework).
+
+## Consequences
+
+### Positive
+* Static assets no longer wait behind PHP page renders in the queue on first
+  navigation — the slowest moment today. They are answered by a synchronous
+  MEMFS read and skip one body copy.
+* No change to PHP-execution accounting, plugin-install detection, or crash
+  recovery (fast-path hits don't touch `requestCount`).
+
+### Negative / Risks
+* The fast path reads MEMFS while a `php.run()` may be suspended. Safe under
+  @php-wasm 3.1.38's single-threaded MEMFS model, but it is an implementation
+  detail — every call is wrapped in try/catch with fallback to the queue, and
+  `readyPhp` is cleared on reset / boot error.
+* A future change that makes MEMFS reads non-atomic (threads, SharedArrayBuffer
+  FS) would invalidate the safety argument — revisit then.
+
+## Implementation Notes
+
+* `src/runtime/php-compat.js`: `serveStaticSync` on the wrapped instance.
+* `php-worker.js`: `readyPhp` lifecycle + fast-path branch in
+  `installBridgeListener`. Requires `npm run build-worker`.
+* Tests: `tests/runtime/serve-static-sync.test.js`.
+
+## Review Criteria
+
+* Revisit the deferred transport rework if profiling shows p95 dynamic-response
+  bridge overhead > ~5 ms, or if large-media downloads become a common path.
+* Revisit the fast-path safety argument if the runtime gains a threaded or
+  shared-memory filesystem.

--- a/docs/decisions/0013-build-time-requirejs-combined-bundle-seed.md
+++ b/docs/decisions/0013-build-time-requirejs-combined-bundle-seed.md
@@ -1,0 +1,141 @@
+# 0013 — Build-time RequireJS combined-bundle seed (re-enable cachejs)
+
+## Status
+
+Accepted (2026-06).
+
+## Context and Problem
+
+With `$CFG->cachejs = false` (the prior default), Moodle's `lib/requirejs.php`
+serves JavaScript in **dev mode**: every AMD module is a separate, uncached
+PHP execution. A first page load pulls ~50–120 such requests, all serialized
+through the worker's single PHP request queue — the slowest moment of in-session
+navigation.
+
+`cachejs = true` (production mode) would collapse that to ONE combined request
+per page (`/lib/requirejs.php/<rev>/core/first.js` returns all non-lazy modules).
+But enabling it previously failed silently with "No define call for core/first":
+`core_requirejs::find_all_amd_modules()` relies on `realpath()` /
+`RecursiveDirectoryIterator::getRealPath()`, which is unreliable on the
+Emscripten VFS (the same reason this project already patches `code_manager`).
+The runtime combine wrote a poisoned-but-existing cache file that
+`js_send_cached()` then served.
+
+## Options Considered
+
+* Keep `cachejs = false` (status quo): dozens of serial PHP requests per page.
+* Let the runtime build the combine with `cachejs = true`: fails on the
+  Emscripten VFS.
+* Build the combined bundle at build time (where filesystem iteration is
+  reliable), ship it in the localcache seed, and forbid the runtime from ever
+  building it.
+
+## Decision
+
+Build the combine at build time and seed it; the WASM runtime never combines.
+
+### Build time
+
+* `scripts/generate-install-snapshot.sh` runs a PHP warmup that replicates
+  `requirejs.php`'s production "all non-lazy modules" combine
+  (`core_requirejs::find_all_amd_modules()` → strip `sourceMappingURL` →
+  `requirejs_fix_define()` → concatenate) and writes it via
+  `js_write_cache_file_content()` to `localcache/requirejs/<sha1(1)>`. It
+  fail-hards if the file is missing, < 1 MB, or lacks the `core/first` define.
+  `requirejs/` is added to the seed tripwire (no build-machine paths) and to the
+  `localcache.zip`.
+* `scripts/patch-moodle-source.sh` patches `lib/requirejs.php` (two hunks,
+  fail-loud needle checks, applied to all CI branches):
+  1. Guard the cache-miss **build** branch with `!defined('MOODLE_PLAYGROUND')`,
+     so the playground never builds the combine — on a miss it falls through to
+     the existing dev-mode single-module serving.
+  2. Serve the seeded combine **only for `core/first`**: for any other non-lazy
+     module, blank the candidate so it falls through to per-module serving. The
+     seed contains only the modules present at build time, so this keeps AMD
+     from runtime-installed plugins working (they are served individually).
+* `scripts/build-moodle-bundle.sh` probes the seed zip (`unzip -l | grep
+  ' requirejs/'`) and passes `--snapshotRequirejs 1`; `generate-manifest.mjs`
+  records `manifest.snapshot.requirejs = true`. The flip is keyed off the
+  **actually shipped** artifact, so cached pre-warmup seeds and legacy bundles
+  keep `cachejs = false`.
+
+### Runtime
+
+`bootstrap.js` passes `requirejsSeeded = Boolean(manifest.snapshot.requirejs)` to
+`createMoodleConfigPhp`. When seeded, `config.php` emits:
+
+```php
+$CFG->jsrev = 1;
+$CFG->cachejs = is_dir($CFG->localcachedir . '/requirejs');
+```
+
+* **`jsrev` is pinned to 1** so the URL revision matches the seeded `sha1(1)`
+  file. config.php overrides DB config, so `js_reset_all_caches()`'s
+  `set_config('jsrev', time())` cannot desync the revision across journaled
+  reloads. Bundle JS is immutable per build, so in-session JS cache-busting being
+  a no-op is acceptable. (A future feature that mutates JS at runtime — e.g.
+  theme designer mode — would need to revisit this.)
+* **`is_dir()` self-heals after "Purge all caches"**: a purge wipes
+  `localcache/requirejs`, so `cachejs` flips to `false` for the rest of the
+  session (per-module dev serving); the next boot re-extracts the seed and
+  recovers. (localcache is intentionally never journaled.)
+
+## Consequences
+
+### Positive
+* First page load per scope: ONE combined `requirejs.php` request instead of
+  ~50–120 serial per-module PHP executions. This is the largest in-session
+  navigation win.
+* The runtime never runs the broken `find_all_amd_modules` combine.
+* Graceful degradation: no seed (legacy/old bundle) → `cachejs = false`, exactly
+  today's behavior.
+
+### Negative / Risks
+* The `requirejs.php` needles must match across all CI branches; the patch fails
+  the build loudly on a mismatch (never ships an unpatched bundle with
+  `cachejs = true`), and the manifest flag is derived from the produced seed, so
+  a failed branch degrades to `cachejs = false`.
+* The `core/first`-only serving rule is **correctness-critical**: without it, a
+  plugin installed at runtime would receive the combined bundle (missing its
+  define) for every module request and break. Verify with an e2e that installs
+  an AMD-bearing plugin.
+* `requirejs_fix_define()` is duplicated from `lib/requirejs.php` (it is not an
+  autoloadable function); keep it in sync with upstream.
+* localcache.zip grows by the combined bundle (~few MB, JS compresses well).
+
+### Why `*.map` is NOT excluded from the bundle
+
+ADR 0011 left the `*.map` exclusion to this ADR, expecting `cachejs = true` to
+make maps dead weight. That is true only for the **non-lazy modules in the
+seeded combine**. It is NOT safe here:
+
+* **Lazy modules** (`chartjs`, TinyMCE's `codemirror`, `videojs`, …) are excluded
+  from the non-lazy combine, so they are always served individually via the
+  dev-mode path, which reads the `min.js` **only if its `.map` exists**, else
+  falls back to `amd/src`.
+* **Runtime-installed plugin** AMD modules and the **post-purge** fallback use
+  the same dev-mode path.
+
+Because ADR 0011 already removed `amd/src`, the `.map` files are **required** for
+all of the above in normal operation (not just post-purge). The invariant
+`amd/src XOR *.map` therefore resolves to: keep `*.map`. The bundle stays at
+~73.8 MB (the ADR 0011 trim). Excluding maps would break lazy/plugin module
+loading.
+
+## Implementation Notes
+
+* `scripts/generate-install-snapshot.sh`, `scripts/patch-moodle-source.sh`,
+  `scripts/build-moodle-bundle.sh`, `scripts/generate-manifest.mjs`.
+* `src/runtime/config-template.js` (emission), `src/runtime/bootstrap.js`
+  (wiring). Requires `npm run build-worker`.
+* `lib/requirejs.php` in the SW cacheable-PHP-asset set (ADR 0011 / sw.js).
+* Tests: `tests/runtime/config-template.test.js` (both cachejs emissions).
+
+## Review Criteria
+
+* Re-evaluate `jsrev = 1` pinning if any runtime feature begins mutating JS
+  (theme designer mode, runtime recompiles).
+* Re-verify the `requirejs.php` needles whenever a Moodle branch is added/bumped
+  (the fail-loud patch surfaces drift as a build error).
+* Re-test the `core/first`-only rule whenever the AMD loading flow changes
+  upstream, and keep `requirejs_fix_define()` in sync.

--- a/lib/moodle-loader.js
+++ b/lib/moodle-loader.js
@@ -130,6 +130,21 @@ function normalizeManifest(manifestUrl, manifest) {
     throw new Error(`Manifest ${resolvedManifestUrl} does not include bundle.path or bundle.parts`);
   }
 
+  // Resolve the auxiliary boot assets (install snapshot + localcache seed)
+  // the same way, so consumers can fetch them cache-first by absolute URL.
+  if (normalized.snapshot?.path) {
+    normalized.snapshot = {
+      ...normalized.snapshot,
+      url: new URL(normalized.snapshot.path, resolvedManifestUrl).toString(),
+    };
+    if (normalized.snapshot.localcache?.path) {
+      normalized.snapshot.localcache = {
+        ...normalized.snapshot.localcache,
+        url: new URL(normalized.snapshot.localcache.path, resolvedManifestUrl).toString(),
+      };
+    }
+  }
+
   return normalized;
 }
 
@@ -318,6 +333,77 @@ export async function fetchBundleWithCache(manifest, onProgress = () => {}) {
     );
   } catch {
     // Caching is an optimization. Bootstrap must continue without it.
+  }
+
+  return bytes;
+}
+
+/**
+ * Fetch an auxiliary bootstrap asset (install snapshot, localcache seed)
+ * cache-first through the same Cache API bucket as the core bundle.
+ *
+ * Caches ONLY when a sha256 is provided: the checksum is the staleness
+ * signal (mismatch deletes the entry and refetches — the same lifecycle as
+ * the bundle cache). Without one (legacy manifests) this degrades to a
+ * plain network fetch with no Cache API involvement. Throws on a non-OK
+ * response or a checksum mismatch of freshly downloaded bytes, so callers
+ * decide whether a missing asset is fatal (localcache seed) or a graceful
+ * fallback (install snapshot -> CLI install).
+ */
+export async function fetchAssetWithCache(url, { sha256: expectedSha256 } = {}, onProgress = () => {}) {
+  const cacheable = Boolean(expectedSha256);
+
+  if (cacheable) {
+    const cache = await openBundleCache();
+    const cached = await cache.match(url);
+    if (cached) {
+      try {
+        const bytes = await responseToBytes(cached);
+        await verifyBundle(bytes, expectedSha256);
+        onProgress({
+          loaded: bytes.byteLength,
+          total: bytes.byteLength,
+          ratio: 1,
+          cached: true,
+          url,
+        });
+        return bytes;
+      } catch {
+        // Stale or corrupted entry: bust it and fall through to the network.
+        await cache.delete(url);
+      }
+    }
+  }
+
+  const response = await fetch(url);
+  if (!response?.ok) {
+    throw new Error(`Unable to download asset: ${response?.status} ${response?.statusText || ""} (${url})`);
+  }
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  await verifyBundle(bytes, expectedSha256);
+  onProgress({
+    loaded: bytes.byteLength,
+    total: bytes.byteLength,
+    ratio: 1,
+    cached: false,
+    url,
+  });
+
+  if (cacheable) {
+    try {
+      const cache = await openBundleCache();
+      await cache.put(
+        url,
+        new Response(bytes, {
+          headers: {
+            "content-length": String(bytes.byteLength),
+            "content-type": "application/octet-stream",
+          },
+        }),
+      );
+    } catch {
+      // Caching is an optimization. Bootstrap must continue without it.
+    }
   }
 
   return bytes;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,10 @@
     "": {
       "name": "moodle-playground",
       "dependencies": {
-        "@php-wasm/fs-journal": "^3.1.36",
-        "@php-wasm/stream-compression": "^3.1.36",
-        "@php-wasm/universal": "^3.1.36",
-        "@php-wasm/web": "^3.1.36",
+        "@php-wasm/fs-journal": "^3.1.38",
+        "@php-wasm/stream-compression": "^3.1.38",
+        "@php-wasm/universal": "^3.1.38",
+        "@php-wasm/web": "^3.1.38",
         "fflate": "^0.8.3"
       },
       "devDependencies": {
@@ -1139,14 +1139,14 @@
       "license": "MIT"
     },
     "node_modules/@php-wasm/fs-journal": {
-      "version": "3.1.36",
-      "resolved": "https://registry.npmjs.org/@php-wasm/fs-journal/-/fs-journal-3.1.36.tgz",
-      "integrity": "sha512-R0ch1dJzxyDR0YP0AprmQCYvnsKnlS9uxydN1OCoFoPCaqOG9UOt/Kgc8TGzasg/fM9VBz/o470I9xmt4OzyJA==",
+      "version": "3.1.38",
+      "resolved": "https://registry.npmjs.org/@php-wasm/fs-journal/-/fs-journal-3.1.38.tgz",
+      "integrity": "sha512-b7WZlZ0BPoGcWswhY41wQoEBWJQ0M7DE1G9c6tEZlEVUCRG0jvnkdhmgS44drpZmNhifPCUsDXbMBHZTAUUYzw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.1.36",
-        "@php-wasm/universal": "3.1.36",
-        "@php-wasm/util": "3.1.36"
+        "@php-wasm/logger": "3.1.38",
+        "@php-wasm/universal": "3.1.38",
+        "@php-wasm/util": "3.1.38"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1154,9 +1154,9 @@
       }
     },
     "node_modules/@php-wasm/logger": {
-      "version": "3.1.36",
-      "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.36.tgz",
-      "integrity": "sha512-Rol0+ZP0JzM1+LP11oP1AJ0G/qEZrbh3XJZwcpi5lhL78ZfKXix4hKAino2C3ObFZXr9I0FbwsG4rifez023lQ==",
+      "version": "3.1.38",
+      "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.38.tgz",
+      "integrity": "sha512-DSLl/gvYtJl+gDubY95PPdks/4MvDd8wJlXE3PPkCIbc7dm+g3V5wXHTSl4cZzfSNdytBmRwmZkdCpe5Fu3hKw==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=20.10.0",
@@ -1164,12 +1164,12 @@
       }
     },
     "node_modules/@php-wasm/progress": {
-      "version": "3.1.36",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.36.tgz",
-      "integrity": "sha512-2NchEvgF6KbNxYOo9PIOiKnJq93EYajLLhub9XK7g5mQmeA+bJg03Mn+QFN4k67sGsVKtgY4W7Wsg8IyoSGbqg==",
+      "version": "3.1.38",
+      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.38.tgz",
+      "integrity": "sha512-cmmbe7ZgIN0kG2Tbp7Nh0gYKVpPygFJMu8B+fOjdS/lfm5zwJqkkIAn6fdcjYL2DO9s3+IGWjhdhqGtlzY3L+g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.1.36"
+        "@php-wasm/logger": "3.1.38"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1177,9 +1177,9 @@
       }
     },
     "node_modules/@php-wasm/scopes": {
-      "version": "3.1.36",
-      "resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.36.tgz",
-      "integrity": "sha512-hE6Yja+lv5Y7oULwf6hxqeQfmeKU+x7/xIvx6XpFtiesROi3b4W95FWWrgIXgpDUpuYLQWd2C9FQpVcMWdwDzA==",
+      "version": "3.1.38",
+      "resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.38.tgz",
+      "integrity": "sha512-rbrsC5X3WVkD7K9E86wnRr4qhUU8AzycJxafJdSsh/LPjeRvxQpu8xhIMxmtFgfuMBzpWRQbsFQmKfSCgHMcAA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=20.10.0",
@@ -1187,24 +1187,24 @@
       }
     },
     "node_modules/@php-wasm/stream-compression": {
-      "version": "3.1.36",
-      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.36.tgz",
-      "integrity": "sha512-6jsYce14wvQ7/ykCGURMaBTqM+edZTBQp0yMYLQWlJbD8DpYeaUkivkWEg0wsNd0ponNEK8jFWr1G5/QETtwxw==",
+      "version": "3.1.38",
+      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.38.tgz",
+      "integrity": "sha512-8YUS+1buRqhkKBfqpPcZYI59wOYaOHiMzryZMpkdJVA4ELFkWR9NfLxJopGJbGGB/qGg7V5GFKFV6EP5RxbdPw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/util": "3.1.36"
+        "@php-wasm/util": "3.1.38"
       }
     },
     "node_modules/@php-wasm/universal": {
-      "version": "3.1.36",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.36.tgz",
-      "integrity": "sha512-1aEreyTpNVIBwMHbaWVgeNA8gUfqLPjtJYmtmqlyMounVtxvUGdiSCpIb2G40ZUv5X15FvI30dhnCV4izLJhZA==",
+      "version": "3.1.38",
+      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.38.tgz",
+      "integrity": "sha512-H2op/4rZb5XYit54Z9jHULQwQIDp11Cv2ubp8Iv0pNkPBb5acW9g5/R+slB6tP6GW2Z0PyVxoVjzc3fab2v0Yw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.1.36",
-        "@php-wasm/progress": "3.1.36",
-        "@php-wasm/stream-compression": "3.1.36",
-        "@php-wasm/util": "3.1.36",
+        "@php-wasm/logger": "3.1.38",
+        "@php-wasm/progress": "3.1.38",
+        "@php-wasm/stream-compression": "3.1.38",
+        "@php-wasm/util": "3.1.38",
         "ini": "4.1.2"
       },
       "engines": {
@@ -1213,35 +1213,35 @@
       }
     },
     "node_modules/@php-wasm/util": {
-      "version": "3.1.36",
-      "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.36.tgz",
-      "integrity": "sha512-gLimD7rMWQTLlKJwQmYDephM1/TdSj2IvXx+sy34da+H4H5lMrOfUHQ0SGsHNZIu/ZCjb6DlAzm6IqlKYnhP0A==",
+      "version": "3.1.38",
+      "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.38.tgz",
+      "integrity": "sha512-afqgA8gBzISH6FGifXWQPcZ7WDLXxvEaSTFnc7uWPtDgsmhl0fGE0vIRMmrfIgR/7EvrdR/9d4wJXs8LcpX5uA==",
       "engines": {
         "node": ">=20.10.0",
         "npm": ">=10.2.3"
       }
     },
     "node_modules/@php-wasm/web": {
-      "version": "3.1.36",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web/-/web-3.1.36.tgz",
-      "integrity": "sha512-KZnSCxjjF1cIut0BuQ4YM1Fz+PXN391pw7xx+Dw09w4ijQRMPBQJ1po5OS1csYHlIhN9RuACjqRacASiXD04Kw==",
+      "version": "3.1.38",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web/-/web-3.1.38.tgz",
+      "integrity": "sha512-ogmRSLuW13zhFgVYE0kcxb5fobZ1lkkzOCaM2MfWvRzogdYwxJKMaJYx8u90RwqCXHdrM3Wn/rn9GycymbGPOA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/fs-journal": "3.1.36",
-        "@php-wasm/logger": "3.1.36",
-        "@php-wasm/universal": "3.1.36",
-        "@php-wasm/util": "3.1.36",
-        "@php-wasm/web-5-2": "3.1.36",
-        "@php-wasm/web-7-4": "3.1.36",
-        "@php-wasm/web-8-0": "3.1.36",
-        "@php-wasm/web-8-1": "3.1.36",
-        "@php-wasm/web-8-2": "3.1.36",
-        "@php-wasm/web-8-3": "3.1.36",
-        "@php-wasm/web-8-4": "3.1.36",
-        "@php-wasm/web-8-5": "3.1.36",
-        "@php-wasm/web-service-worker": "3.1.36",
-        "@wp-playground/common": "3.1.36",
-        "@wp-playground/storage": "3.1.36",
+        "@php-wasm/fs-journal": "3.1.38",
+        "@php-wasm/logger": "3.1.38",
+        "@php-wasm/universal": "3.1.38",
+        "@php-wasm/util": "3.1.38",
+        "@php-wasm/web-5-2": "3.1.38",
+        "@php-wasm/web-7-4": "3.1.38",
+        "@php-wasm/web-8-0": "3.1.38",
+        "@php-wasm/web-8-1": "3.1.38",
+        "@php-wasm/web-8-2": "3.1.38",
+        "@php-wasm/web-8-3": "3.1.38",
+        "@php-wasm/web-8-4": "3.1.38",
+        "@php-wasm/web-8-5": "3.1.38",
+        "@php-wasm/web-service-worker": "3.1.38",
+        "@wp-playground/common": "3.1.38",
+        "@wp-playground/storage": "3.1.38",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1250,12 +1250,12 @@
       }
     },
     "node_modules/@php-wasm/web-5-2": {
-      "version": "3.1.36",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-5-2/-/web-5-2-3.1.36.tgz",
-      "integrity": "sha512-kRp8AyV27ibBksr6hNIiV/euMfK3Rt1G/dZjB2Mt8M5i9Wr1j02ugJTvMJX/9ZnJluRR1OiPGRB5D1hHepDQ7Q==",
+      "version": "3.1.38",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-5-2/-/web-5-2-3.1.38.tgz",
+      "integrity": "sha512-6Zr3RzRjWSyqLAv/MhWqT9G9oa9eD2LlLtnq1FzfEeVPeeg4vKHvkbqMQDreokQm+tD5GoVSPiTvW+YDYNYCtQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.36",
+        "@php-wasm/universal": "3.1.38",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1264,12 +1264,12 @@
       }
     },
     "node_modules/@php-wasm/web-7-4": {
-      "version": "3.1.36",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-7-4/-/web-7-4-3.1.36.tgz",
-      "integrity": "sha512-fz4bluX8ND76hd0WshT3H7W+5u0CWDA2VkyrU/PqxKn5CeA5Qi3rGn4JJJrc3A0xSnd/JFRSYb5boFrtzOwYiw==",
+      "version": "3.1.38",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-7-4/-/web-7-4-3.1.38.tgz",
+      "integrity": "sha512-1ZHsr2dfem0IESNrYEGdKBrHEw2vVNI+NRpth0njQ0VtXH0dV9xYAV/UBN8RDtWsICvOpC0dRppGcwEorQUzjg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.36",
+        "@php-wasm/universal": "3.1.38",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1278,12 +1278,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-0": {
-      "version": "3.1.36",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-0/-/web-8-0-3.1.36.tgz",
-      "integrity": "sha512-f0q7P082J6jedFAYvLJPWBzG4aF/sX5OFk1O+v+ytUGF/skj7VCrHYObKkIOScZQJtycv6GxHavPXjNtWLPRFQ==",
+      "version": "3.1.38",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-0/-/web-8-0-3.1.38.tgz",
+      "integrity": "sha512-L9LqiJmsM7VoihcUWrm5kCkZ0D1dfd3e1YIfw7ParUs8mSs4W6j2MNnZYXlE+xKkHpehtK2zOnUM7XpYdDn42w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.36",
+        "@php-wasm/universal": "3.1.38",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1292,12 +1292,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-1": {
-      "version": "3.1.36",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-1/-/web-8-1-3.1.36.tgz",
-      "integrity": "sha512-rVQTnIxufV0f7rgH6kJUV3PZYLMPI4uXIoNBGuva/xJm33YWL8O8039Cz5pGGA51O43F+vY/1enCDaNZicLXvw==",
+      "version": "3.1.38",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-1/-/web-8-1-3.1.38.tgz",
+      "integrity": "sha512-frHqnJIxGC4sKdf57pm7mOcmQygqMCNIXV0d8dsA2lKXLe3JxU/xBrx2dmc4SrkdhDK995LAUxU5sJBch1Ngww==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.36",
+        "@php-wasm/universal": "3.1.38",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1306,12 +1306,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-2": {
-      "version": "3.1.36",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-2/-/web-8-2-3.1.36.tgz",
-      "integrity": "sha512-S6D62ddwq3lOkEi4YCiPeXqTh/QMuVCQ4/cr1q3afRyqJY/34mKGle3ytjfGHl4ej9rk5dBN196Swxa6E2z9VQ==",
+      "version": "3.1.38",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-2/-/web-8-2-3.1.38.tgz",
+      "integrity": "sha512-6bBH7FwU5WnJ2/xEPC2RfKFPDqpG9ZOMkHADznI5fVTqtlkbZAdM1tY9vxvv7UwsN8vhze5EVo6s+gWrNGVOAQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.36",
+        "@php-wasm/universal": "3.1.38",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1320,12 +1320,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-3": {
-      "version": "3.1.36",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-3/-/web-8-3-3.1.36.tgz",
-      "integrity": "sha512-fIWxx1aXGA+pZI9bHe8E+LBZky9jm6fFSQGjx+MVQFN5xC5q0Vtq089hhNlUb9dGmJ9bXOmX59Sy/pWp1t5Z7Q==",
+      "version": "3.1.38",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-3/-/web-8-3-3.1.38.tgz",
+      "integrity": "sha512-/I2dBR3WZ/5yYjuVScGJEOd8uCvNmbWc0d3rEcPBHG5bW8xgEn2Q9OQzCII2+lfESkpzQ6aA9JvFrBW6TrnbHw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.36",
+        "@php-wasm/universal": "3.1.38",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1334,12 +1334,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-4": {
-      "version": "3.1.36",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-4/-/web-8-4-3.1.36.tgz",
-      "integrity": "sha512-7T6WOOfHDydlRRx6oOHJKgvxX60il435oidSpqOtNCm7IEITc3pziy+uCcdDQKjX25lBTnyBvl4cGFj81T7PtQ==",
+      "version": "3.1.38",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-4/-/web-8-4-3.1.38.tgz",
+      "integrity": "sha512-0rkY5a5NOi9FfMkDZVPSgfKacCppsevFlsJkiTAX+fKF5+9ZGwmAiUApqWhILhKrSVWS9dZoM6OruQwFWDzuWg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.36",
+        "@php-wasm/universal": "3.1.38",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1348,12 +1348,12 @@
       }
     },
     "node_modules/@php-wasm/web-8-5": {
-      "version": "3.1.36",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-5/-/web-8-5-3.1.36.tgz",
-      "integrity": "sha512-T6a9+KjMApi/TDqJoIJ+204qTJXNSE3wuYJfEbBN26fBxlK8W95sagarq2Nx2PZIzjOPZCSRgUmEkRRkJCUHMA==",
+      "version": "3.1.38",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-8-5/-/web-8-5-3.1.38.tgz",
+      "integrity": "sha512-/wDusNnqHbs6zuH1JUHeqo8FFJcqvIIF/BadWGDOW8KmIPH0Nsr5XdRhMCFGzsmPD81iRRRiHWPfVVdYgHHx2w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.36",
+        "@php-wasm/universal": "3.1.38",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1362,13 +1362,13 @@
       }
     },
     "node_modules/@php-wasm/web-service-worker": {
-      "version": "3.1.36",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.36.tgz",
-      "integrity": "sha512-W2ZSOs98v0EkK7xxQCuMhsNOrUw860riYM9OBavYOKU8tQ1l8IUvI2RwgUll9YBEa1tn6A+mDwEaMlcGR2Nfew==",
+      "version": "3.1.38",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.38.tgz",
+      "integrity": "sha512-7ghdF2YfrRnbKUpl8/KYkwgp4qkNBz6hubfXjMiHTmfEoPG/ZPEMxAavdJxJSAOfW1GXpdzUTVviu2B+g/UTLg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/scopes": "3.1.36",
-        "@php-wasm/universal": "3.1.36"
+        "@php-wasm/scopes": "3.1.38",
+        "@php-wasm/universal": "3.1.38"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1392,9 +1392,9 @@
       }
     },
     "node_modules/@types/aws-lambda": {
-      "version": "8.10.161",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.161.tgz",
-      "integrity": "sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==",
+      "version": "8.10.162",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.162.tgz",
+      "integrity": "sha512-Fn658grtLOci1oxi1391vvDWJRKNGWRSqfxRkmN/Iy3c0tQH1USMKEXcPYHLvope+ZgTFocx9FRQJx1muBL6qw==",
       "license": "MIT"
     },
     "node_modules/@types/btoa-lite": {
@@ -1420,22 +1420,22 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "25.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@wp-playground/common": {
-      "version": "3.1.36",
-      "resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.36.tgz",
-      "integrity": "sha512-uxYwWscPL76IntpIk5FJitPzcRm2BudmSlPNDswCc7DbnHVsaoG1jishFK/baTocQInsAdJlHZwL/sHgARx1Dg==",
+      "version": "3.1.38",
+      "resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.38.tgz",
+      "integrity": "sha512-v2nO0h9US0ohIOuSOeYwn8GmOkYkvoUdGAsKnRMPkmXd4zRcvduvfuhSunZXZYIkHiZc7pPawPUtuHml5oGHFQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.36",
-        "@php-wasm/util": "3.1.36"
+        "@php-wasm/universal": "3.1.38",
+        "@php-wasm/util": "3.1.38"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1443,14 +1443,14 @@
       }
     },
     "node_modules/@wp-playground/storage": {
-      "version": "3.1.36",
-      "resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.36.tgz",
-      "integrity": "sha512-BGXtXvZZDKwg1LuwTQlqFx5FHg9jC8fq3kCsMi389MIm7OGerqoUw5ONcGnrkarIxybkjHbrLZBUk5zsaXNiVg==",
+      "version": "3.1.38",
+      "resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.38.tgz",
+      "integrity": "sha512-QSDb8f5eGg2ZE6dq2hWHJHTj5kVVlPZDoCTAv5f+VE8gauBc/8FKKQgZgGPW/3t8LcSt8GLYG50Uw3B+xOwHIg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/stream-compression": "3.1.36",
-        "@php-wasm/universal": "3.1.36",
-        "@php-wasm/util": "3.1.36",
+        "@php-wasm/stream-compression": "3.1.38",
+        "@php-wasm/universal": "3.1.38",
+        "@php-wasm/util": "3.1.38",
         "@zip.js/zip.js": "2.7.57",
         "isomorphic-git": "1.37.6",
         "octokit": "3.1.2",
@@ -2769,9 +2769,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3127,9 +3127,9 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.21.tgz",
-      "integrity": "sha512-zbRA8cVm6io/d5W8uIe2hblzN76/Wm3v/yiythQvr+dpBWeqhPSWIDNj4zOyHi4zKbMK6DN34Xsr9jPHJERAEw==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "test:e2e:install": "playwright install chromium"
   },
   "dependencies": {
-    "@php-wasm/fs-journal": "^3.1.36",
-    "@php-wasm/stream-compression": "^3.1.36",
-    "@php-wasm/universal": "^3.1.36",
-    "@php-wasm/web": "^3.1.36",
+    "@php-wasm/fs-journal": "^3.1.38",
+    "@php-wasm/stream-compression": "^3.1.38",
+    "@php-wasm/universal": "^3.1.38",
+    "@php-wasm/web": "^3.1.38",
     "fflate": "^0.8.3"
   },
   "devDependencies": {

--- a/php-worker.js
+++ b/php-worker.js
@@ -1,6 +1,6 @@
 import { loadPlaygroundConfig } from "./src/shared/config.js";
 import { createPhpBridgeChannel, createShellChannel } from "./src/shared/protocol.js";
-import { bootstrapMoodle } from "./src/runtime/bootstrap.js";
+import { bootstrapMoodle, startArchiveResolution } from "./src/runtime/bootstrap.js";
 import { isFatalWasmError, isEmscriptenNetworkError, isSafeToReplay, formatErrorDetail, createSnapshotManager } from "./src/runtime/crash-recovery.js";
 import { createPhpRuntime, createProvisioningRuntime } from "./src/runtime/php-loader.js";
 import {
@@ -34,6 +34,11 @@ let debug = workerUrl.searchParams.get("debug") || null;
 let profile = workerUrl.searchParams.get("profile") || null;
 let bridgeChannel = null;
 let runtimeStatePromise = null;
+// The ready PHP instance, exposed for the static fast path (see
+// installBridgeListener). Set once boot completes, cleared on reset / boot
+// error. Reading it is only ever a fast-path optimization — a stale or null
+// value just routes the request through the normal serial queue.
+let readyPhp = null;
 let requestQueue = Promise.resolve();
 let activeBlueprint = null;
 let activeRuntimeConfig = null;
@@ -451,6 +456,7 @@ function resetRuntime(reason) {
   reactiveRestartCount += 1;
   requestCount = 0;
   runtimeStatePromise = null;
+  readyPhp = null;
   phpInfoCapturePromise = null;
   automaticPhpInfoAttempted = false;
   activeRuntimeConfig = null;
@@ -500,33 +506,55 @@ async function getRuntimeState() {
       forceCleanBoot,
     });
 
-    postShell({
-      kind: "progress",
-      title: "Refreshing PHP runtime",
-      detail: `[${configMs}ms config] Booting PHP ${phpVersion || "8.3"}${branchMeta ? ` + ${branchMeta.label}` : ""}.`,
-      progress: 0.12,
+    // Progress reporter, hoisted above refresh so the bundle-download band
+    // (0.16-0.44, emitted by startArchiveResolution running concurrently with
+    // refresh below) and the refresh band (0.12-0.14) can interleave. Clamp to
+    // monotonic so the bar never jumps backwards when the two interleave.
+    let maxProgress = 0;
+    const emitProgress = (title, detail, progress) => {
+      const elapsed = Math.round(performance.now() - bootStart);
+      const clamped =
+        typeof progress === "number" ? Math.max(maxProgress, progress) : progress;
+      if (typeof clamped === "number") {
+        maxProgress = clamped;
+      }
+      postShell({
+        kind: "progress",
+        title,
+        detail: `[${elapsed}ms] ${detail}`,
+        progress: clamped,
+      });
+    };
+    const publish = (detail, progress) =>
+      emitProgress("Bootstrapping Moodle", detail, progress);
+
+    emitProgress(
+      "Refreshing PHP runtime",
+      `[${configMs}ms config] Booting PHP ${phpVersion || "8.3"}${branchMeta ? ` + ${branchMeta.label}` : ""}.`,
+      0.12,
+    );
+
+    // Kick off the manifest resolution + bundle download NOW so it overlaps the
+    // WASM compile in php.refresh(). The no-op .catch prevents an
+    // unhandledrejection if refresh() throws first; the real error resurfaces
+    // at `await archivePromise` inside bootstrapMoodle and flows into the
+    // bootstrap-error catch below.
+    const archivePromise = startArchiveResolution({
+      moodleBranch,
+      appBaseUrl: appRootUrl,
+      publish,
     });
+    archivePromise.catch(() => {});
 
     const t1 = performance.now();
     await php.refresh();
     const refreshMs = Math.round(performance.now() - t1);
 
-    postShell({
-      kind: "progress",
-      title: "Refreshing PHP runtime",
-      detail: `[${refreshMs}ms refresh] PHP runtime ready.`,
-      progress: 0.14,
-    });
-
-    const publish = (detail, progress) => {
-      const elapsed = Math.round(performance.now() - bootStart);
-      postShell({
-        kind: "progress",
-        title: "Bootstrapping Moodle",
-        detail: `[${elapsed}ms] ${detail}`,
-        progress,
-      });
-    };
+    emitProgress(
+      "Refreshing PHP runtime",
+      `[${refreshMs}ms refresh] PHP runtime ready.`,
+      0.14,
+    );
 
     const t2 = performance.now();
     let bootstrapState;
@@ -545,6 +573,7 @@ async function getRuntimeState() {
         profile,
         webRoot,
         onPluginInstalled: (dirPath) => snapshot.trackPluginDir(dirPath),
+        archivePromise,
       });
     } catch (error) {
       if (!automaticPhpInfoAttempted) {
@@ -558,16 +587,26 @@ async function getRuntimeState() {
       // retry decision live in the bridge listener (installBridgeListener),
       // not here, to avoid double-counting restarts.
       runtimeStatePromise = null;
+      readyPhp = null;
 
       throw error;
     }
     const bootstrapMs = Math.round(performance.now() - t2);
 
     const totalMs = Math.round(performance.now() - bootStart);
+    // downloadWaitMs = bundle download time that did NOT overlap the WASM
+    // compile (0 means the parallel download fully hid behind php.refresh()).
+    // A large value is the signal that bundle chunking could still help
+    // (plan F2.5 / ADR 0011).
+    const t = bootstrapState?.timings || {};
+    const downloadWaitDetail =
+      typeof t.downloadWaitMs === "number"
+        ? ` | Bundle wait (post-refresh): ${t.downloadWaitMs}ms`
+        : "";
     postShell({
       kind: "progress",
       title: "Boot timing summary",
-      detail: `Config: ${configMs}ms | PHP refresh: ${refreshMs}ms | Bootstrap: ${bootstrapMs}ms | Total: ${totalMs}ms`,
+      detail: `Config: ${configMs}ms | PHP refresh: ${refreshMs}ms | Bootstrap: ${bootstrapMs}ms${downloadWaitDetail} | Total: ${totalMs}ms`,
       progress: 0.95,
     });
 
@@ -594,6 +633,8 @@ async function getRuntimeState() {
       path: bootstrapState.readyPath || activeBlueprint?.landingPage || config.landingPath || "/",
     });
 
+    // Expose the ready instance for the static fast path (installBridgeListener).
+    readyPhp = php;
     return { php };
   })();
 
@@ -624,6 +665,37 @@ function installBridgeListener() {
 
     if (data?.kind !== "http-request") {
       return;
+    }
+
+    // Static fast path: serve non-.php MEMFS files (CSS/JS/images/fonts)
+    // WITHOUT waiting in the serial PHP request queue. readFileAsBuffer is a
+    // pure-JS Emscripten MEMFS read, safe to run while a php.run() is
+    // suspended (the worker is single-threaded). serveStaticSync returns null
+    // for PHP scripts, .php/PATH_INFO routes, traversals and missing files, so
+    // those fall through to the queue with today's exact semantics.
+    // requestCount and detectPluginInstall are intentionally skipped — both
+    // are PHP-execution concerns. HEAD/POST keep queueing.
+    if (data.request?.method === "GET" && readyPhp) {
+      let staticHit = null;
+      try {
+        const u = new URL(data.request.url);
+        staticHit = readyPhp.serveStaticSync(u.pathname + u.search);
+      } catch {
+        staticHit = null;
+      }
+      if (staticHit) {
+        respond({
+          kind: "http-response",
+          id: data.id,
+          response: {
+            status: staticHit.status,
+            statusText: "OK",
+            headers: staticHit.headers,
+            body: staticHit.bytes,
+          },
+        });
+        return;
+      }
     }
 
     requestQueue = requestQueue.then(async () => {

--- a/scripts/build-moodle-bundle.sh
+++ b/scripts/build-moodle-bundle.sh
@@ -220,6 +220,13 @@ if [ -f "$SNAPSHOT_DIR/install.sq3" ]; then
     # The seed and the drained task queue are produced together by
     # generate-install-snapshot.sh, so advertise both to the runtime.
     SNAPSHOT_ARGS="$SNAPSHOT_ARGS --snapshotLocalcache $SNAPSHOT_DIR/localcache.zip --snapshotDrained 1"
+    # Advertise the combined RequireJS seed ONLY if it is actually in the zip,
+    # so the runtime cachejs flip is keyed off the shipped artifact: cached
+    # pre-warmup seeds and legacy bundles keep cachejs=false (graceful
+    # degradation). See ADR 0013.
+    if unzip -l "$SNAPSHOT_DIR/localcache.zip" 2>/dev/null | grep -q ' requirejs/'; then
+      SNAPSHOT_ARGS="$SNAPSHOT_ARGS --snapshotRequirejs 1"
+    fi
   fi
 fi
 

--- a/scripts/build-moodle-bundle.sh
+++ b/scripts/build-moodle-bundle.sh
@@ -122,6 +122,16 @@ echo "Packing $BUNDLE_NAME" >&2
 # Remove any previous archive: zip -r UPDATES an existing file, which would
 # keep entries that the exclusion list below no longer allows.
 rm -f "$BUNDLE_PATH"
+
+# Exclusion list. zip -x patterns match the stored entry paths (no leading
+# "./"), so "README.md" anchors at the bundle root while "*/README*" matches
+# nested entries only. Keep this an explicit, commented allowlist: audit any
+# new pattern against ALL branches before landing — e.g. HISTORY* must NEVER
+# be added (it would swallow real code: mod/wiki/history.php,
+# lib/aws-sdk/src/History.php, question/bank/history/...). The PHP-parity
+# tripwire below fails the build if a pattern ever swallows runtime PHP.
+# See docs/decisions/0011-bundle-trim-and-runtime-tuning.md.
+#
 # The runtime never reads VCS metadata or PHPUnit/Behat test suites; excluding
 # them cuts the download roughly in half (the shallow .git packfile alone is
 # ~82 MB of incompressible data) and shrinks MEMFS/extraction accordingly.
@@ -130,17 +140,78 @@ rm -f "$BUNDLE_PATH"
 # require_once($CFG->libdir . '/behat/lib.php')) and admin/tool/behat/ (an
 # installed plugin); plugin Behat suites live under */tests/behat/ and are
 # already covered by the tests pattern.
-(cd "$MOODLE_DIR" && zip -qr "$BUNDLE_PATH" . \
-  -x ".git/*" \
-  -x "*/tests/*" \
-  -x "node_modules/*" -x "*/node_modules/*")
+set -- -x ".git/*" -x "*/tests/*" -x "node_modules/*" -x "*/node_modules/*"
 
-# Keep the manifest fileCount consistent with what the zip actually contains.
-FILE_COUNT=$(find "$MOODLE_DIR" -type f \
+# AMD sources: Moodle serves the compiled amd/build/*.min.js. The dev-mode
+# fallback in lib/requirejs.php only reads amd/src when a module's
+# .min.js.map is MISSING, and every bundled min.js ships its map, so amd/src
+# is dead weight (~845 files / ~13 MB uncompressed). INVARIANT: while
+# $CFG->cachejs is false, amd/src XOR *.map must remain in the bundle —
+# excluding BOTH breaks dev-mode JS (lib/requirejs.php falls back to reading
+# amd/src when the map is absent).
+set -- "$@" -x "*/amd/src/*"
+
+# Root-level docs and build/CI/IDE metadata — never in the runtime include
+# graph. security.txt is deliberately KEPT (it is a servable file).
+set -- "$@" \
+  -x "UPGRADING.md" -x "CONTRIBUTING.md" -x "README.md" -x "INSTALL.txt" \
+  -x "COPYING.txt" -x "TRADEMARK.txt" \
+  -x "Gruntfile.js" -x "package.json" -x "npm-shrinkwrap.json" \
+  -x "composer.json" -x "composer.lock" \
+  -x ".github/*" -x ".grunt/*" -x ".upgradenotes/*" -x ".esbuild/*" -x ".jest/*" \
+  -x ".eslintrc" -x ".stylelintrc" -x ".gherkin-lintrc" -x ".jshintrc" \
+  -x ".jshintignore" -x ".nvmrc" -x ".shifter.json" -x ".phpstorm.meta.php" \
+  -x ".gitattributes" -x ".gitignore"
+
+# Vendor/plugin documentation bundled by Moodle's dependency strategy —
+# nothing in the runtime include graph reads these (~344 files / ~4.6 MB).
+set -- "$@" \
+  -x "*/README*" -x "*/readme*" \
+  -x "*/CHANGELOG*" -x "*/changelog*" -x "*/CHANGES*" \
+  -x "*/AUTHORS*" -x "*/CONTRIBUTING*" \
+  -x "*/upgrade.txt" -x "*/UPGRADING*"
+
+(cd "$MOODLE_DIR" && zip -qr "$BUNDLE_PATH" . "$@")
+
+# Keep the manifest fileCount consistent with what the zip actually contains:
+# derive it from the artifact itself instead of mirroring the exclusion list
+# in a parallel find (root-anchored patterns like "README.md" cannot be
+# expressed as -not -path filters, so a mirror would silently drift).
+mkdir -p "$WORK_DIR"
+BUNDLE_LISTING="$WORK_DIR/bundle-listing.txt"
+unzip -Z1 "$BUNDLE_PATH" > "$BUNDLE_LISTING"
+FILE_COUNT=$(grep -cv '/$' "$BUNDLE_LISTING" || true)
+
+# Tripwire 1: no exclusion pattern may ever swallow runtime PHP. Compare the
+# bundled .php count against the tree filtered by the structural exclusions
+# plus the two known non-runtime PHP locations (.phpstorm.meta.php and the
+# root .github CI tooling — both excluded deliberately above; the .github
+# filter is anchored to the root, matching the zip pattern's anchoring).
+ZIP_PHP_COUNT=$(grep -c '\.php$' "$BUNDLE_LISTING" || true)
+TREE_PHP_COUNT=$(find "$MOODLE_DIR" -type f -name '*.php' \
   -not -path "*/.git/*" \
   -not -path "*/tests/*" \
   -not -path "*/node_modules/*" \
+  -not -path "$MOODLE_DIR/.github/*" \
+  -not -name '.phpstorm.meta.php' \
   | wc -l | tr -d ' ')
+if [ "$ZIP_PHP_COUNT" -ne "$TREE_PHP_COUNT" ]; then
+  echo "ERROR: bundle PHP entry count ($ZIP_PHP_COUNT) != source tree PHP count ($TREE_PHP_COUNT)." >&2
+  echo "An exclusion pattern is swallowing runtime PHP files. Audit the -x list above." >&2
+  exit 1
+fi
+
+# Tripwire 2: required runtime files must be present (Moodle 5.1+ nests the
+# docroot under public/).
+for REQUIRED_RE in \
+  '^(public/)?lib/requirejs\.php$' \
+  '^(public/)?lib/behat/lib\.php$' \
+  '^(public/)?lang/en/moodle\.php$'; do
+  if ! grep -Eq "$REQUIRED_RE" "$BUNDLE_LISTING"; then
+    echo "ERROR: required runtime file matching $REQUIRED_RE missing from bundle." >&2
+    exit 1
+  fi
+done
 
 SNAPSHOT_ARGS=""
 if [ -f "$SNAPSHOT_DIR/install.sq3" ]; then

--- a/scripts/generate-install-snapshot.sh
+++ b/scripts/generate-install-snapshot.sh
@@ -353,23 +353,113 @@ if [ ! -d "$MOODLEDATA/localcache/theme" ]; then
   exit 1
 fi
 
+# Pre-build the combined RequireJS bundle so the first page in the browser does
+# not pay for find_all_amd_modules() (unreliable on the Emscripten VFS) +
+# concatenation. Replicates requirejs.php's production "all non-lazy modules"
+# combine and writes it to the file requirejs.php will serve at runtime, where
+# config.php forces $CFG->jsrev = 1 (so $etag = sha1(1)). See ADR 0013.
+REQUIREJS_WARMUP="$TMPROOT/requirejs-warmup.php"
+cat > "$REQUIREJS_WARMUP" <<'PHPEOF'
+<?php
+define('CLI_SCRIPT', true);
+define('CACHE_DISABLE_ALL', true);
+define('CACHE_DISABLE_STORES', true);
+$sourcedir = $argv[1];
+require($sourcedir . '/config.php');
+require_once($CFG->dirroot . '/lib/jslib.php');
+
+// requirejs_fix_define() is defined INSIDE lib/requirejs.php (a web script, not
+// an autoloadable class), so it cannot be reused here — duplicated verbatim
+// from lib/requirejs.php. Keep in sync with upstream if that function changes.
+function requirejs_fix_define(string $modulename, string $js): string {
+    $missingmodule = preg_match('/define\(\s*(\[|function)/', $js);
+    $missingmodule = $missingmodule && !preg_match("@define\s*\(\s*['\"]{$modulename}['\"]@", $js);
+    if ($missingmodule) {
+        $replace = 'define(\'' . $modulename . '\', ';
+        return implode($replace, explode('define(', $js, 2));
+    }
+    return $js;
+}
+
+// Mirror requirejs.php's non-lazy "return ALL amd modules" branch exactly.
+$jsfiles = core_requirejs::find_all_amd_modules();
+$content = '';
+foreach ($jsfiles as $modulename => $jsfile) {
+    $js = file_get_contents($jsfile);
+    if ($js === false) {
+        // Fail the build instead of embedding requirejs.php's
+        // "/* Failed to load */" placeholder into the shipped bundle.
+        fwrite(STDERR, 'Failed to read AMD module ' . $jsfile . PHP_EOL);
+        exit(1);
+    }
+    $js = preg_replace('~//# sourceMappingURL.*$~s', '', $js);
+    $js = rtrim($js) . "\n";
+    $js = requirejs_fix_define($modulename, $js);
+    $content .= $js;
+}
+
+// At runtime config.php forces $CFG->jsrev = 1, so module URLs are
+// /lib/requirejs.php/1/<component>/<module> and requirejs.php computes the
+// non-lazy combine etag as sha1($rev) = sha1(1). Seed exactly that file
+// (sha1(1) === sha1('1') === 356a192b7913b04c54574d18c28d46e6395428ab).
+$target = $CFG->localcachedir . '/requirejs/' . sha1(1);
+js_write_cache_file_content($target, $content);
+clearstatcache();
+if (!file_exists($target)) {
+    fwrite(STDERR, 'RequireJS combine was not written to ' . $target . PHP_EOL);
+    exit(1);
+}
+$size = filesize($target);
+$combined = file_get_contents($target);
+if ($size < 1048576) {
+    fwrite(STDERR, 'RequireJS combine too small (' . $size . ' bytes) — expected > 1MB' . PHP_EOL);
+    exit(1);
+}
+// core/first is the bootstrap module RequireJS loads first; its named define
+// must be present or the whole combined bundle is unusable.
+if (strpos($combined, 'define("core/first"') === false
+    && strpos($combined, "define('core/first'") === false) {
+    fwrite(STDERR, 'RequireJS combine is missing the core/first define' . PHP_EOL);
+    exit(1);
+}
+echo 'RequireJS combined bundle written (' . count($jsfiles) . ' modules, ' . $size . ' bytes).' . PHP_EOL;
+PHPEOF
+REQUIREJS_LOG="$TMPROOT/requirejs-warmup.log"
+if ${PHP_BIN:-php} -d max_input_vars=5000 "$REQUIREJS_WARMUP" "$SOURCE_DIR" >"$REQUIREJS_LOG" 2>&1; then
+  WARMUP_EXIT=0
+else
+  WARMUP_EXIT=$?
+fi
+sed 's/^/[snapshot] /' "$REQUIREJS_LOG" >&2
+if [ "$WARMUP_EXIT" -ne 0 ]; then
+  echo "Error: RequireJS warmup exited with code $WARMUP_EXIT" >&2
+  exit 1
+fi
+if [ ! -f "$MOODLEDATA/localcache/requirejs/356a192b7913b04c54574d18c28d46e6395428ab" ]; then
+  echo "Error: RequireJS combined seed missing at localcache/requirejs/356a192b..." >&2
+  exit 1
+fi
+
 # Tripwire: the seed must be portable to the WASM filesystem. The compiled
 # candidate sheets are path-free (theme_config::post_process strips host and
-# scheme) and the compiled DI container is generated PHP without filesystem
-# paths — fail loud if a build-machine path ever leaks in.
+# scheme), the compiled DI container is generated PHP without filesystem paths,
+# and the RequireJS combine has its sourceMappingURL comments stripped — fail
+# loud if a build-machine path ever leaks in.
 if grep -R -l -e "$TMPROOT" -e "$SOURCE_DIR" \
-  "$MOODLEDATA/localcache/theme" "$MOODLEDATA/localcache/di" >&2; then
+  "$MOODLEDATA/localcache/theme" "$MOODLEDATA/localcache/di" \
+  "$MOODLEDATA/localcache/requirejs" >&2; then
   echo "Error: build-machine paths leaked into the localcache seed (files above)" >&2
   exit 1
 fi
 
 # Package the localcache seed: ONLY the deterministic, portable artifacts.
-# Whitelisting theme/ and di/ inherently excludes .lastpurged (its absence
-# skips the purge-on-boot check in make_localcache_directory), bootstrap.php
-# (its bootstraphash embeds the build dbname) and core_component.php
-# (build-machine classmap paths; the runtime uses .playground's cache).
+# Whitelisting theme/, di/ and requirejs/ inherently excludes .lastpurged (its
+# absence skips the purge-on-boot check in make_localcache_directory),
+# bootstrap.php (its bootstraphash embeds the build dbname) and
+# core_component.php (build-machine classmap paths; the runtime uses
+# .playground's cache).
 rm -f "$OUTPUT_DIR/localcache.zip"
-(cd "$MOODLEDATA/localcache" && zip -qr "$OUTPUT_DIR/localcache.zip" theme di)
+(cd "$MOODLEDATA/localcache" && zip -qr "$OUTPUT_DIR/localcache.zip" theme di requirejs)
 SEED_SIZE=$(wc -c < "$OUTPUT_DIR/localcache.zip" | tr -d ' ')
 echo "Localcache seed written to $OUTPUT_DIR/localcache.zip ($SEED_SIZE bytes)" >&2
 

--- a/scripts/generate-manifest.mjs
+++ b/scripts/generate-manifest.mjs
@@ -98,6 +98,14 @@ if (args.snapshot) {
     manifest.snapshot.drained = true;
   }
 
+  // The localcache seed carries a pre-built combined RequireJS bundle: the
+  // runtime re-enables $CFG->cachejs (one combined JS request per page instead
+  // of dozens). Keyed off the actual artifact so cached/legacy seeds without it
+  // keep cachejs=false. See ADR 0013.
+  if (args.snapshotRequirejs === "1" || args.snapshotRequirejs === "true") {
+    manifest.snapshot.requirejs = true;
+  }
+
   if (args.snapshotLocalcache) {
     const seedPath = resolve(args.snapshotLocalcache);
     const seedStats = statSync(seedPath);

--- a/scripts/patch-moodle-source.sh
+++ b/scripts/patch-moodle-source.sh
@@ -52,6 +52,7 @@ ENCRYPTION_PATCH="$PATCH_DIR/lib/classes/encryption.php"
 COMPONENTPHP="$SOURCE_DIR/${PUB}lib/classes/component.php"
 SETUPLIBPHP="$SOURCE_DIR/${PUB}lib/setuplib.php"
 SETUPPHP="$SOURCE_DIR/${PUB}lib/setup.php"
+REQUIREJSPHP="$SOURCE_DIR/${PUB}lib/requirejs.php"
 
 if [ -f "$DMLLIB" ] && [ -f "$SOURCE_DIR/${PUB}lib/classes/exception/response_aware_exception.php" ] && ! grep -q "response_aware_exception.php" "$DMLLIB"; then
   python3 - "$DMLLIB" <<'PY'
@@ -143,6 +144,72 @@ if needle not in text:
     raise SystemExit(f"Needle not found in {path}")
 
 path.write_text(text.replace(needle, insert, 1), encoding="utf-8")
+PY
+fi
+
+# PLAYGROUND: re-enable cachejs by serving a build-time-seeded combined
+# RequireJS bundle (see ADR 0013). Two hunks:
+#  1. The runtime must NEVER build the combine itself — find_all_amd_modules()
+#     relies on realpath()/getRealPath(), unreliable on the Emscripten VFS, so
+#     a runtime build writes a poisoned-but-existing cache file
+#     ("No define call for core/first"). Guard the cache-miss build branch with
+#     !defined('MOODLE_PLAYGROUND') so the playground falls through to the
+#     existing dev-mode single-module serving instead.
+#  2. The seeded combine contains only the modules present at BUILD time, so it
+#     is served ONLY for the core/first bootstrap request; every other non-lazy
+#     module (incl. AMD from plugins installed at runtime) falls through to
+#     per-module serving. Restricting it to core/first keeps runtime plugins
+#     working while still saving the dozens-of-requests-per-page cost.
+if [ -f "$REQUIREJSPHP" ] && ! grep -q "MOODLE_PLAYGROUND" "$REQUIREJSPHP"; then
+  python3 - "$REQUIREJSPHP" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+
+# Hunk 2: restrict the seeded combine to core/first and skip the candidate for
+# every other non-lazy module. Applied first because hunk 1 rewrites the
+# "} else {" that follows the file_exists() block.
+needle2 = (
+    "    $candidate = $CFG->localcachedir . '/requirejs/' . $etag;\n"
+    "\n"
+    "    if (file_exists($candidate)) {\n"
+)
+insert2 = (
+    "    $candidate = $CFG->localcachedir . '/requirejs/' . $etag;\n"
+    "\n"
+    "    // PLAYGROUND: the combined bundle is seeded at build time and contains\n"
+    "    // only the modules present then, so serve it ONLY for the core/first\n"
+    "    // bootstrap request. Every other non-lazy module (including AMD from\n"
+    "    // plugins installed at runtime) falls through to per-module serving.\n"
+    "    if (defined('MOODLE_PLAYGROUND') && !$lazyload && !($component === 'core' && $module === 'first.js')) {\n"
+    "        $candidate = '';\n"
+    "    }\n"
+    "\n"
+    "    if ($candidate !== '' && file_exists($candidate)) {\n"
+)
+
+# Hunk 1: never build the combine at runtime in the playground.
+needle1 = (
+    "    } else {\n"
+    "        $jsfiles = array();\n"
+    "        if ($lazyload) {\n"
+)
+insert1 = (
+    "    } else if (!defined('MOODLE_PLAYGROUND')) {\n"
+    "        $jsfiles = array();\n"
+    "        if ($lazyload) {\n"
+)
+
+if needle2 not in text:
+    raise SystemExit(f"Needle 2 (candidate guard) not found in {path}")
+if needle1 not in text:
+    raise SystemExit(f"Needle 1 (build branch) not found in {path}")
+
+text = text.replace(needle2, insert2, 1)
+text = text.replace(needle1, insert1, 1)
+path.write_text(text, encoding="utf-8")
 PY
 fi
 

--- a/src/runtime/bootstrap.js
+++ b/src/runtime/bootstrap.js
@@ -2,8 +2,8 @@ import { ProgressTracker } from "@php-wasm/progress";
 import { setPhpIniEntries } from "@php-wasm/universal";
 import {
   buildCoreExtractScript,
+  fetchAssetWithCache,
   fetchBundleWithCache,
-  verifyBundle,
 } from "../../lib/moodle-loader.js";
 import { buildInstallConfig } from "../blueprint/index.js";
 import {
@@ -1340,6 +1340,11 @@ async function patchRuntimePhpSources(php, webRoot) {
     ],
   ]);
 
+  // All three plugin_manager.php hunks are applied in ONE patchFile call:
+  // patchFile applies replacers sequentially over a single in-memory string,
+  // so this is identical to the previous three read-after-write passes while
+  // saving two decode/split/join/encode/write cycles on this large file.
+  // Order is preserved (the third hunk must keep matching after the first two).
   await patchFile(rp.PLUGIN_MANAGER_PATH, [
     [
       `        remove_dir($plugin->rootdir);
@@ -1356,9 +1361,6 @@ async function patchRuntimePhpSources(php, webRoot) {
             opcache_reset();
         }`,
     ],
-  ]);
-
-  await patchFile(rp.PLUGIN_MANAGER_PATH, [
     [
       `        if (function_exists('opcache_reset')) {
             opcache_reset();
@@ -1381,12 +1383,9 @@ async function patchRuntimePhpSources(php, webRoot) {
 
         return true;`,
     ],
-  ]);
-
-  // Guard against null $plugininfo when reinstalling over an existing plugin.
-  // After core_component::reset() during upgrade, get_plugin_info() may return null
-  // for the old plugin. Fall back to direct remove_dir() in that case.
-  await patchFile(rp.PLUGIN_MANAGER_PATH, [
+    // Guard against null $plugininfo when reinstalling over an existing plugin.
+    // After core_component::reset() during upgrade, get_plugin_info() may return
+    // null for the old plugin. Fall back to direct remove_dir() in that case.
     [
       `            if (file_exists($target . '/' . $pluginname)) {
                 $this->remove_plugin_folder($this->get_plugin_info($plugin->component));
@@ -1927,40 +1926,68 @@ async function prepareMoodleRuntime({
 
 async function loadInstallSnapshot(
   php,
-  { dbFile, appBaseUrl, publish, moodleBranch },
+  { dbFile, appBaseUrl, publish, moodleBranch, manifest, prefetched },
 ) {
   const branch = moodleBranch || DEFAULT_MOODLE_BRANCH;
   const meta = getBranchMetadata(branch);
 
-  // Try branch-specific snapshot first, then fall back to legacy path
-  const snapshotPaths = [];
-  if (meta) {
-    snapshotPaths.push(`assets/moodle/${meta.snapshotDir}/install.sq3`);
+  // Candidate sources: the manifest-advertised URL first (served cache-first
+  // through the Cache API and verified against the manifest sha256), then
+  // the legacy branch-path probes (plain fetch, no checksum) for manifests
+  // that predate snapshot.url.
+  const candidates = [];
+  if (manifest?.snapshot?.url) {
+    candidates.push({ url: manifest.snapshot.url, info: manifest.snapshot });
   }
-  snapshotPaths.push("assets/moodle/snapshot/install.sq3");
+  if (meta) {
+    candidates.push({
+      url: new URL(
+        `./assets/moodle/${meta.snapshotDir}/install.sq3`,
+        appBaseUrl,
+      ).toString(),
+      info: {},
+    });
+  }
+  candidates.push({
+    url: new URL("./assets/moodle/snapshot/install.sq3", appBaseUrl).toString(),
+    info: {},
+  });
 
   publish("Downloading pre-installed database snapshot.", 0.87);
 
-  let response;
-  for (const snapshotPath of snapshotPaths) {
-    const snapshotUrl = new URL(`./${snapshotPath}`, appBaseUrl);
-    try {
-      response = await fetch(snapshotUrl);
-      if (response.ok) {
-        break;
-      }
-      response = null;
-    } catch {
-      response = null;
+  let bytes = null;
+
+  // Use the bytes prefetched in parallel with the ZIP extraction if that
+  // prefetch (against manifest.snapshot.url) succeeded. A wrapped {error}
+  // means it failed — fall through to the candidate loop, which re-tries the
+  // manifest URL and the legacy branch paths.
+  if (prefetched) {
+    const result = await prefetched;
+    if (result instanceof Uint8Array) {
+      bytes = result;
     }
   }
 
-  if (!response?.ok) {
+  if (!bytes) {
+    for (const candidate of candidates) {
+      try {
+        bytes = await fetchAssetWithCache(candidate.url, candidate.info);
+        if (bytes) {
+          break;
+        }
+      } catch {
+        // A missing or corrupted snapshot is non-fatal: try the next candidate
+        // and ultimately fall back to the full CLI install below.
+        bytes = null;
+      }
+    }
+  }
+
+  if (!bytes) {
     publish("Snapshot not available, falling back to full install.", 0.875);
     return false;
   }
 
-  const bytes = new Uint8Array(await response.arrayBuffer());
   if (bytes.length < 100) {
     publish("Snapshot too small, falling back to full install.", 0.875);
     return false;
@@ -2059,7 +2086,7 @@ echo json_encode($result, JSON_UNESCAPED_SLASHES);
  */
 async function loadLocalcacheSeed(
   php,
-  { manifest, appBaseUrl, publish, moodleBranch, wwwroot },
+  { manifest, appBaseUrl, publish, moodleBranch, wwwroot, prefetched },
 ) {
   const seedInfo = manifest?.snapshot?.localcache;
   if (!seedInfo) {
@@ -2074,15 +2101,30 @@ async function loadLocalcacheSeed(
     : `assets/moodle/snapshot/${fileName}`;
 
   publish("Downloading pre-built localcache seed (theme CSS + DI).", 0.911);
-  const seedUrl = new URL(`./${seedPath}`, appBaseUrl);
-  const response = await fetch(seedUrl);
-  if (!response?.ok) {
-    throw new Error(
-      `Manifest advertises a localcache seed but ${seedPath} returned HTTP ${response?.status}.`,
-    );
+  // Prefer the manifest-advertised absolute URL (cache-first + checksum
+  // verified); fall back to the branch path for older manifests. The seed is
+  // re-applied on EVERY snapshot-origin boot, so the Cache API turns a
+  // recurring network round-trip into a CacheStorage read. fetchAssetWithCache
+  // throws on a non-OK response or checksum mismatch, preserving this
+  // function's fail-loud contract for an advertised-but-broken seed.
+  const seedUrl =
+    seedInfo.url || new URL(`./${seedPath}`, appBaseUrl).toString();
+  // Use the bytes prefetched in parallel with the ZIP extraction when present.
+  // The prefetch wraps rejections as { error }; rethrow to keep the fail-loud
+  // contract (a deploy that ships a bad seed must fail, not boot silently
+  // without it and re-enable the slow SCSS warmups).
+  let bytes;
+  if (prefetched) {
+    const result = await prefetched;
+    if (result instanceof Uint8Array) {
+      bytes = result;
+    } else if (result && result.error) {
+      throw result.error;
+    }
   }
-  const bytes = new Uint8Array(await response.arrayBuffer());
-  await verifyBundle(bytes, seedInfo.sha256);
+  if (!bytes) {
+    bytes = await fetchAssetWithCache(seedUrl, seedInfo);
+  }
 
   const zipPath = `${TEMP_ROOT}/moodle-localcache-seed.zip`;
   await php.writeFile(zipPath, bytes);
@@ -2394,6 +2436,59 @@ function createBootstrapTracker() {
   };
 }
 
+/**
+ * Resolve the manifest and download the core bundle (cache-first). Extracted
+ * so the caller (php-worker getRuntimeState) can kick this off CONCURRENTLY
+ * with php.refresh() (WASM compilation) instead of strictly after it — the
+ * download proceeds in the browser's network process while the worker thread
+ * compiles WASM, so cold boot saves ~min(refresh, download). Touches only the
+ * network + Cache API, never the PHP FS, so it is safe to run during
+ * loadWebRuntime/initFsPersistence.
+ *
+ * Returns the same archive object as the inline path; the progress mapping
+ * mirrors the original (manifest -> 0.16, cache-bust -> 0.24, download ratio
+ * -> 0.2..0.44) but uses a local pct accumulator instead of a static on
+ * bootstrapMoodle.
+ */
+export async function startArchiveResolution({
+  moodleBranch,
+  appBaseUrl,
+  publish,
+}) {
+  const resolvedBranch = moodleBranch || DEFAULT_MOODLE_BRANCH;
+  const manifestUrl = await resolveManifestUrl(
+    resolvedBranch,
+    appBaseUrl || self.location.href,
+  );
+  let lastDownloadPct;
+  return resolveBootstrapArchive(
+    { manifestUrl },
+    ({ ratio, cached, phase, detail }) => {
+      if (phase === "manifest") {
+        publish(detail, 0.16);
+        return;
+      }
+      if (phase === "cache-bust") {
+        publish(detail, 0.24);
+        return;
+      }
+      const progress = cached
+        ? 0.44
+        : 0.2 + (typeof ratio === "number" ? ratio * 0.22 : 0.22);
+      // Only publish at ~10% intervals to avoid log spam
+      const pct = Math.floor((typeof ratio === "number" ? ratio : 0) * 10);
+      if (cached || pct !== lastDownloadPct) {
+        lastDownloadPct = pct;
+        const label =
+          typeof ratio === "number"
+            ? `Downloading Moodle bundle (${Math.round(ratio * 100)}%).`
+            : detail || "Downloading Moodle bundle.";
+        publish(label, progress);
+      }
+    },
+  );
+}
+
 export async function bootstrapMoodle({
   config,
   blueprint,
@@ -2408,6 +2503,7 @@ export async function bootstrapMoodle({
   moodleBranch,
   webRoot: webRootParam,
   onPluginInstalled,
+  archivePromise,
 }) {
   const selection = resolveRuntimeSelection({ runtimeId, moodleBranch });
   const resolvedRuntimeId = selection.runtimeId;
@@ -2485,43 +2581,21 @@ export async function bootstrapMoodle({
   const branchMeta = getBranchMetadata(resolvedBranch);
   const webRoot = webRootParam || branchMeta?.webRoot || MOODLE_ROOT;
   const tArchive = performance.now();
-  const manifestUrl = await resolveManifestUrl(
-    resolvedBranch,
-    appBaseUrl || self.location.href,
-  );
-  let archive = await resolveBootstrapArchive(
-    {
-      manifestUrl,
-    },
-    ({ ratio, cached, phase, detail }) => {
-      if (phase === "manifest") {
-        publish(detail, 0.16);
-        return;
-      }
-
-      if (phase === "cache-bust") {
-        publish(detail, 0.24);
-        return;
-      }
-
-      const progress = cached
-        ? 0.44
-        : 0.2 + (typeof ratio === "number" ? ratio * 0.22 : 0.22);
-      // Only publish at ~10% intervals to avoid log spam
-      const pct = Math.floor((typeof ratio === "number" ? ratio : 0) * 10);
-      if (cached || pct !== bootstrapMoodle._lastDownloadPct) {
-        bootstrapMoodle._lastDownloadPct = pct;
-        const label =
-          typeof ratio === "number"
-            ? `Downloading Moodle bundle (${Math.round(ratio * 100)}%).`
-            : detail || "Downloading Moodle bundle.";
-        publish(label, progress);
-      }
-    },
-  );
+  // When the caller pre-started the download in parallel with php.refresh()
+  // (php-worker getRuntimeState), await that promise; otherwise resolve it
+  // inline for back-compat. tArchive then measures only the remaining wait.
+  let archive = await (archivePromise ||
+    startArchiveResolution({
+      moodleBranch: resolvedBranch,
+      appBaseUrl,
+      publish,
+    }));
   phases.download.finish();
   const archiveMs = Math.round(performance.now() - tArchive);
-  publish(`Bundle resolved in ${archiveMs}ms.`, 0.45);
+  publish(
+    `Bundle resolved in ${archiveMs}ms (waited ${archiveMs}ms after refresh).`,
+    0.45,
+  );
 
   if (
     runtime.mountStrategy === "zip-extract" &&
@@ -2587,6 +2661,36 @@ export async function bootstrapMoodle({
     debugdisplay: effectiveConfig.debugdisplay,
   });
 
+  // Kick off the install snapshot + localcache seed downloads NOW so the
+  // network transfer overlaps the multi-second PHP-side ZIP extraction inside
+  // prepareMoodleRuntime (the fetch proceeds in the browser's network process
+  // while the WASM thread is busy in ZipArchive). markerLikelyValid mirrors the
+  // installMarkerMatches initialization below; gating by it avoids downloading
+  // install.sq3 on journaled reloads where only the seed is needed. Failures
+  // are wrapped (not thrown) here so a missing/broken asset keeps today's
+  // graceful fallback — the loaders unwrap and decide. On warm Cache API boots
+  // these resolve from CacheStorage almost instantly.
+  const markerLikelyValid = installStateMatches(
+    savedInstallState,
+    manifestState,
+    dbName,
+  );
+  const snapshotPrefetch =
+    !markerLikelyValid && archive.manifest?.snapshot?.url
+      ? fetchAssetWithCache(
+          archive.manifest.snapshot.url,
+          archive.manifest.snapshot,
+        ).catch((error) => ({ error }))
+      : null;
+  const seedPrefetch =
+    (!markerLikelyValid || savedInstallState?.source === "snapshot") &&
+    archive.manifest?.snapshot?.localcache?.url
+      ? fetchAssetWithCache(
+          archive.manifest.snapshot.localcache.url,
+          archive.manifest.snapshot.localcache,
+        ).catch((error) => ({ error }))
+      : null;
+
   const tPrepare = performance.now();
   publish("Writing Moodle runtime configuration.", 0.84);
   await prepareMoodleRuntime({
@@ -2619,18 +2723,23 @@ export async function bootstrapMoodle({
     await setPhpIniEntries(php._php, iniOverrides);
   }
 
-  const tPdo = performance.now();
-  publish("Probing PDO SQLite connectivity.", 0.865);
-  const pdoProbe = await runPdoProbe(php, webRoot);
-  const pdoMs = Math.round(performance.now() - tPdo);
-  if (pdoProbe.ok) {
-    publish(
-      `PDO SQLite probe connected successfully with ${pdoProbe.dsn}. [${pdoMs}ms]`,
-      0.868,
-    );
-  } else {
-    const detail = pdoProbe.error?.message || "SQLite PDO connection failed.";
-    publish(`PDO SQLite probe failed: ${detail} [${pdoMs}ms]`, 0.868);
+  // The PDO probe is purely diagnostic (it does not gate the boot — a failure
+  // only logs). Skip the extra php.run() on normal boots and only spend it
+  // when debugging/profiling, where the diagnostic is actually consumed.
+  if (debug || profile) {
+    const tPdo = performance.now();
+    publish("Probing PDO SQLite connectivity.", 0.865);
+    const pdoProbe = await runPdoProbe(php, webRoot);
+    const pdoMs = Math.round(performance.now() - tPdo);
+    if (pdoProbe.ok) {
+      publish(
+        `PDO SQLite probe connected successfully with ${pdoProbe.dsn}. [${pdoMs}ms]`,
+        0.868,
+      );
+    } else {
+      const detail = pdoProbe.error?.message || "SQLite PDO connection failed.";
+      publish(`PDO SQLite probe failed: ${detail} [${pdoMs}ms]`, 0.868);
+    }
   }
 
   publish(
@@ -2640,11 +2749,9 @@ export async function bootstrapMoodle({
 
   let installState = null;
   const hasSavedInstallState = Boolean(savedInstallState?.installed);
-  let installMarkerMatches = installStateMatches(
-    savedInstallState,
-    manifestState,
-    dbName,
-  );
+  // Same computation as markerLikelyValid above (used to gate the prefetches);
+  // reused here so the value cannot diverge.
+  let installMarkerMatches = markerLikelyValid;
 
   if (installMarkerMatches) {
     publish(
@@ -2719,6 +2826,8 @@ export async function bootstrapMoodle({
       appBaseUrl: appBaseUrl || origin,
       publish,
       moodleBranch: resolvedBranch,
+      manifest: archive.manifest,
+      prefetched: snapshotPrefetch,
     });
 
     if (snapshotLoaded) {
@@ -2740,6 +2849,7 @@ export async function bootstrapMoodle({
         publish,
         moodleBranch: resolvedBranch,
         wwwroot,
+        prefetched: seedPrefetch,
       });
     } else {
       // Fallback: run the full Moodle CLI installer
@@ -2818,6 +2928,7 @@ export async function bootstrapMoodle({
         publish,
         moodleBranch: resolvedBranch,
         wwwroot,
+        prefetched: seedPrefetch,
       });
     }
   }
@@ -3037,5 +3148,14 @@ export async function bootstrapMoodle({
     manifest: archive.manifest,
     manifestState,
     readyPath,
+    // Boot timings surfaced for the "should we chunk the bundle?" decision
+    // (ADR 0011 / plan F2.5). downloadWaitMs is how long bootstrap blocked
+    // waiting for the bundle AFTER php.refresh() finished — i.e. the part of
+    // the download that did NOT overlap the WASM compile. A large value is the
+    // signal that chunking (parallel part downloads) could still help.
+    timings: {
+      downloadWaitMs: archiveMs,
+      prepareMs,
+    },
   };
 }

--- a/src/runtime/bootstrap.js
+++ b/src/runtime/bootstrap.js
@@ -2118,7 +2118,7 @@ async function loadLocalcacheSeed(
     const result = await prefetched;
     if (result instanceof Uint8Array) {
       bytes = result;
-    } else if (result && result.error) {
+    } else if (result?.error) {
       throw result.error;
     }
   }
@@ -2659,6 +2659,9 @@ export async function bootstrapMoodle({
     wwwroot,
     playgroundProxyUrl,
     debugdisplay: effectiveConfig.debugdisplay,
+    // Re-enable cachejs only when the manifest advertises the build-time
+    // RequireJS combined seed (ADR 0013); legacy bundles keep cachejs=false.
+    requirejsSeeded: Boolean(archive.manifest?.snapshot?.requirejs),
   });
 
   // Kick off the install snapshot + localcache seed downloads NOW so the

--- a/src/runtime/config-template.js
+++ b/src/runtime/config-template.js
@@ -271,13 +271,32 @@ export function createPhpIniEntries({
     upload_tmp_dir: TEMP_ROOT,
     "session.save_handler": "files",
     "session.save_path": `${TEMP_ROOT}/sessions`,
-    // OPcache tuning — use in-memory file cache with a high file limit
-    // and no timestamp checks (the readonly bundle never changes within
-    // a session), so PHP avoids recompiling on every request.
+    // Realpath cache — every include resolves each path component via lstat
+    // through Emscripten's JS FS (cheap individually, but tens of thousands
+    // of JS calls per Moodle request at path depth ~6). The bundle tree is
+    // immutable within a session and there is exactly ONE PHP process, so
+    // every mid-session unlink/rename happens inside PHP, which invalidates
+    // its own realpath-cache entries; JS-side FS writes (journal hydration,
+    // boot patches) all happen before the first request, and PHP does not
+    // cache negative lookups, so files created later are never masked.
+    // If a future feature ever deletes MEMFS files from the JS side between
+    // requests, revisit this TTL.
+    realpath_cache_size: "8M",
+    realpath_cache_ttl: "86400",
+    // OPcache tuning — compiled bytecode is kept in /internal/shared/opcache
+    // with no timestamp checks (the readonly bundle never changes within a
+    // session), so PHP avoids recompiling on every request.
+    // NOTE: with file_cache_only=1 OPcache allocates NO shared memory
+    // segment, so max_accelerated_files / memory_consumption /
+    // interned_strings_buffer are inert in this mode. They are kept (with
+    // max_accelerated_files sized above Moodle's ~15k bundled PHP files)
+    // only as future-proofing should file_cache_only ever be revisited.
+    // See docs/decisions/0011-bundle-trim-and-runtime-tuning.md (amends
+    // ADR 0004).
     "opcache.enable": "1",
     "opcache.file_cache": "/internal/shared/opcache",
     "opcache.file_cache_only": "1",
-    "opcache.max_accelerated_files": "10000",
+    "opcache.max_accelerated_files": "20000",
     "opcache.memory_consumption": "128",
     "opcache.interned_strings_buffer": "32",
     "opcache.validate_timestamps": "0",

--- a/src/runtime/config-template.js
+++ b/src/runtime/config-template.js
@@ -25,6 +25,7 @@ export function createMoodleConfigPhp({
   wwwroot,
   playgroundProxyUrl = "",
   debugdisplay = 0,
+  requirejsSeeded = false,
 }) {
   const resolvedComponentCachePath =
     componentCachePath || buildComponentCachePath(moodleRoot);
@@ -66,10 +67,28 @@ $CFG->debugdisplay = ${Number(debugdisplay) ? 1 : 0};
 $CFG->showcrondebugging = false;
 // Enable all caching layers — the filesystem is MEMFS (pure memory) so file-backed
 // caches are fast and persist for the lifetime of the worker session.
-// cachejs must stay false: when enabled, Moodle rewrites JS module URLs to serve
-// combined bundles through javascript.php. The caching endpoint fails silently
-// in the WASM environment, causing "No define call for core/first" RequireJS errors.
-$CFG->cachejs = false;
+${
+  requirejsSeeded
+    ? `// RequireJS combined bundle is seeded at build time (manifest
+// snapshot.requirejs), so we re-enable $CFG->cachejs: the browser makes ONE
+// combined JS request per page (/lib/requirejs.php/1/core/first.js) instead of
+// dozens of per-module requests through the serial worker queue. See ADR 0013.
+// - jsrev is FORCED to 1 (not time()): config.php overrides DB config, so
+//   js_reset_all_caches()'s set_config('jsrev', time()) cannot desync the URL
+//   revision from the seeded sha1(1) file across journaled reloads. Bundle JS
+//   is immutable per build, so in-session JS cache-busting being a no-op is fine.
+// - The runtime NEVER builds the combine (lib/requirejs.php is patched at build
+//   time; find_all_amd_modules is unreliable on the Emscripten VFS).
+// - 'Purge all caches' wipes localcache including requirejs/, so the is_dir()
+//   probe flips cachejs back to false (dev-mode per-module serving — today's
+//   behavior) for the rest of the session; the next boot re-extracts the seed.
+$CFG->jsrev = 1;
+$CFG->cachejs = is_dir($CFG->localcachedir . '/requirejs');`
+    : `// cachejs stays false: without the build-time RequireJS seed, enabling it makes
+// the runtime build the combine itself, which fails silently in the WASM
+// environment ("No define call for core/first" RequireJS errors). See ADR 0013.
+$CFG->cachejs = false;`
+}
 $CFG->cachetemplates = true;
 $CFG->langstringcache = true;
 $CFG->themedesignermode = false;

--- a/src/runtime/php-compat.js
+++ b/src/runtime/php-compat.js
@@ -509,6 +509,52 @@ export function wrapPhpInstance(
     },
 
     /**
+     * Synchronously serve a static (non-.php) file from MEMFS, or return null
+     * when the caller must fall back to the normal queued request() path:
+     * the target is a PHP script (incl. `.php/PATH_INFO` routes), a path
+     * traversal, or the file is missing.
+     *
+     * This is the same MEMFS read as the static branch of request() (above),
+     * exposed so the worker can answer it WITHOUT waiting in the serial PHP
+     * request queue. Safe to call while a php.run() is suspended:
+     * readFileAsBuffer is a pure-JS Emscripten MEMFS read (no WASM re-entry)
+     * and the worker is single-threaded, so reads are atomic w.r.t. PHP
+     * writes. moodledata is NOT URL-addressable (resolveScriptPath only maps
+     * under webRoot), so dataroot files never take this path.
+     *
+     * @returns {{status:number, headers:object, bytes:Uint8Array}|null}
+     */
+    serveStaticSync(urlPath) {
+      const path = String(urlPath || "/");
+      const qIdx = path.indexOf("?");
+      const pathname = qIdx >= 0 ? path.substring(0, qIdx) : path;
+      // Defense in depth: never let a traversal escape webRoot. The SW/Request
+      // URL normalization already collapses dot segments, so this is
+      // belt-and-braces.
+      if (pathname.includes("/../")) {
+        return null;
+      }
+      const { scriptPath } = resolveScriptPath(pathname, resolvedWebRoot);
+      // .php (and .php/PATH_INFO, which resolveScriptPath maps to a .php
+      // script) must keep going through the queued PHP execution path.
+      if (isPhpScript(scriptPath)) {
+        return null;
+      }
+      try {
+        const bytes = php.readFileAsBuffer(scriptPath);
+        return {
+          status: 200,
+          headers: { "content-type": getMimeType(scriptPath) },
+          bytes,
+        };
+      } catch {
+        // Missing file → fall back to the queue (preserves boot-race /
+        // mid-install semantics; never reply 404 from the fast path).
+        return null;
+      }
+    },
+
+    /**
      * Run inline PHP code. Returns a PHPResponse with .text and .errors.
      */
     async run(code) {

--- a/sw.js
+++ b/sw.js
@@ -21,7 +21,12 @@ const SCOPED_STATIC_RE = /\.(css|js|mjs|woff2?|ttf|otf|eot|png|jpe?g|gif|svg|ico
 // PHP scripts that serve cacheable assets with revision numbers in the URL.
 // The revision acts as a natural cache key — when content changes, the URL changes.
 // Excludes pluginfile.php and draftfile.php (user content, not cacheable).
-const CACHEABLE_PHP_ASSET_RE = /\/(theme\/styles\.php|lib\/javascript\.php|theme\/image\.php|theme\/font\.php)\//u;
+// lib/requirejs.php is included for symmetry with lib/javascript.php: its
+// module URLs (/lib/requirejs.php/<rev>/core/first.js) already match
+// SCOPED_STATIC_RE via their .js suffix, so this is belt-and-braces (the
+// scope+runtime cache key and BUILD_VERSION-scoped cache name prevent stale
+// cross-build content), not a functional change.
+const CACHEABLE_PHP_ASSET_RE = /\/(theme\/styles\.php|lib\/javascript\.php|lib\/requirejs\.php|theme\/image\.php|theme\/font\.php)\//u;
 const INTERNAL_PROXY_PATH = "/__playground_proxy__";
 let playgroundConfigPromise;
 let addonProxyUrlOverride = null;
@@ -74,10 +79,20 @@ const STATIC_PREFIXES = [
   "/logo.png",
 ];
 
+// self.registration.scope is constant for the Service Worker's lifetime, so
+// memoize the parsed base path: getScopedBasePath -> withAppBasePath ->
+// getAppBasePath used to construct a fresh URL on every HTML attribute rewrite.
+let cachedAppBasePath = null;
 function getAppBasePath() {
+  if (cachedAppBasePath !== null) {
+    return cachedAppBasePath;
+  }
   const scopeUrl = new URL(self.registration.scope);
   const pathname = scopeUrl.pathname;
-  return pathname.endsWith("/") ? pathname.slice(0, -1) || "/" : pathname || "/";
+  cachedAppBasePath = pathname.endsWith("/")
+    ? pathname.slice(0, -1) || "/"
+    : pathname || "/";
+  return cachedAppBasePath;
 }
 
 function stripAppBasePath(pathname) {
@@ -408,10 +423,16 @@ function decodeHtmlAttributeEntities(value) {
     .replaceAll("&amp;", "&");
 }
 
-function rewriteHtmlAttributeUrl(rawValue, { origin, scopeId, runtimeId }) {
+function rewriteHtmlAttributeUrl(rawValue, scope) {
+  const { origin } = scope;
+  // scopedBasePath / appBasePath are computed once per document by
+  // rewriteHtmlDocument and threaded through `scope`, instead of being
+  // recomputed for every matched attribute. Fall back to computing them for
+  // callers that don't pre-populate the scope (keeps the function standalone).
+  const scopedBasePath =
+    scope.scopedBasePath ?? getScopedBasePath(scope.scopeId, scope.runtimeId);
+  const appBasePath = scope.appBasePath ?? getAppBasePath();
   const decodedValue = decodeHtmlAttributeEntities(rawValue);
-  const scopedBasePath = getScopedBasePath(scopeId, runtimeId);
-  const appBasePath = getAppBasePath();
 
   if (!decodedValue) {
     return decodedValue;
@@ -472,7 +493,15 @@ function rewriteHtmlAttributeUrl(rawValue, { origin, scopeId, runtimeId }) {
 
 function rewriteHtmlDocument(html, scope) {
   const { origin, scopeId, runtimeId } = scope;
-  const scopedBase = `${origin}${getScopedBasePath(scopeId, runtimeId)}`;
+  const scopedBasePath = getScopedBasePath(scopeId, runtimeId);
+  const appBasePath = getAppBasePath();
+  const scopedBase = `${origin}${scopedBasePath}`;
+  // Compute the per-document base paths once and thread them through `scope`
+  // so rewriteHtmlAttributeUrl doesn't recompute them for every attribute.
+  const docScope = { ...scope, scopedBasePath, appBasePath };
+  // Moodle pages repeat identical pix/theme URLs dozens of times; memoize the
+  // rewritten+escaped output per raw attribute value within this document.
+  const memo = new Map();
 
   let result = html.replace(
     /((?:href|src|action|data-[\w-]*url|data-url|data-action)=["'])([^"']*)(["'])/giu,
@@ -481,7 +510,29 @@ function rewriteHtmlDocument(html, scope) {
     // interpolating it back between the quotes, otherwise a decoded value
     // containing a quote could close the attribute early and inject HTML into
     // the playground iframe (reflected XSS).
-    (match, prefix, rawValue, suffix) => `${prefix}${escapeHtml(rewriteHtmlAttributeUrl(rawValue, scope))}${suffix}`,
+    (match, prefix, rawValue, suffix) => {
+      // Fast path: a value that is relative (no leading "/", no "://") and
+      // contains none of & < > decodes to itself and re-encodes to itself, so
+      // the full decode -> rewrite -> escapeHtml round-trip is the identity.
+      // The regex capture already excludes quotes ([^"']*), so escapeHtml has
+      // nothing to encode here. Returning `match` unchanged is byte-identical.
+      if (
+        rawValue === "" ||
+        (!rawValue.startsWith("/") &&
+          !rawValue.includes("://") &&
+          !rawValue.includes("&") &&
+          !rawValue.includes("<") &&
+          !rawValue.includes(">"))
+      ) {
+        return match;
+      }
+      let encoded = memo.get(rawValue);
+      if (encoded === undefined) {
+        encoded = escapeHtml(rewriteHtmlAttributeUrl(rawValue, docScope));
+        memo.set(rawValue, encoded);
+      }
+      return `${prefix}${encoded}${suffix}`;
+    },
   );
 
   // Rewrite M.cfg.wwwroot in inline <script> blocks so Moodle's JavaScript

--- a/tests/runtime/config-template.test.js
+++ b/tests/runtime/config-template.test.js
@@ -167,4 +167,17 @@ describe("createPhpIniEntries", () => {
     const entries = createPhpIniEntries();
     assert.ok(entries["session.save_path"].startsWith(TEMP_ROOT));
   });
+
+  it("enables the realpath cache for the immutable MEMFS tree", () => {
+    const entries = createPhpIniEntries();
+    assert.strictEqual(entries.realpath_cache_size, "8M");
+    assert.strictEqual(entries.realpath_cache_ttl, "86400");
+  });
+
+  it("keeps OPcache in file-cache-only mode with timestamps disabled", () => {
+    const entries = createPhpIniEntries();
+    assert.strictEqual(entries["opcache.enable"], "1");
+    assert.strictEqual(entries["opcache.file_cache_only"], "1");
+    assert.strictEqual(entries["opcache.validate_timestamps"], "0");
+  });
 });

--- a/tests/runtime/config-template.test.js
+++ b/tests/runtime/config-template.test.js
@@ -132,6 +132,30 @@ describe("createMoodleConfigPhp", () => {
     const config = createMoodleConfigPhp(baseParams);
     assert.ok(config.includes("spl_autoload_register"));
   });
+
+  it("keeps cachejs disabled by default (no RequireJS seed)", () => {
+    const config = createMoodleConfigPhp(baseParams);
+    assert.ok(config.includes("$CFG->cachejs = false;"));
+    assert.ok(!config.includes("$CFG->jsrev = 1;"));
+    assert.ok(!config.includes("is_dir($CFG->localcachedir . '/requirejs')"));
+  });
+
+  it("re-enables cachejs and pins jsrev when the RequireJS seed is present", () => {
+    const config = createMoodleConfigPhp({
+      ...baseParams,
+      requirejsSeeded: true,
+    });
+    // jsrev forced to 1 so the URL revision matches the seeded sha1(1) file.
+    assert.ok(config.includes("$CFG->jsrev = 1;"));
+    // cachejs flips back to false (self-heal) if localcache/requirejs is purged.
+    assert.ok(
+      config.includes(
+        "$CFG->cachejs = is_dir($CFG->localcachedir . '/requirejs');",
+      ),
+    );
+    // Must NOT also emit the unconditional disable.
+    assert.ok(!config.includes("$CFG->cachejs = false;"));
+  });
 });
 
 describe("createPhpIniEntries", () => {

--- a/tests/runtime/serve-static-sync.test.js
+++ b/tests/runtime/serve-static-sync.test.js
@@ -1,0 +1,90 @@
+/**
+ * Tests for the static fast-path method serveStaticSync(), exposed by
+ * wrapPhpInstance() in php-compat.js. The worker (php-worker.js) calls this to
+ * serve non-.php MEMFS files WITHOUT waiting in the serial PHP request queue.
+ *
+ * Unlike the sibling php-compat.test.js (which replicates pure helpers), this
+ * imports the real wrapPhpInstance and drives serveStaticSync against a mock
+ * PHP instance whose readFileAsBuffer is backed by an in-memory file map.
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { __private__dont__use } from "@php-wasm/universal";
+import { wrapPhpInstance } from "../../src/runtime/php-compat.js";
+
+const WEB_ROOT = "/www/moodle";
+
+function makeWrapped(files) {
+  const php = {
+    [__private__dont__use]: {},
+    readFileAsBuffer(path) {
+      if (Object.hasOwn(files, path)) {
+        return files[path];
+      }
+      throw new Error(`ENOENT: ${path}`);
+    },
+  };
+  return wrapPhpInstance(php, {
+    absoluteUrl: "http://localhost:8080/",
+    webRoot: WEB_ROOT,
+  });
+}
+
+describe("serveStaticSync", () => {
+  it("serves an existing static file with the right MIME type and bytes", () => {
+    const bytes = new Uint8Array([10, 20, 30]);
+    const w = makeWrapped({ [`${WEB_ROOT}/lib/javascript-static.js`]: bytes });
+    const hit = w.serveStaticSync("/lib/javascript-static.js");
+    assert.ok(hit);
+    assert.equal(hit.status, 200);
+    assert.equal(
+      hit.headers["content-type"],
+      "application/javascript; charset=utf-8",
+    );
+    assert.deepEqual(hit.bytes, bytes);
+  });
+
+  it("ignores the query string when resolving the file", () => {
+    const bytes = new Uint8Array([1]);
+    const w = makeWrapped({ [`${WEB_ROOT}/theme/photo.svg`]: bytes });
+    const hit = w.serveStaticSync("/theme/photo.svg?ver=12345");
+    assert.ok(hit);
+    assert.equal(hit.headers["content-type"], "image/svg+xml");
+  });
+
+  it("returns null for a .php script (must stay on the queued path)", () => {
+    const w = makeWrapped({
+      [`${WEB_ROOT}/admin/index.php`]: new Uint8Array([1]),
+    });
+    assert.equal(w.serveStaticSync("/admin/index.php"), null);
+  });
+
+  it("returns null for a .php/PATH_INFO route (e.g. theme/styles.php)", () => {
+    const w = makeWrapped({});
+    assert.equal(w.serveStaticSync("/theme/styles.php/boost/123/all"), null);
+  });
+
+  it("returns null for a directory request (resolves to index.php)", () => {
+    const w = makeWrapped({});
+    assert.equal(w.serveStaticSync("/course/"), null);
+  });
+
+  it("returns null for a path traversal attempt", () => {
+    const w = makeWrapped({ [`${WEB_ROOT}/secret.css`]: new Uint8Array([1]) });
+    assert.equal(w.serveStaticSync("/../../etc/passwd"), null);
+    assert.equal(w.serveStaticSync("/a/../b.css"), null);
+  });
+
+  it("returns null for a missing file (falls back to the queue, never 404)", () => {
+    const w = makeWrapped({});
+    assert.equal(w.serveStaticSync("/lib/does-not-exist.js"), null);
+  });
+
+  it("falls back to octet-stream for an unknown extension", () => {
+    const bytes = new Uint8Array([7]);
+    const w = makeWrapped({ [`${WEB_ROOT}/files/blob.bin`]: bytes });
+    const hit = w.serveStaticSync("/files/blob.bin");
+    assert.ok(hit);
+    assert.equal(hit.headers["content-type"], "application/octet-stream");
+  });
+});

--- a/tests/shared/moodle-loader-asset-cache.test.js
+++ b/tests/shared/moodle-loader-asset-cache.test.js
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import { createHash, randomBytes } from "node:crypto";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { fetchAssetWithCache, fetchManifest } from "../../lib/moodle-loader.js";
+
+const makeAsset = (size) => new Uint8Array(randomBytes(size));
+const sha256Hex = (bytes) => createHash("sha256").update(bytes).digest("hex");
+
+// Minimal in-memory Cache Storage + fetch so the loader can run under node.
+function installMocks() {
+  const store = new Map();
+  let fetchCount = 0;
+  const responses = new Map();
+
+  globalThis.__fetchCount = () => fetchCount;
+  globalThis.fetch = async (url) => {
+    fetchCount += 1;
+    const entry = responses.get(String(url));
+    if (entry === undefined) return new Response("not found", { status: 404 });
+    if (typeof entry === "string") {
+      return new Response(entry, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return new Response(entry, { status: 200 });
+  };
+
+  const cache = {
+    async match(url) {
+      const bytes = store.get(String(url));
+      return bytes ? new Response(bytes, { status: 200 }) : undefined;
+    },
+    async put(url, response) {
+      store.set(String(url), new Uint8Array(await response.arrayBuffer()));
+    },
+    async delete(url) {
+      return store.delete(String(url));
+    },
+  };
+  globalThis.caches = { open: async () => cache };
+  // normalizeManifest resolves relative paths against self.location.href.
+  globalThis.self = { location: { href: "https://example.test/" } };
+
+  return { responses, store };
+}
+
+function teardownMocks() {
+  delete globalThis.fetch;
+  delete globalThis.caches;
+  delete globalThis.__fetchCount;
+  delete globalThis.self;
+}
+
+describe("fetchAssetWithCache", () => {
+  let mocks;
+  beforeEach(() => {
+    mocks = installMocks();
+  });
+  afterEach(() => {
+    teardownMocks();
+  });
+
+  it("downloads, verifies and caches an asset with a sha256", async () => {
+    const url = "https://example.test/install.sq3";
+    const bytes = makeAsset(64 * 1024);
+    mocks.responses.set(url, bytes);
+
+    const got = await fetchAssetWithCache(url, { sha256: sha256Hex(bytes) });
+    assert.deepEqual(got, bytes);
+    assert.equal(globalThis.__fetchCount(), 1);
+    assert.ok(mocks.store.has(url), "asset cached after first fetch");
+  });
+
+  it("serves a cached asset without a second network fetch", async () => {
+    const url = "https://example.test/install.sq3";
+    const bytes = makeAsset(32 * 1024);
+    const info = { sha256: sha256Hex(bytes) };
+    mocks.responses.set(url, bytes);
+
+    await fetchAssetWithCache(url, info);
+    const fromCache = await fetchAssetWithCache(url, info);
+    assert.deepEqual(fromCache, bytes);
+    assert.equal(globalThis.__fetchCount(), 1, "second call hits the cache");
+  });
+
+  it("busts a stale cache entry whose checksum no longer matches", async () => {
+    const url = "https://example.test/install.sq3";
+    const stale = makeAsset(16 * 1024);
+    const fresh = makeAsset(16 * 1024);
+    // Seed the cache with stale bytes but advertise the fresh checksum.
+    mocks.store.set(url, stale);
+    mocks.responses.set(url, fresh);
+
+    const got = await fetchAssetWithCache(url, { sha256: sha256Hex(fresh) });
+    assert.deepEqual(got, fresh);
+    assert.equal(globalThis.__fetchCount(), 1, "refetched after cache bust");
+    assert.deepEqual(
+      mocks.store.get(url),
+      fresh,
+      "cache replaced with fresh bytes",
+    );
+  });
+
+  it("does NOT touch the cache when no sha256 is provided (legacy manifest)", async () => {
+    const url = "https://example.test/install.sq3";
+    const bytes = makeAsset(8 * 1024);
+    mocks.responses.set(url, bytes);
+
+    const got = await fetchAssetWithCache(url, {});
+    assert.deepEqual(got, bytes);
+    assert.equal(mocks.store.size, 0, "nothing cached without a checksum");
+  });
+
+  it("throws on a non-OK response", async () => {
+    await assert.rejects(
+      () => fetchAssetWithCache("https://example.test/missing.sq3", {}),
+      /Unable to download asset/,
+    );
+  });
+
+  it("throws when freshly downloaded bytes fail checksum verification", async () => {
+    const url = "https://example.test/install.sq3";
+    mocks.responses.set(url, makeAsset(4 * 1024));
+    await assert.rejects(
+      () =>
+        fetchAssetWithCache(url, { sha256: sha256Hex(makeAsset(4 * 1024)) }),
+      /checksum mismatch/i,
+    );
+  });
+});
+
+describe("normalizeManifest snapshot/localcache URL resolution", () => {
+  let mocks;
+  beforeEach(() => {
+    mocks = installMocks();
+  });
+  afterEach(() => {
+    teardownMocks();
+  });
+
+  it("resolves snapshot.path and snapshot.localcache.path to absolute URLs", async () => {
+    const manifestUrl =
+      "https://example.test/assets/manifests/MOODLE_500_STABLE.json";
+    mocks.responses.set(
+      manifestUrl,
+      JSON.stringify({
+        bundle: { path: "../moodle/MOODLE_500_STABLE/core.zip" },
+        snapshot: {
+          path: "../moodle/MOODLE_500_STABLE/snapshot/install.sq3",
+          localcache: {
+            path: "../moodle/MOODLE_500_STABLE/snapshot/localcache.zip",
+          },
+        },
+      }),
+    );
+
+    const manifest = await fetchManifest(manifestUrl);
+    assert.equal(
+      manifest.snapshot.url,
+      "https://example.test/assets/moodle/MOODLE_500_STABLE/snapshot/install.sq3",
+    );
+    assert.equal(
+      manifest.snapshot.localcache.url,
+      "https://example.test/assets/moodle/MOODLE_500_STABLE/snapshot/localcache.zip",
+    );
+  });
+
+  it("leaves a manifest without a snapshot untouched", async () => {
+    const manifestUrl = "https://example.test/assets/manifests/legacy.json";
+    mocks.responses.set(
+      manifestUrl,
+      JSON.stringify({ bundle: { path: "../moodle/core.zip" } }),
+    );
+
+    const manifest = await fetchManifest(manifestUrl);
+    assert.equal(manifest.snapshot, undefined);
+  });
+});

--- a/tests/sw/sw-helpers.test.js
+++ b/tests/sw/sw-helpers.test.js
@@ -167,6 +167,34 @@ function rewriteHtmlDocumentAttributes(html, scope) {
   );
 }
 
+// Replicate the OPTIMIZED rewriteHtmlDocument attribute step from sw.js with
+// the fast-path filter + per-document memo. Used by the equivalence tests
+// below to prove the fast path is byte-identical to the unfiltered path.
+function rewriteHtmlDocumentAttributesFast(html, scope) {
+  const memo = new Map();
+  return html.replace(
+    /((?:href|src|action|data-[\w-]*url|data-url|data-action)=["'])([^"']*)(["'])/giu,
+    (match, prefix, rawValue, suffix) => {
+      if (
+        rawValue === "" ||
+        (!rawValue.startsWith("/") &&
+          !rawValue.includes("://") &&
+          !rawValue.includes("&") &&
+          !rawValue.includes("<") &&
+          !rawValue.includes(">"))
+      ) {
+        return match;
+      }
+      let encoded = memo.get(rawValue);
+      if (encoded === undefined) {
+        encoded = escapeHtml(rewriteHtmlAttributeUrl(rawValue, scope));
+        memo.set(rawValue, encoded);
+      }
+      return `${prefix}${encoded}${suffix}`;
+    },
+  );
+}
+
 // Replicate buildScopedCacheKey from sw.js
 function buildScopedCacheKey(origin, scopeId, runtimeId, requestPath) {
   const queryIndex = requestPath.indexOf("?");
@@ -438,6 +466,63 @@ describe("rewriteHtmlDocumentAttributes (attribute re-encoding)", () => {
     const html = '<a href="upgradesettings.php">x</a>';
     const out = rewriteHtmlDocumentAttributes(html, scope);
     assert.strictEqual(out, '<a href="upgradesettings.php">x</a>');
+  });
+});
+
+describe("rewriteHtmlDocument fast-path equivalence", () => {
+  // The fast-path filter + memo in sw.js must produce BYTE-IDENTICAL output to
+  // the unfiltered decode -> rewrite -> escapeHtml path for every value,
+  // otherwise it changes behaviour (and, for the escape cases, security).
+  const scope = {
+    origin: "https://ateeducacion.github.io",
+    scopeId: "main",
+    runtimeId: "php83-moodle50",
+    appBasePath: "/moodle-playground",
+  };
+
+  const corpus = [
+    // Relative URLs without special chars (the values the fast path skips).
+    '<a href="upgradesettings.php">x</a>',
+    '<a href="view.php?id=3">x</a>',
+    '<form action="">x</form>',
+    '<a href="#section">x</a>',
+    '<img src="logo.png">',
+    "<a href='../course/index.php'>x</a>",
+    // Anchor / scheme values handled by the early returns.
+    '<a href="javascript:void(0)">x</a>',
+    '<a href="mailto:a@b.test">x</a>',
+    '<a href="data:image/png;base64,AAAA">x</a>',
+    '<a href="//cdn.example.test/x.js">x</a>',
+    // Entity-encoded query strings (force the slow path via "&").
+    '<a href="/moodle-playground/admin/index.php?cache=1&amp;sesskey=abc">x</a>',
+    // Absolute same-origin path (force the slow path via leading "/").
+    '<a href="/moodle-playground/course/edit.php">x</a>',
+    // Absolute URL (force the slow path via "://").
+    '<a href="https://ateeducacion.github.io/moodle-playground/x.php">x</a>',
+    // Quote-breakout payloads (force the slow path via "<"/">" and "&").
+    '<a href="foo.php?x=&quot;&gt;&lt;img src=x onerror=alert(1)&gt;">x</a>',
+    "<a href='foo.php?n=&#39;a&#39;'>x</a>",
+    // Repeated identical values (exercise the memo).
+    '<img src="/moodle-playground/pix/i.svg"><img src="/moodle-playground/pix/i.svg">',
+    // Multiple attributes in one tag.
+    '<a href="/moodle-playground/a.php" data-url="b.php" data-action="/moodle-playground/c.php">x</a>',
+  ];
+
+  for (const html of corpus) {
+    it(`is byte-identical for: ${html.slice(0, 50)}`, () => {
+      assert.strictEqual(
+        rewriteHtmlDocumentAttributesFast(html, scope),
+        rewriteHtmlDocumentAttributes(html, scope),
+      );
+    });
+  }
+
+  it("is byte-identical for a combined document", () => {
+    const html = corpus.join("\n");
+    assert.strictEqual(
+      rewriteHtmlDocumentAttributesFast(html, scope),
+      rewriteHtmlDocumentAttributes(html, scope),
+    );
   });
 });
 


### PR DESCRIPTION
## Context

Performance work to make Moodle Playground feel more fluid: **faster boot, smoother navigation, and a smaller core bundle**. Based on analysis of `wordpress-playground` (php-wasm), this repo, and the Moodle core.

3 phases. Each commit is a self-contained, verified phase.

## Phase 1 — quick wins

- **Bundle trim**: 78 → 73.8 MB, 24,635 → 23,324 files. Excludes `amd/src`, root docs, build/CI/IDE metadata and vendor docs. **Tripwires** fail the build if an exclusion swallows runtime PHP or a required file is missing. `FILE_COUNT` is derived from the zip itself. Never `HISTORY*`.
- **php.ini**: `realpath_cache` (8M/86400) for the immutable single-process MEMFS tree; corrected OPcache comment (SHM knobs are inert under `file_cache_only=1`).
- **`fetchAssetWithCache`**: install snapshot and localcache seed are now cache-first with sha256 verification (previously a naked `fetch` on every boot); `normalizeManifest` resolves paths to absolute URLs.
- **Runtime patches**: the three `plugin_manager.php` patches merged into one pass; PDO probe gated behind `debug/profile`.
- **`@php-wasm` 3.1.36 → 3.1.38** (`tcpOverFetch` TLS fix for curl/HTTPS).
- `lib/requirejs.php` added to the SW cacheable-asset set. **ADR 0011**.

## Phase 2 — parallel boot + request path

- **Bundle download in parallel with `php.refresh()`** (saves ~min(refresh, download) on cold boot). Monotonic progress.
- **Prefetch of snapshot + seed** overlapped with the ZIP extraction (seed fail-loud contract preserved).
- **Static fast path**: CSS/JS/images are served from MEMFS without waiting in the serial PHP queue (`serveStaticSync`).
- **Cheaper SW HTML rewriting**: memoized base paths, per-document memo, fast-path filter (**byte-identical** output, covered by an equivalence corpus test).
- Post-refresh bundle-wait timing surfaced in the boot summary. **ADR 0012**.

## Phase 3 — re-enable `cachejs` (highest impact)

With `cachejs=false`, `lib/requirejs.php` served every AMD module separately (~50-120 serial PHP requests on the first page load). Enabling it previously failed silently ("No define call for core/first") because `find_all_amd_modules()` relies on `realpath()`, which is unreliable on the Emscripten VFS.

- **Build-time warmup**: `generate-install-snapshot.sh` builds the production combine and seeds it at `localcache/requirejs/<sha1(1)>` (fail-hard if <1MB or missing `core/first`).
- **Build-time patch to `lib/requirejs.php`** (2 fail-loud hunks, verified across all 6 branches): the runtime never builds the combine and serves the seed **only for `core/first`** (everything else, including AMD from runtime-installed plugins, falls through to per-module serving).
- **Manifest flag + flip**: `snapshot.requirejs` is set only when the seed actually contains it; with the seed → `$CFG->jsrev = 1` (pinned) + `$CFG->cachejs = is_dir(...)` (self-heals after "Purge all caches"). Without the seed → `cachejs=false` (graceful degradation). **ADR 0013**.
- `*.map` is KEPT: lazy modules (chartjs, TinyMCE, videojs), runtime-plugin AMD and the post-purge fallback all use the dev-mode path which needs `.map` (since `amd/src` was excluded in Phase 1). Invariant: `amd/src` XOR `*.map`.

## Verification

- **603 unit tests** + lint (Biome) green.
- **e2e Playwright (chromium)**: boot, page-render (themed page without exceptions), shell + persistence + non-journaled-cache invariant, blueprint (course/user/enrollment), theme, PHP networking (HTTPS to GitHub, ZIP, proxy fallback). Green.
- **Targeted probe** against the `cachejs=true` bundle: a **single** `/lib/requirejs.php/1/core/first.js` request (instead of dozens), `jsrev=1`, and **zero** "No define call" errors.

> Bundle artifacts (`assets/moodle/**`) are gitignored; CI regenerates them with the new scripts and tripwires.