### PR TITLE
fix(bundle): /admin/plugins.php fatals on require_once of a trait under tests/ (mlbackend_python)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -413,6 +413,7 @@ so that future contributors (human or AI) understand **why** a choice was made â
 | [0011](docs/decisions/0011-bundle-trim-and-runtime-tuning.md) | Bundle content trim + php.ini/runtime tuning (amends ADR 0004) | Accepted |
 | [0012](docs/decisions/0012-worker-static-fast-path.md) | Static-file fast path bypassing the serial PHP request queue | Accepted |
 | [0013](docs/decisions/0013-build-time-requirejs-combined-bundle-seed.md) | Build-time RequireJS combined-bundle seed (re-enable cachejs) | Accepted |
+| [0014](docs/decisions/0014-production-require-of-tests-files-patch.md) | Patch production code that require_once()s files under tests/ (mlbackend_python) | Accepted |
 
 ## Debugging
 

--- a/docs/KNOWN-ISSUES.md
+++ b/docs/KNOWN-ISSUES.md
@@ -136,6 +136,50 @@ Examples:
 - some config values must be seeded manually
 - extension assumptions from Moodle core still need local accommodation
 
+## 6. Production code that require_once()s files under tests/
+
+Status:
+
+- mlbackend_python case: resolved (patched)
+- other references: latent (open, low impact)
+
+Impact:
+
+- low — the active case is fixed; the remaining references are unreachable in
+  the playground
+
+Background:
+
+- the core bundle excludes every `*/tests/*` directory (ADR 0011) to halve the
+  download. A few Moodle 5.0+ production files violate the "runtime never reads
+  test code" assumption by `require_once()`-ing files under `tests/`.
+
+Current state:
+
+- **Fixed:** `lib/mlbackend/python/classes/processor.php` required the analytics
+  test trait `core_analytics\tests\mlbackend_helper_trait`, which made
+  `/admin/plugins.php` (and analytics admin pages) fatal. Patched in
+  `scripts/patch-moodle-source.sh` (drop the require, inline the one method used).
+  See ADR 0014.
+- **Latent (not patched):** `cache/classes/factory.php` →
+  `cache/tests/fixtures/lib.php` (test-mode only) and the `tool_generator` /
+  `tool_behat` Behat data generators →
+  `lib/tests/behat/…`, `admin/tests/behat/…`, `course/tests/behat/…`. These code
+  paths are only reached under Behat/PHPUnit, never in the playground.
+
+Where to continue:
+
+- if a new Moodle branch fatals on a different `…/tests/…` require, add a
+  build-time detector in `scripts/build-moodle-bundle.sh` (grep production PHP
+  for `require/include` of `tests/…\.php`, assert each is present in the zip via
+  a suffix match). See ADR 0014 Review Criteria.
+
+Main files involved:
+
+- `scripts/patch-moodle-source.sh`
+- `scripts/build-moodle-bundle.sh`
+- `docs/decisions/0014-production-require-of-tests-files-patch.md`
+
 ## Current top priority
 
 If continuing work from here, the next priority should be:

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -96,6 +96,31 @@ Files:
 - `patches/shared/lib/dml/sqlite3_pdo_moodle_database.php`
 - runtime override in `src/runtime/bootstrap.js`
 
+### Fatal in `admin/plugins.php`: `Failed opening required '…/analytics/tests/classes/mlbackend_helper_trait.php'`
+
+Likely cause:
+
+- the core bundle excludes every `*/tests/*` directory (ADR 0011), but some
+  Moodle 5.0+ **production** code `require_once()`s a file that lives under
+  `tests/`. `lib/mlbackend/python/classes/processor.php` requires the analytics
+  test trait `core_analytics\tests\mlbackend_helper_trait`. Building the admin
+  tree instantiates every `mlbackend` plugin
+  (`core_analytics\manager::get_all_prediction_processors()`), so loading
+  `/admin/plugins.php` (or any analytics admin page) fatals on the excluded file.
+
+Files:
+
+- `scripts/patch-moodle-source.sh` (drops the test-trait `require_once`/`use` and
+  inlines the only method the class actually uses)
+- `docs/decisions/0014-production-require-of-tests-files-patch.md`
+
+Notes:
+
+- `make up-local` does NOT reproduce this — it serves the full checkout with
+  `tests/` present. Reproduce/verify only against a real bundle (`make bundle`).
+- If a different Moodle branch fatals on another `…/tests/…` require, generalize
+  this into a build-time detector (see ADR 0014 Review Criteria).
+
 ### `Invalid cache store in config` warnings everywhere
 
 Likely cause:

--- a/docs/decisions/0014-production-require-of-tests-files-patch.md
+++ b/docs/decisions/0014-production-require-of-tests-files-patch.md
@@ -1,0 +1,135 @@
+# 0014 — Patch production code that require_once()s files under tests/
+
+## Status
+
+Accepted (2026-06).
+
+## Context and Problem
+
+The core bundle excludes every `*/tests/*` directory from the ZIP (ADR 0011 /
+PR #141, `scripts/build-moodle-bundle.sh`), which halves the download and the
+MEMFS extraction cost. That exclusion assumes the runtime never reads test code
+— a safe assumption for PHPUnit/Behat suites, but **Moodle 5.0+ ships an
+upstream architectural violation**: production code `require_once()`s a file
+that lives under `tests/`.
+
+Concretely, opening `/admin/plugins.php` fatals with:
+
+```
+Exception - Failed opening required
+'[dirroot]/analytics/tests/classes/mlbackend_helper_trait.php'
+```
+
+Trigger chain:
+
+1. `/admin/plugins.php` builds the admin tree, which includes
+   `admin/settings/analytics.php`.
+2. That page calls `\core_analytics\manager::get_all_prediction_processors()`
+   (`analytics/classes/manager.php`), which **instantiates every `mlbackend`
+   plugin**, including `mlbackend_python`.
+3. Declaring `\mlbackend_python\processor`
+   (`lib/mlbackend/python/classes/processor.php:30`) runs
+   `require_once($CFG->dirroot . '/analytics/tests/classes/mlbackend_helper_trait.php');`
+   and `use mlbackend_helper_trait;` in the class body.
+4. The trait file was excluded by `*/tests/*` → fatal.
+
+The trait (`@category test`, namespace `core_analytics\tests`) declares two
+methods. Only `is_mlbackend_python_configured()` is used by the class itself
+(in the constructor), and only inside an
+`if (defined('BEHAT_SITE_RUNNING') || (defined('PHPUNIT_TEST') && PHPUNIT_TEST)) && …`
+guard — never reached in the playground (short-circuited away). `generate_courses()`
+is test-only (uses `phpunit_util`). `mlbackend_python` cannot function in WASM at
+all (no `python`/`exec()`, no remote ML server); the class only needs to **load**
+cleanly so the analytics admin page can enumerate prediction processors.
+
+A repo-wide scan found `processor.php` is the **only** production consumer of
+this trait across the affected branches (5.0, 5.01, 5.02, main; 4.04/4.05 do not
+have it). Other production→`tests/` references exist but are **latent** —
+unreachable in the playground:
+
+* `cache/classes/factory.php` → `cache/tests/fixtures/lib.php` (test-mode only).
+* `admin/tool/generator/.../runner.php` and
+  `admin/tool/behat/.../get_entity_generator.php` →
+  `lib/tests/behat/…`, `admin/tests/behat/…`, `course/tests/behat/…`
+  (Behat data-generator scenarios only).
+
+## Options Considered
+
+* **Re-add the referenced `tests/` files to the bundle** (allowlist / build-time
+  scan in `build-moodle-bundle.sh`) + a tripwire. General, but re-introduces the
+  per-branch count-parity bookkeeping and keeps shipping test code.
+* **Revert the `*/tests/*` exclusion.** Throws away ~52 MB / ~6,100 files to
+  paper over a handful of upstream bugs. Rejected.
+* **Patch `processor.php`** to drop the test-trait dependency and inline the one
+  method the class uses. Chosen.
+* **Full-file copy** of `processor.php` into `patches/shared/`. Rejected: would
+  pin a copy that silently drifts from upstream across six branches.
+
+## Decision
+
+A guarded in-place edit in `scripts/patch-moodle-source.sh` (the repo's dominant
+patch pattern: a `python3` `str.replace` block that `raise SystemExit`s if a
+needle is missing). The block:
+
+1. Removes `require_once($CFG->dirroot . '/analytics/tests/classes/mlbackend_helper_trait.php');`.
+2. Removes the file-level `use core_analytics\tests\mlbackend_helper_trait;`.
+3. Replaces the class-body `use mlbackend_helper_trait;` with an inline copy of
+   `is_mlbackend_python_configured()` (the only method the class itself calls).
+
+It is gated by `grep -q "analytics/tests/classes/mlbackend_helper_trait"`, so it
+applies only where the dependency exists (no-op on 4.04/4.05) and is idempotent
+(the needle is gone after the first run; the surviving mention is a `\`-separated
+reference inside a doc comment, which the `/`-separated guard does not match).
+
+`generate_courses()` is intentionally **not** inlined — it is test-only and
+references `phpunit_util`, which does not exist at runtime.
+
+The latent `cache`/`behat` references are left untouched: they are unreachable in
+the playground, and patching dead code would add maintenance surface for no
+runtime benefit.
+
+## Consequences
+
+### Positive
+
+* `/admin/plugins.php` and the analytics admin settings page load cleanly on
+  every affected branch, with the `*/tests/*` exclusion (and its ~52 MB saving)
+  fully preserved.
+* The patch is surgical and version-tolerant: it edits only three localized
+  lines that are byte-identical across 5.0/5.01/5.02/main, and the `raise
+  SystemExit` makes any future upstream reformatting fail the build loudly
+  instead of shipping a broken bundle.
+* The build pipeline re-applies it automatically: `build-moodle-bundle.sh` runs
+  `patch-moodle-source.sh` on every build, and the snapshot fingerprint hashes
+  that script, so editing it invalidates the snapshot cache.
+
+### Negative / Risks
+
+* `mlbackend_python`'s prediction methods are now subtly diverged from upstream
+  (the trait's `generate_courses()` is absent). Irrelevant in the playground —
+  the backend cannot run — but noted for anyone porting this elsewhere.
+* If a **new** Moodle release adds another production→`tests/` `require_once`,
+  the bundle will fatal the same way at a different entry point. There is no
+  generic tripwire for this class of bug yet (see Review Criteria).
+
+## Implementation Notes
+
+* `scripts/patch-moodle-source.sh`: new `PROCESSORPHP` path var (respecting the
+  `${PUB}` 5.1+ `public/` prefix) and the guarded Python block.
+* No `npm run build-worker` needed (no `src/blueprint/**` or worker JS change).
+* Verify by rebuilding the bundle (`make bundle`) — `make up-local` does **not**
+  reproduce the bug because it serves the full checkout with `tests/` present.
+* Watch for the `*/` trap: a `/** … */` PHP doc comment must not contain the glob
+  literal `*/tests/*` (the `*/` closes the comment early).
+
+## Review Criteria
+
+* If a future Moodle branch fatals on a different `[dirroot]/…/tests/…` require,
+  generalize this into a build-time detector in `build-moodle-bundle.sh` that
+  greps production PHP for `require/include` of `tests/…\.php` and asserts each
+  referenced path is present in the bundle (a suffix match against the zip
+  listing avoids `dirroot`/`libdir` resolution).
+* Revisit if `mlbackend_python` is ever removed from the bundle outright, which
+  would make this patch unnecessary.
+* Revisit the latent `cache`/`behat` references if any playground feature ever
+  reaches Behat data generators or the test cache factory at runtime.

--- a/scripts/patch-moodle-source.sh
+++ b/scripts/patch-moodle-source.sh
@@ -53,6 +53,7 @@ COMPONENTPHP="$SOURCE_DIR/${PUB}lib/classes/component.php"
 SETUPLIBPHP="$SOURCE_DIR/${PUB}lib/setuplib.php"
 SETUPPHP="$SOURCE_DIR/${PUB}lib/setup.php"
 REQUIREJSPHP="$SOURCE_DIR/${PUB}lib/requirejs.php"
+PROCESSORPHP="$SOURCE_DIR/${PUB}lib/mlbackend/python/classes/processor.php"
 
 if [ -f "$DMLLIB" ] && [ -f "$SOURCE_DIR/${PUB}lib/classes/exception/response_aware_exception.php" ] && ! grep -q "response_aware_exception.php" "$DMLLIB"; then
   python3 - "$DMLLIB" <<'PY'
@@ -209,6 +210,51 @@ if needle1 not in text:
 
 text = text.replace(needle2, insert2, 1)
 text = text.replace(needle1, insert1, 1)
+path.write_text(text, encoding="utf-8")
+PY
+fi
+
+# PLAYGROUND: mlbackend_python's processor.php require_once()s a PHPUnit test
+# trait (analytics/tests/classes/mlbackend_helper_trait.php). The core bundle
+# excludes */tests/* (ADR 0011), so /admin/plugins.php -> the analytics admin
+# settings -> core_analytics\manager::get_all_prediction_processors() instantiates
+# \mlbackend_python\processor and fatals on the missing trait. mlbackend_python
+# cannot run in WASM (no python/exec, no server), so drop the test-trait
+# dependency and inline the only method the class itself uses
+# (is_mlbackend_python_configured(), reached only under BEHAT/PHPUNIT).
+if [ -f "$PROCESSORPHP" ] && grep -q "analytics/tests/classes/mlbackend_helper_trait" "$PROCESSORPHP"; then
+  python3 - "$PROCESSORPHP" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+
+require_needle = "require_once($CFG->dirroot . '/analytics/tests/classes/mlbackend_helper_trait.php');\n"
+use_needle = "use core_analytics\\tests\\mlbackend_helper_trait;\n"
+trait_needle = "    use mlbackend_helper_trait;\n"
+inline = (
+    "    /**\n"
+    "     * Check if mlbackend_python is configured. Inlined from the upstream\n"
+    "     * core_analytics\\tests\\mlbackend_helper_trait so the playground bundle\n"
+    "     * (which excludes test directories) does not need the test trait file.\n"
+    "     */\n"
+    "    public static function is_mlbackend_python_configured(): bool {\n"
+    "        if (defined('TEST_MLBACKEND_PYTHON_HOST') && defined('TEST_MLBACKEND_PYTHON_PORT')\n"
+    "                && defined('TEST_MLBACKEND_PYTHON_USERNAME') && defined('TEST_MLBACKEND_PYTHON_USERNAME')) {\n"
+    "            return true;\n"
+    "        }\n"
+    "        return false;\n"
+    "    }\n"
+)
+
+for needle in (require_needle, use_needle, trait_needle):
+    if needle not in text:
+        raise SystemExit(f"Needle not found in {path}: {needle!r}")
+
+text = text.replace(require_needle, "", 1)
+text = text.replace(use_needle, "", 1)
+text = text.replace(trait_needle, inline, 1)
 path.write_text(text, encoding="utf-8")
 PY
 fi


### PR DESCRIPTION
## Problem

After excluding `*/tests/*` from the core ZIP (PR #141, ADR 0011), opening
`/admin/plugins.php` throws a fatal:

```
Exception - Failed opening required '[dirroot]/analytics/tests/classes/mlbackend_helper_trait.php'
```

## Root cause

Moodle 5.0+ has an upstream architectural violation: **production** code
`require_once()`s a file that lives under `tests/`.

1. `/admin/plugins.php` builds the admin tree → loads `admin/settings/analytics.php`.
2. That page calls `core_analytics\manager::get_all_prediction_processors()`, which **instantiates every `mlbackend` plugin** (including `mlbackend_python`).
3. Declaring `\mlbackend_python\processor` runs `lib/mlbackend/python/classes/processor.php:30`:
   `require_once($CFG->dirroot . '/analytics/tests/classes/mlbackend_helper_trait.php')`.
4. That file was excluded by `*/tests/*` → fatal.

The `*/tests/*` exclusion **is worth keeping** (~52 MB / ~6,100 files saved): we do not revert it, we patch the broken dependency.

## Fix

Surgical in-place edit in `scripts/patch-moodle-source.sh` (the repo's patch
pattern): remove the trait `require_once` and the `use`, and inline the only
method the class uses (`is_mlbackend_python_configured()`, reachable only under
BEHAT/PHPUNIT). `mlbackend_python` cannot run in WASM anyway; it only needs to
load cleanly for the analytics admin enumeration.

- `grep`-guarded and idempotent; a no-op on 4.04/4.05 (they do not reference the trait).
- `processor.php` is the **only** production consumer of the trait on 500/501/502/main (verified).

## Verification

- `php -l` clean on the 4 affected branches after the patch.
- The ZIP (built with `-x "*/tests/*"`) ships `processor.php` patched and **excludes** the trait; `fileCount` identical to the official bundle.
- **End-to-end in the browser:** rebuilt the patched bundle (reusing the snapshot); after a clean boot **`/admin/plugins.php` loads the "Plugins overview" with 411 plugins**, no fatal.

> Note: `make up-local` does **not** reproduce the bug (it serves the full checkout with `tests/`). Always verify against a real bundle.

## Documentation

- `docs/decisions/0014-production-require-of-tests-files-patch.md` — new ADR.
- `AGENTS.md` — ADR table row.
- `docs/TROUBLESHOOTING.md` — symptom → cause → fix.
- `docs/KNOWN-ISSUES.md` — issue #6: mlbackend case resolved + equivalent **latent** references (`cache/tests/fixtures/lib.php`, behat generators) left untouched as they are unreachable in the playground.