### PR TITLE
refactor(sw): buffer request body fully synchronously for Firefox + ADR 0014

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -414,6 +414,7 @@ so that future contributors (human or AI) understand **why** a choice was made â
 | [0012](docs/decisions/0012-worker-static-fast-path.md) | Static-file fast path bypassing the serial PHP request queue | Accepted |
 | [0013](docs/decisions/0013-build-time-requirejs-combined-bundle-seed.md) | Build-time RequireJS combined-bundle seed (re-enable cachejs) | Accepted |
 | [0014](docs/decisions/0014-production-require-of-tests-files-patch.md) | Patch production code that require_once()s files under tests/ (mlbackend_python) | Accepted |
+| [0015](docs/decisions/0015-firefox-request-body-buffering.md) | Buffer the request body synchronously for Firefox (SW fetch handler) | Accepted |
 
 ## Debugging
 

--- a/docs/decisions/0014-firefox-request-body-buffering.md
+++ b/docs/decisions/0014-firefox-request-body-buffering.md
@@ -1,0 +1,110 @@
+# 0014 — Buffer the request body synchronously for Firefox
+
+## Status
+
+Accepted (2026-06).
+
+## Context and Problem
+
+The service worker bridges every scoped request to the PHP worker
+(`forwardToPhpWorker` → `serializeRequest`). For non-`GET`/`HEAD` requests it
+must read the request body and forward it to the worker, which rebuilds the
+request via `buildPhpRequest(originalRequest, forwardedUrl, body)`.
+
+Firefox's service worker implementation **neuters `event.request.body` once the
+`fetch` handler yields to the event loop** (the first `await`). After that point
+reading the body — `event.request.arrayBuffer()` or `request.clone().arrayBuffer()`
+— resolves empty (and constructing a streaming `new Request({ body, duplex })`
+throws, rejecting `respondWith` with *"A ServiceWorker intercepted the request
+and encountered an unexpected error"*). Chromium keeps the body across awaits,
+so the bug is Firefox-only.
+
+The symptom is that any non-`GET` request whose **body is semantically required**
+fails on Firefox: form `POST`s (including login, which carries the CSRF token +
+credentials) and, in WebDAV-based apps, `PROPFIND`/`REPORT`. Requests that ignore
+their body (e.g. a `POST` to a front controller that just renders a page) appear
+to work, which makes the bug easy to miss.
+
+This SW already read the body "early" — but **after** `await
+resolveScopedRequest(event, url)`, i.e. after the handler had already yielded.
+That contradicted the accompanying comment ("before any async operations").
+
+Empirically that previous placement still **worked** on Firefox (a logout →
+CSRF login `POST` round-trip succeeded under Playwright Firefox), because for a
+scoped path `resolveScopedRequest` returns synchronously, so awaiting it only
+schedules one microtask and the body survives. But that correctness is
+incidental: it relies on `resolveScopedRequest` never awaiting before returning,
+and on a single microtask being short enough — both of which a future change
+could break, reintroducing the silent Firefox failure. The sibling playgrounds,
+which read the body several awaits later (inside `forwardToPhpWorker`), did fail
+in Firefox. So this is a **hardening + documentation** decision, not a bug fix.
+
+## Options Considered
+
+* **Read the body lazily inside `serializeRequest`** (status quo of the sibling
+  playgrounds before their fix): simplest, but the read happens after several
+  awaits and is reliably empty on Firefox.
+* **Read it after `resolveScopedRequest`** (this project's previous state):
+  better, but still after a yield and dependent on `resolveScopedRequest`
+  resolving synchronously for the common scoped-path case.
+* **Buffer it synchronously at the very top of the `fetch` handler, before any
+  await, and forward the buffered bytes** (chosen).
+
+## Decision
+
+Capture the body in the `fetch` listener **before** `event.respondWith(...)`'s
+async work runs any `await`:
+
+```js
+self.addEventListener("fetch", (event) => {
+  const bufferedBody = ["GET", "HEAD"].includes(event.request.method)
+    ? null
+    : event.request.clone().arrayBuffer().catch(() => null);
+  event.respondWith((async () => { /* … */ })());
+});
+```
+
+* `clone()` (rather than consuming `event.request` directly) leaves the original
+  request intact for the pass-through branches (`fetch(event.request)`, the
+  static cache fetches), so buffering is safe for every code path.
+* The promise is awaited later where the body is actually needed
+  (`const earlyBody = bufferedBody ? await bufferedBody : null;`) and threaded
+  into `buildPhpRequest(..., earlyBody)`. Starting the read synchronously is what
+  matters; awaiting the already-started read afterwards is fine.
+* `.catch(() => null)` keeps a failed/absent body from rejecting the handler.
+
+The worker already received an `ArrayBuffer` body before, so Chromium behaviour
+is unchanged; only the Firefox failure mode is removed.
+
+## Consequences
+
+### Positive
+
+* Form `POST`s (login, settings, blueprint-driven actions) work on Firefox, at
+  parity with Chromium.
+* The code now matches its stated intent ("buffer before any async operation")
+  and is no longer coupled to `resolveScopedRequest` happening to resolve
+  synchronously.
+
+### Negative / Risks
+
+* The body of every non-`GET` request is cloned and buffered even for the
+  pass-through branches that end up calling `fetch(event.request)`. The extra
+  clone is a cheap reference until consumed and is dropped when unused; bodies in
+  this app are small (form posts), so the overhead is negligible.
+
+## Implementation Notes
+
+* `sw.js`: `bufferedBody` captured at the top of the `fetch` handler; the former
+  post-`resolveScopedRequest` `earlyBody` read now just `await`s it. Rebuild with
+  `npm run build-worker` (the SW is shipped as `sw.bundle.js`).
+* The sibling php-wasm playgrounds (omeka-s, nextcloud, facturascripts) carried
+  the lazy-read variant of this bug and were fixed with the same pattern
+  (e.g. ateeducacion/nextcloud-playground#24, verified in Playwright Firefox:
+  WebDAV folder navigation and a CSRF login `POST` went from failing to working).
+
+## Review Criteria
+
+* Revisit if the SW transport changes (e.g. a `MessagePort` rework, see ADR 0012)
+  in a way that moves body handling — the synchronous capture must stay before
+  the first `await`.

--- a/docs/decisions/0015-firefox-request-body-buffering.md
+++ b/docs/decisions/0015-firefox-request-body-buffering.md
@@ -1,4 +1,4 @@
-# 0014 — Buffer the request body synchronously for Firefox
+# 0015 — Buffer the request body synchronously for Firefox
 
 ## Status
 
@@ -68,9 +68,11 @@ self.addEventListener("fetch", (event) => {
   request intact for the pass-through branches (`fetch(event.request)`, the
   static cache fetches), so buffering is safe for every code path.
 * The promise is awaited later where the body is actually needed
-  (`const earlyBody = bufferedBody ? await bufferedBody : null;`) and threaded
-  into `buildPhpRequest(..., earlyBody)`. Starting the read synchronously is what
-  matters; awaiting the already-started read afterwards is fine.
+  (`const earlyBody = await bufferedBody;` — `bufferedBody` is `null` for
+  `GET`/`HEAD` and `await null` is `null`, so no extra guard is needed) and
+  threaded into `buildPhpRequest(..., earlyBody)`. Starting the read
+  synchronously is what matters; awaiting the already-started read afterwards is
+  fine.
 * `.catch(() => null)` keeps a failed/absent body from rejecting the handler.
 
 The worker already received an `ArrayBuffer` body before, so Chromium behaviour

--- a/sw.js
+++ b/sw.js
@@ -665,6 +665,15 @@ self.addEventListener("activate", (event) => {
 });
 
 self.addEventListener("fetch", (event) => {
+  // Buffer the request body synchronously, before any await. Firefox neuters
+  // event.request.body once this handler yields to the event loop, so reading
+  // it later (e.g. after `await resolveScopedRequest()`) can return an empty
+  // body for POST/PUT and break form submissions. Cloning leaves event.request
+  // intact for the pass-through `fetch(event.request)` / static branches. See
+  // ADR 0014.
+  const bufferedBody = ["GET", "HEAD"].includes(event.request.method)
+    ? null
+    : event.request.clone().arrayBuffer().catch(() => null);
   event.respondWith((async () => {
     try {
       const url = new URL(event.request.url);
@@ -708,12 +717,9 @@ self.addEventListener("fetch", (event) => {
         return fetch(event.request);
       }
 
-      // Read POST body immediately, before any async operations.
-      // Firefox's Service Worker may discard the request body after
-      // the handler yields to the event loop.
-      const earlyBody = !["GET", "HEAD"].includes(event.request.method)
-        ? await event.request.arrayBuffer()
-        : null;
+      // Resolve the body buffered synchronously at the top of the handler
+      // (before any yield), so Firefox has not discarded it. See ADR 0014.
+      const earlyBody = bufferedBody ? await bufferedBody : null;
 
       const { scopeId, runtimeId, requestPath } = scopedRequest;
       if (event.clientId) {

--- a/sw.js
+++ b/sw.js
@@ -670,7 +670,7 @@ self.addEventListener("fetch", (event) => {
   // it later (e.g. after `await resolveScopedRequest()`) can return an empty
   // body for POST/PUT and break form submissions. Cloning leaves event.request
   // intact for the pass-through `fetch(event.request)` / static branches. See
-  // ADR 0014.
+  // ADR 0015.
   const bufferedBody = ["GET", "HEAD"].includes(event.request.method)
     ? null
     : event.request.clone().arrayBuffer().catch(() => null);
@@ -718,8 +718,10 @@ self.addEventListener("fetch", (event) => {
       }
 
       // Resolve the body buffered synchronously at the top of the handler
-      // (before any yield), so Firefox has not discarded it. See ADR 0014.
-      const earlyBody = bufferedBody ? await bufferedBody : null;
+      // (before any yield), so Firefox has not discarded it. `bufferedBody` is
+      // null for GET/HEAD and `await null` is null, so no guard is needed. See
+      // ADR 0015.
+      const earlyBody = await bufferedBody;
 
       const { scopeId, runtimeId, requestPath } = scopedRequest;
       if (event.clientId) {


### PR DESCRIPTION
## What this is

While fixing a Firefox request-body bug in the sibling php-wasm playgrounds (omeka-s, nextcloud, facturascripts), I checked this project. moodle-playground is the **only** one that already buffers the request body for Firefox — so **it does not have the bug**. This PR is a **defensive hardening + an ADR**, not a bug fix.

## Empirical verification (Playwright Firefox)

I ran a body-dependent round-trip against a local `make up` (logout → `POST /login/index.php` with `logintoken` + credentials → check `/my/` is logged in):

| `sw.js` | `loggedInAfter` |
|---|---|
| current `main` (reads body after `await resolveScopedRequest`) | **true** ✅ |
| this PR (reads body synchronously at the top) | **true** ✅ |

So the current code already works on Firefox — because for a scoped path `resolveScopedRequest` returns synchronously, so the trailing `await` is a single microtask and the body survives. (The siblings read the body several awaits later and **did** fail: ateeducacion/nextcloud-playground#24 went `500`→`200` for a WebDAV body request.)

## Why change it anyway

The current read sits **after** `await resolveScopedRequest()`, contradicting its own comment ("Read POST body immediately, before any async operations"). Its correctness is incidental — it depends on `resolveScopedRequest` never awaiting before returning. This PR moves the read to the very top of the `fetch` handler (before any await), with `clone()` so the original request stays intact for the pass-through / static branches:

```js
self.addEventListener('fetch', (event) => {
  const bufferedBody = ['GET','HEAD'].includes(event.request.method)
    ? null
    : event.request.clone().arrayBuffer().catch(() => null);
  event.respondWith((async () => { /* … const earlyBody = bufferedBody ? await bufferedBody : null; */ })());
});
```

This makes the Firefox-safety guarantee robust (regardless of `resolveScopedRequest`'s future shape) and matches the pattern now used across the sibling repos.

Adds **ADR 0015** (`docs/decisions/0015-firefox-request-body-buffering.md`) documenting the Firefox failure mode and this decision.

> **Update (review):** the ADR was renumbered `0014 → 0015` — `0014` was already taken by `0014-production-require-of-tests-files-patch.md` (#147). The `earlyBody` read was also simplified to `const earlyBody = await bufferedBody;` (`await null` is `null`, so the ternary guard was dead). Verified on real Firefox via Playwright — logout → CSRF login `POST` → `/my/` round-trip succeeds. See review comment below.

## Verification

- Playwright Firefox: login round-trip succeeds on both the previous and hardened code (table above).
- `make lint` (0 errors), `make test` (**603** unit tests) pass.
- `sw.bundle.js` is build-generated (gitignored); rebuilt with `npm run build-worker`.

If you'd rather keep `sw.js` untouched, the ADR alone still stands as documentation — happy to split.

## Related

- ateeducacion/nextcloud-playground#24 · ateeducacion/omeka-s-playground#95 · erseco/facturascripts-playground#75
