### PR TITLE
build: run composer install for Moodle 5.1+ bundles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,10 @@ This project uses npm, esbuild, and a small Makefile workflow.
 - Python 3
 - Git
 - PHP 8.3 with `pdo_sqlite` for `make up-local`
+- Composer — required to build Moodle **5.1+** bundles (`MOODLE_501_STABLE`,
+  `main`, …). Since 5.1 `vendor/` is no longer committed upstream, so
+  `scripts/build-moodle-bundle.sh` runs `composer install` for those branches.
+  Pre-5.1 branches do not need it. CI provisions it via `shivammathur/setup-php`.
 
 ### Common Commands
 

--- a/scripts/build-moodle-bundle.sh
+++ b/scripts/build-moodle-bundle.sh
@@ -42,6 +42,24 @@ mkdir -p "$DIST_DIR" "$MANIFEST_DIR"
 
 "$SCRIPT_DIR/patch-moodle-source.sh" "$MOODLE_DIR" "$BRANCH"
 
+# Moodle 5.1+ manages its runtime dependencies with Composer; vendor/ is no
+# longer committed to the source tree, so the git checkout from
+# fetch-moodle-source.sh lacks it. The component-cache and install-snapshot
+# steps below boot Moodle, which without vendor/ fails its "Composer vendor
+# directory not found" environment check (and can fatal on missing autoloaded
+# classes). Materialize vendor/ with native Composer on the build machine
+# before those steps; vendor/ then travels in the bundle (it is not excluded
+# from the zip, and PHP autoloading is self-contained — composer.json/lock stay
+# excluded). Pre-5.1 has no public/ webroot and ships its dependencies, so it is
+# skipped. Idempotent: a no-op if vendor/ already exists.
+if [ -f "$MOODLE_DIR/composer.json" ] \
+  && [ ! -f "$MOODLE_DIR/vendor/autoload.php" ] \
+  && [ -f "$MOODLE_DIR/public/version.php" ]; then
+  echo "Installing Composer runtime dependencies (Moodle 5.1+)" >&2
+  ( cd "$MOODLE_DIR" && composer install --no-dev --prefer-dist \
+      --classmap-authoritative --no-interaction --no-progress )
+fi
+
 COMPONENT_CACHE_DIR="$MOODLE_DIR/.playground"
 COMPONENT_CACHE_FILE="$COMPONENT_CACHE_DIR/core_component.php"
 mkdir -p "$COMPONENT_CACHE_DIR"

--- a/scripts/build-moodle-bundle.sh
+++ b/scripts/build-moodle-bundle.sh
@@ -51,10 +51,21 @@ mkdir -p "$DIST_DIR" "$MANIFEST_DIR"
 # before those steps; vendor/ then travels in the bundle (it is not excluded
 # from the zip, and PHP autoloading is self-contained — composer.json/lock stay
 # excluded). Pre-5.1 has no public/ webroot and ships its dependencies, so it is
-# skipped. Idempotent: a no-op if vendor/ already exists.
+# skipped. Re-runs when vendor/ is missing OR composer.lock is newer than the
+# installed vendor/ — fetch-moodle-source.sh keeps the untracked vendor/ across
+# `git reset --hard`, so an autoload.php-presence-only guard would ship stale
+# deps after a checkout whose composer.lock changed. Otherwise a no-op.
 if [ -f "$MOODLE_DIR/composer.json" ] \
-  && [ ! -f "$MOODLE_DIR/vendor/autoload.php" ] \
-  && [ -f "$MOODLE_DIR/public/version.php" ]; then
+  && [ -f "$MOODLE_DIR/public/version.php" ] \
+  && { [ ! -f "$MOODLE_DIR/vendor/autoload.php" ] \
+    || [ "$MOODLE_DIR/composer.lock" -nt "$MOODLE_DIR/vendor/autoload.php" ]; }; then
+  if ! command -v composer >/dev/null 2>&1; then
+    echo "ERROR: building a Moodle 5.1+ bundle ($BRANCH) requires Composer to" >&2
+    echo "install runtime dependencies (vendor/ is not committed upstream), but" >&2
+    echo "'composer' was not found in PATH. Install it from https://getcomposer.org/" >&2
+    echo "(CI uses shivammathur/setup-php with tools: composer)." >&2
+    exit 1
+  fi
   echo "Installing Composer runtime dependencies (Moodle 5.1+)" >&2
   ( cd "$MOODLE_DIR" && composer install --no-dev --prefer-dist \
       --classmap-authoritative --no-interaction --no-progress )


### PR DESCRIPTION
## What

Run `composer install` as part of `scripts/build-moodle-bundle.sh` for Moodle **5.1+** bundles, right after patching the source and before the steps that boot Moodle (component-cache and install-snapshot).

```sh
if [ -f "$MOODLE_DIR/composer.json" ] \
  && [ ! -f "$MOODLE_DIR/vendor/autoload.php" ] \
  && [ -f "$MOODLE_DIR/public/version.php" ]; then
  echo "Installing Composer runtime dependencies (Moodle 5.1+)" >&2
  ( cd "$MOODLE_DIR" && composer install --no-dev --prefer-dist \
      --classmap-authoritative --no-interaction --no-progress )
fi
```

## Why

Since **Moodle 5.1**, runtime dependencies are managed by Composer and `vendor/` is **no longer committed** to the source tree (Moodle ships a "Composer vendor directory not found" environment check; the documented fix is `composer install --no-dev --classmap-authoritative`).

Our bundles are built from a **git checkout** (`fetch-moodle-source.sh`), which therefore lacks `vendor/`. The `generate-component-cache.php` and `generate-install-snapshot.sh` steps boot Moodle, and the browser runtime loads it too — without `vendor/` they fail the environment check and can fatal on missing autoloaded classes. In practice this means 5.1+ bundles were missing their Composer dependencies (and the install-snapshot step could silently fall back via the warning in `build-moodle-bundle.sh`).

## How

- Materialize `vendor/` with **native Composer** on the build machine (the right tool — it has git, network and full PHP), before the boot-dependent steps.
- **Gated on the 5.1+ `public/` webroot layout** (`public/version.php`), the same 5.1+ signal already used in this script — so pre-5.1 branches (4.04 / 4.05 / 5.00) are untouched.
- **Idempotent**: skipped when `vendor/autoload.php` already exists (e.g. legacy release-tarball builds that ship it).
- `vendor/` then travels in the bundle — it is **not** excluded from the zip, and PHP autoloading is self-contained, so `composer.json`/`composer.lock` stay excluded.
- No CI change needed: the workflow already provisions Composer (`shivammathur/setup-php` with `tools: composer`, PHP 8.3).

## Verification

- `sh -n scripts/build-moodle-bundle.sh` passes; the gate is three file tests (composer.json present ∧ vendor/autoload.php absent ∧ public/version.php present).
- End-to-end validation runs in CI (`make bundle` + E2E with PHP 8.3 + Composer). On a 5.1+ branch the build should print "Installing Composer runtime dependencies", produce `vendor/autoload.php`, let the install-snapshot succeed, and include `vendor/` in `moodle-core-*.zip`; on a pre-5.1 branch the step is skipped.
