### PR TITLE
Add runtime PR overlay support for Moodle core previews

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - uses: actions/configure-pages@v6
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
 
       - uses: actions/setup-node@v6
         with:
@@ -142,7 +142,7 @@ jobs:
           retention-days: 1
 
       - name: Upload Pages artifact
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: actions/upload-pages-artifact@v5
         with:
           path: _site
@@ -247,9 +247,9 @@ jobs:
           path: test-results/
           retention-days: 7
 
-  # ── Deploy to GitHub Pages (push to main only) ──
+  # ── Deploy to GitHub Pages (push to main, or scheduled/manual rebuild) ──
   deploy-pages:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     needs: [lint-and-test, build, e2e]
     runs-on: ubuntu-latest
     environment:
@@ -259,9 +259,9 @@ jobs:
       - id: deployment
         uses: actions/deploy-pages@v5
 
-  # ── Deploy to Cloudflare Pages (production, push to main; gated on e2e) ──
+  # ── Deploy to Cloudflare Pages (production; push to main or scheduled/manual rebuild; gated on e2e) ──
   deploy-cloudflare:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     needs: [lint-and-test, build, e2e]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/scheduled-base-rebuild.yml
+++ b/.github/workflows/scheduled-base-rebuild.yml
@@ -38,8 +38,11 @@ jobs:
       - name: Dispatch CI to rebuild and redeploy base bundles
         env:
           GH_TOKEN: ${{ github.token }}
+          # Pass the untrusted input via env (never inline ${{ ... }} into the
+          # script) to avoid shell injection.
+          REASON: ${{ github.event.inputs.reason }}
         run: |
-          reason="${{ github.event.inputs.reason }}"
+          reason="$REASON"
           if [ -z "$reason" ]; then
             reason="Scheduled base rebuild to keep PR-overlay bases close to branch tips"
           fi

--- a/.github/workflows/scheduled-base-rebuild.yml
+++ b/.github/workflows/scheduled-base-rebuild.yml
@@ -1,0 +1,49 @@
+# Scheduled base rebuild
+#
+# The PR Overlay Preview feature (ADR-0016, applyPrOverlay) overlays a pull
+# request's changed files on top of a prebuilt Moodle base. Whole-file overlay
+# assumes that prebuilt base is reasonably close to the branch tip, so the bases
+# must be rebuilt periodically to keep drift small.
+#
+# This workflow does NOT build or deploy anything itself — it simply dispatches
+# the existing CI pipeline (ci.yml) on `main`, which already builds every Moodle
+# branch bundle and deploys to GitHub Pages / Cloudflare with the established
+# credentials. Reusing ci.yml avoids inventing new deployment secrets here.
+name: Scheduled base rebuild
+
+on:
+  schedule:
+    # Weekly, Mondays at 06:00 UTC. Conservative cadence; adjust if drift hurts.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Reason for the manual base rebuild"
+        required: false
+        type: string
+
+# Least privilege: only enough to trigger ci.yml via the API.
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: scheduled-base-rebuild
+  cancel-in-progress: false
+
+jobs:
+  trigger-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch CI to rebuild and redeploy base bundles
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          reason="${{ github.event.inputs.reason }}"
+          if [ -z "$reason" ]; then
+            reason="Scheduled base rebuild to keep PR-overlay bases close to branch tips"
+          fi
+          gh workflow run ci.yml \
+            --repo "${{ github.repository }}" \
+            --ref main \
+            -f reason="$reason"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -419,6 +419,7 @@ so that future contributors (human or AI) understand **why** a choice was made â
 | [0013](docs/decisions/0013-build-time-requirejs-combined-bundle-seed.md) | Build-time RequireJS combined-bundle seed (re-enable cachejs) | Accepted |
 | [0014](docs/decisions/0014-production-require-of-tests-files-patch.md) | Patch production code that require_once()s files under tests/ (mlbackend_python) | Accepted |
 | [0015](docs/decisions/0015-firefox-request-body-buffering.md) | Buffer the request body synchronously for Firefox (SW fetch handler) | Accepted |
+| [0016](docs/decisions/0016-runtime-pr-file-overlay.md) | Runtime PR file overlay for Moodle core PR previews (`applyPrOverlay`) | Accepted |
 
 ## Debugging
 

--- a/assets/blueprints/blueprint-schema.json
+++ b/assets/blueprints/blueprint-schema.json
@@ -104,10 +104,14 @@
               "writeFiles",
               "copyFile",
               "moveFile",
+              "deleteFile",
+              "deleteFiles",
               "unzip",
               "request",
               "runPhpCode",
-              "runPhpScript"
+              "runPhpScript",
+              "purgeMoodleCaches",
+              "applyPrOverlay"
             ]
           }
         },

--- a/assets/blueprints/examples/pr-overlay.blueprint.json
+++ b/assets/blueprints/examples/pr-overlay.blueprint.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "../blueprint-schema.json",
+  "preferredVersions": { "php": "8.3", "moodle": "5.1" },
+  "landingPage": "/admin/index.php",
+  "steps": [
+    {
+      "step": "installMoodle",
+      "options": {
+        "siteName": "Moodle core PR #1234 Preview",
+        "adminUser": "admin",
+        "adminPass": "password"
+      }
+    },
+    {
+      "step": "applyPrOverlay",
+      "baseRef": "MOODLE_501_STABLE",
+      "runUpgrade": "auto",
+      "root": "/www/moodle",
+      "files": [
+        {
+          "path": "lib/classes/example.php",
+          "status": "modified",
+          "rawUrl": "https://raw.githubusercontent.com/moodle/moodle/abc123def456/lib/classes/example.php",
+          "size": 12345
+        },
+        {
+          "path": "lib/classes/removed.php",
+          "status": "removed"
+        },
+        {
+          "path": "lib/classes/newname.php",
+          "previousPath": "lib/classes/oldname.php",
+          "status": "renamed",
+          "rawUrl": "https://raw.githubusercontent.com/moodle/moodle/abc123def456/lib/classes/newname.php"
+        }
+      ]
+    },
+    {
+      "step": "login",
+      "username": "admin"
+    }
+  ]
+}

--- a/docs/blueprint-json.md
+++ b/docs/blueprint-json.md
@@ -822,6 +822,44 @@ Whole-file overlay assumes the prebuilt base is reasonably close to the branch t
 workflow (`.github/workflows/scheduled-base-rebuild.yml`) periodically rebuilds the bases to keep
 drift small.
 
+### Fork support
+
+**Forks are supported.** A Moodle core PR's head almost always lives in a contributor's fork
+(e.g. `someone/moodle`), and both overlay modes handle that:
+
+- **`files` manifest mode** — each entry's `rawUrl` points at the PR head repo (the fork) at the
+  head commit, e.g. `https://raw.githubusercontent.com/someone/moodle/<headSha>/<path>`. The action
+  builds these from the PR head repo, so fork content is fetched directly.
+- **`repo` + `pr` mode** — pass the **base** repository the PR was opened against (e.g.
+  `moodle/moodle`) and the PR number. The GitHub API (`/repos/{base}/pulls/{n}/files`) resolves the
+  fork's head commit automatically, so you do not need to know the fork name.
+
+> The GitHub REST API is rate-limited to 60 requests/hour for unauthenticated browser calls, which
+> is enough for an occasional `repo` + `pr` preview. The action's `files` mode avoids runtime API
+> calls entirely.
+
+### Try it live
+
+You can drive `applyPrOverlay` directly against a deployed playground without the action, using the
+compact `repo` + `pr` form (the URL stays tiny regardless of PR size). For example, to preview
+[`moodle/moodle#532`](https://github.com/moodle/moodle/pull/532) (a fork PR targeting `main`):
+
+```json
+{
+  "preferredVersions": { "php": "8.3", "moodle": "dev" },
+  "landingPage": "/admin/index.php",
+  "steps": [
+    { "step": "installMoodle", "options": { "siteName": "Core PR #532 preview", "adminUser": "admin", "adminPass": "password" } },
+    { "step": "applyPrOverlay", "repo": "moodle/moodle", "pr": 532, "baseRef": "main", "runUpgrade": "auto" },
+    { "step": "login", "username": "admin" }
+  ]
+}
+```
+
+base64url-encode that JSON and open `https://<playground-host>/?blueprint=<base64url>`. Swap `pr`
+for any open core PR and `baseRef` for its target branch (the base maps to a version per the table
+above). Admin credentials are `admin` / `password`.
+
 ### Limitations
 
 - **SQLite vs. real DB.** Lower fidelity than a full Moodle Docker/Codespaces environment,

--- a/docs/blueprint-json.md
+++ b/docs/blueprint-json.md
@@ -874,12 +874,14 @@ above). Admin credentials are `admin` / `password`.
 - No in-browser code editor, no Tampermonkey implementation, and no full per-PR bundle builder are
   part of this feature.
 
-### Future work: Tampermonkey
+### Tampermonkey button
 
-A Tampermonkey userscript could add an "Open in Moodle Playground" button on GitHub PR pages and on
-Moodle Tracker issues that link a PR. It should prefer an Action-generated preview URL when present,
-and otherwise build a direct `applyPrOverlay` blueprint URL from `repo` + `pr`. This is separate
-future work and is **not** implemented here.
+A [Tampermonkey userscript](tampermonkey-pr-button.md) adds an "Open in Moodle Playground" button on
+Moodle core GitHub PR pages (and on Moodle Tracker issues that link a PR). It prefers an
+Action-generated preview URL when present, and otherwise builds a compact `applyPrOverlay` blueprint
+URL from `repo` + `pr`. The script lives at
+[`scripts/moodle-playground-pr-button.user.js`](../scripts/moodle-playground-pr-button.user.js);
+see [docs/tampermonkey-pr-button.md](tampermonkey-pr-button.md) for installation and configuration.
 
 ## Roles, scales and cohorts
 

--- a/docs/blueprint-json.md
+++ b/docs/blueprint-json.md
@@ -334,7 +334,16 @@ Named resources can be defined once and referenced from steps using `@name`:
 | `writeFiles` | Write multiple files |
 | `copyFile` | Copy a file |
 | `moveFile` | Move a file |
+| `deleteFile` | Delete a file (idempotent) |
+| `deleteFiles` | Delete multiple files |
 | `unzip` | Extract a ZIP archive |
+
+### PR overlay preview
+
+| Step | Description |
+|------|-------------|
+| `purgeMoodleCaches` | Purge Moodle caches and reset the component registry |
+| `applyPrOverlay` | Overlay a pull request's changed files onto the booted Moodle base |
 
 ### Low-level
 
@@ -657,6 +666,182 @@ Provide exactly one **source** (precedence `url` > `path` > `data`):
 > transaction limits and fail. A failed restore is reported in the boot log and does **not** abort
 > the rest of the blueprint. Prefer smaller course backups, and host large `.mbz` files at a
 > CORS-accessible URL (e.g. GitHub raw) so they stream into the runtime instead of being buffered.
+
+### deleteFile / deleteFiles
+
+Delete files from the runtime filesystem. `deleteFile` is **idempotent** — a path that
+does not exist is silently skipped — but a real filesystem error (e.g. a failed `unlink`)
+is surfaced and aborts the blueprint. `deleteFiles` deletes a batch; each entry may be a
+plain string path or an object with a `path` property.
+
+```json
+{ "step": "deleteFile", "path": "/www/moodle/lib/example.php" }
+```
+
+```json
+{
+  "step": "deleteFiles",
+  "files": [
+    "/www/moodle/lib/old.php",
+    "/www/moodle/course/old.php"
+  ]
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `path` | yes (`deleteFile`) | Absolute path of the file to delete. |
+| `files` | yes (`deleteFiles`) | Array of string paths or `{ "path": "…" }` objects. |
+
+### purgeMoodleCaches
+
+Purge Moodle's caches and reset the component registry. Run this after overwriting core or
+plugin files at runtime so MUC, the compiled DI container, theme CSS, and the component cache
+no longer point at stale code. It loads `/www/moodle/config.php`, then calls
+`\core_component::reset()`, `theme_reset_all_caches()`, `purge_all_caches()`, and clears
+`allversionshash`. `applyPrOverlay` runs this automatically; you rarely need it standalone.
+
+```json
+{ "step": "purgeMoodleCaches" }
+```
+
+### applyPrOverlay
+
+Preview a **Moodle core pull request** by overlaying its changed files onto an already-booted,
+prebuilt Moodle base. This is the runtime half of the [PR Overlay Preview](#pr-overlay-preview)
+feature; the [GitHub Action](https://github.com/ateeducacion/action-moodle-playground-pr-preview)
+generates the blueprint that drives it.
+
+**Whole-file overlay, not a unified diff.** Each changed file is replaced with its *final*
+contents fetched at the PR head commit. Whole-file replacement handles add / modify / remove /
+rename predictably and avoids hunk failures, fuzzy patching, `.rej` files, context drift, and
+binary-diff problems. This is a preview system, not a source-control engine — no diff/patch
+engine is implemented.
+
+Two input modes:
+
+1. **Pre-resolved manifest (`files`)** — recommended; reproducible and avoids runtime GitHub
+   API calls. The Action emits this.
+2. **Runtime fetch (`repo` + `pr`)** — the step calls the GitHub REST API
+   (`/repos/{owner}/{repo}/pulls/{n}/files`) itself. Useful for Tampermonkey/manual URLs.
+
+```json
+{
+  "step": "applyPrOverlay",
+  "baseRef": "MOODLE_501_STABLE",
+  "runUpgrade": "auto",
+  "root": "/www/moodle",
+  "files": [
+    {
+      "path": "lib/classes/example.php",
+      "status": "modified",
+      "rawUrl": "https://raw.githubusercontent.com/user/moodle/abc123/lib/classes/example.php",
+      "size": 12345
+    },
+    { "path": "lib/classes/old.php", "status": "removed" },
+    {
+      "path": "lib/classes/newname.php",
+      "previousPath": "lib/classes/oldname.php",
+      "status": "renamed",
+      "rawUrl": "https://raw.githubusercontent.com/user/moodle/abc123/lib/classes/newname.php"
+    }
+  ]
+}
+```
+
+Runtime-fetch form:
+
+```json
+{ "step": "applyPrOverlay", "repo": "moodle/moodle", "pr": 1234, "runUpgrade": "auto" }
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `files` | one of `files` / `repo`+`pr` | Pre-resolved manifest of changed files (see below). |
+| `repo` | with `pr` | `owner/name` to fetch changed files from at runtime. |
+| `pr` | with `repo` | Pull request number. |
+| `baseRef` | no | Informational: the PR target branch the base was chosen for. |
+| `runUpgrade` | no | `off`, `on`, or `auto` (default `auto`). See below. |
+| `root` | no | Filesystem root to overlay onto. Defaults to `/www/moodle`. |
+| `proxy` | no | Optional CORS/caching proxy base URL (URL-passthrough `?url=`). |
+| `maxFiles` | no | Cap on changed-file count (default 200). |
+| `maxFileBytes` | no | Per-file byte cap (default 5 MiB). |
+| `purgeCaches` | no | Set `false` to skip the automatic cache purge (rarely useful). |
+
+**Manifest entries** carry `path` (repo-relative), `status` (`added`/`modified`/`removed`/
+`renamed`), `rawUrl` (required for everything except `removed`), `previousPath` (required for
+`renamed`), and optional `size`. Paths are sanitized: empty, absolute, `..`, backslash, null-byte,
+and control-character paths are rejected.
+
+**Paths root at `/www/moodle`, never auto-prefixed with `public/`.** GitHub PR paths are
+relative to the repo root, so `lib/classes/example.php` → `/www/moodle/lib/classes/example.php`
+and `public/course/view.php` → `/www/moodle/public/course/view.php` (the `public/` prefix comes
+from the PR path itself).
+
+**`runUpgrade`:**
+
+- `off` — never run the upgrade.
+- `on` — always run Moodle's upgrade after the overlay.
+- `auto` (default) — run only when a changed file looks upgrade-relevant: `version.php`,
+  `public/version.php`, or any `**/db/{install.xml,install.php,upgrade.php}`.
+
+The upgrade is a **best-effort attempt**. It loads the overlaid `version.php` and runs
+`upgrade_core()` / `upgrade_noncore()`. SQLite-in-WASM has lower schema-upgrade fidelity than a
+full Moodle environment (nested savepoints, ADR-0003), so an upgrade may fail; the failure is
+reported honestly in the boot log and is **non-fatal** (the overlaid files are already in place).
+The preview never fakes a successful upgrade.
+
+**Fetching, CORS, and proxy.** By default the runtime fetches `raw.githubusercontent.com` and (in
+`repo`+`pr` mode) `api.github.com` directly — both send CORS headers for public repositories. The
+browser never fetches `github.com/.../pull/N.diff` HTML endpoints. An optional `proxy` routes
+requests through a caching/token-injecting proxy.
+
+## PR Overlay Preview
+
+`applyPrOverlay` (plus `purgeMoodleCaches`, `deleteFile`, `deleteFiles`) implements a runtime
+**PR Overlay Preview**: boot a prebuilt Moodle base selected from a pull request's target branch,
+then apply the PR's changed files over the in-browser Moodle filesystem. It is inspired by the
+old Gitpod-based Moodle workflow where reviewers could open a tracker issue or PR and get a quickly
+running Moodle instance. No per-PR WASM bundle is built.
+
+### Base selection and freshness
+
+The base bundle is chosen by the blueprint's `preferredVersions`, mapped from the PR target
+branch (`base.ref`):
+
+| Target branch (`base.ref`) | Playground version |
+|----------------------------|--------------------|
+| `MOODLE_404_STABLE`        | 4.4 |
+| `MOODLE_405_STABLE`        | 4.5 |
+| `MOODLE_500_STABLE`        | 5.0 |
+| `MOODLE_501_STABLE`        | 5.1 |
+| `MOODLE_502_STABLE`        | 5.2 |
+| `main` / `master`          | dev (`main`) |
+
+Whole-file overlay assumes the prebuilt base is reasonably close to the branch tip. A scheduled
+workflow (`.github/workflows/scheduled-base-rebuild.yml`) periodically rebuilds the bases to keep
+drift small.
+
+### Limitations
+
+- **SQLite vs. real DB.** Lower fidelity than a full Moodle Docker/Codespaces environment,
+  especially for schema/upgrade-heavy PRs.
+- **Composer / frontend builds.** Changes that require `composer install`, `grunt`, or other
+  generated assets (`amd/build`, compiled CSS) are not reproduced — only the changed source files
+  are overlaid.
+- **Database upgrades.** `runUpgrade=auto` attempts an upgrade but may not fully apply complex
+  schema changes under SQLite/WASM.
+- **Binary / large files.** Bounded by `maxFiles` / `maxFileBytes`.
+- **Base drift.** A base far behind the branch tip may miss files the PR depends on.
+- No in-browser code editor, no Tampermonkey implementation, and no full per-PR bundle builder are
+  part of this feature.
+
+### Future work: Tampermonkey
+
+A Tampermonkey userscript could add an "Open in Moodle Playground" button on GitHub PR pages and on
+Moodle Tracker issues that link a PR. It should prefer an Action-generated preview URL when present,
+and otherwise build a direct `applyPrOverlay` blueprint URL from `repo` + `pr`. This is separate
+future work and is **not** implemented here.
 
 ## Roles, scales and cohorts
 

--- a/docs/decisions/0016-runtime-pr-file-overlay.md
+++ b/docs/decisions/0016-runtime-pr-file-overlay.md
@@ -1,0 +1,82 @@
+# ADR-0016 Runtime PR file overlay for Moodle core PR previews
+
+* Status: Accepted
+* Date: 2026-06-28
+
+## Context and Problem
+
+Moodle previously had a Gitpod-based workflow that let reviewers open a tracker issue or
+pull request and get a quickly running Moodle instance. Moodle Playground already previews
+**plugin** PRs (the GitHub Action generates a blueprint that installs the plugin ZIP from the
+PR branch), but **core** PRs cannot be previewed that way because core *is* the base
+application — there is no plugin to install.
+
+Building a custom Moodle WASM bundle per core PR is far too slow and expensive for a preview.
+We need a way to preview a core PR on top of an existing, prebuilt Moodle Playground base
+without rebuilding the runtime.
+
+## Options Considered
+
+* **Per-PR bundle builder** — build a fresh Moodle WASM bundle for every PR. Most faithful,
+  but minutes-to-build and heavy infrastructure; wrong tool for a fast preview.
+* **Unified-diff patching at runtime** — fetch the PR `.diff` and apply hunks in the browser.
+  Brittle: hunk failures, fuzzy matching, `.rej` files, context drift, no binary support, and a
+  diff parser to maintain.
+* **Whole-file overlay at runtime** — boot a prebuilt base selected from the PR target branch,
+  then replace each changed file with its *final* contents fetched at the PR head commit.
+
+## Decision
+
+Implement **whole-file overlay at runtime**. A new blueprint step `applyPrOverlay` overlays a
+PR's changed files onto the booted Moodle base in the browser filesystem, purges caches, and
+optionally runs Moodle's upgrade. Supporting steps `deleteFile`, `deleteFiles`, and
+`purgeMoodleCaches` are added. The base version is selected from the PR target branch
+(`base.ref`); the GitHub Action generates the blueprint (preferring a pre-resolved `files`
+manifest), and a runtime `repo`+`pr` fetch mode remains for manual/Tampermonkey use.
+
+Whole-file replacement is chosen because GitHub exposes both the changed-file metadata and the
+final file contents at the head SHA, and it handles add/modify/remove/rename uniformly without a
+patch engine. This is a preview system, not a source-control engine.
+
+## Consequences
+
+### Positive
+
+* Core PRs become previewable in seconds on top of existing prebuilt bases — no per-PR build.
+* No diff/patch engine: add/modify/remove/rename are predictable; binary files work (within caps).
+* Reuses the existing blueprint engine, resource model, and the Action's preview-URL plumbing.
+* Path sanitization and size/count caps bound the runtime cost and block traversal writes.
+
+### Negative / Risks
+
+* **Base drift.** Whole-file overlay assumes the prebuilt base is reasonably close to the branch
+  tip; a stale base may miss files the PR depends on. Mitigated by a scheduled base rebuild.
+* **Lower DB fidelity.** Schema/upgrade-heavy PRs run against SQLite-in-WASM, which has lower
+  fidelity than a full Moodle environment (nested savepoints, ADR-0003). `runUpgrade` is a
+  best-effort attempt and failures are reported honestly, never faked.
+* **Out of scope.** Composer installs, frontend/grunt builds, and generated assets are not
+  reproduced — only changed source files are overlaid.
+
+## Implementation Notes
+
+* `src/blueprint/pr-overlay.js` — pure helpers (path validation, manifest normalization,
+  upgrade detection, `runUpgrade` normalization, GitHub/proxy URL builders).
+* `src/blueprint/steps/pr-overlay.js` — `purgeMoodleCaches` and `applyPrOverlay` handlers
+  (fetch, write, delete, purge, upgrade).
+* `src/blueprint/steps/filesystem.js` — `deleteFile` / `deleteFiles`.
+* `src/blueprint/php/helpers.js` — `phpPurgeMoodleCaches()`, `phpRunCoreUpgrade()`.
+* Allowlists updated in `src/blueprint/schema.js`, `assets/blueprints/blueprint-schema.json`,
+  and `tests/blueprint/steps.test.js`. Docs in `docs/blueprint-json.md`; example at
+  `assets/blueprints/examples/pr-overlay.blueprint.json`.
+* Overlay root is `/www/moodle`; the `public/` prefix (Moodle 5.1+) comes from the PR path and
+  is never auto-prepended. Remember to `npm run build-worker` after editing `src/blueprint/**`.
+* Companion change: the `action-moodle-playground-pr-preview` Action gains a `core` preview type
+  that resolves the manifest and emits the `applyPrOverlay` blueprint.
+
+## Review Criteria
+
+Revisit if: base drift makes overlays unreliable in practice (consider tightening the rebuild
+cadence or a lightweight per-PR build); core upgrades under SQLite/WASM prove too lossy to be
+useful (consider gating or disabling `runUpgrade=auto`); GitHub changes its PR files API or CORS
+behavior; or demand appears for a Tampermonkey integration or an in-browser editor (both
+currently out of scope).

--- a/docs/tampermonkey-pr-button.md
+++ b/docs/tampermonkey-pr-button.md
@@ -1,0 +1,110 @@
+# "Open in Moodle Playground" Tampermonkey button
+
+A small [Tampermonkey](https://www.tampermonkey.net/) / [Violentmonkey](https://violentmonkey.github.io/)
+userscript that adds an **"Open in Moodle Playground"** badge on Moodle core
+**GitHub pull requests** (and on Moodle **tracker** issues that link a PR). Clicking
+it opens the PR in Moodle Playground using a runtime [`applyPrOverlay`](blueprint-json.md#applyproverlay)
+overlay — booting a prebuilt base and applying the PR's changed files in the browser.
+
+It is inspired by Sara Arjona's ["Open in Gitpod" tracker userscript](https://gist.github.com/sarjona/9fc728eb2d2b41a783ea03afd6a6161e)
+([documented in the Moodle dev docs](https://moodledev.io/general/development/tools/gitpod)),
+which adds a Gitpod badge on tracker issues. This one targets pull requests and the
+Playground overlay instead.
+
+## Install
+
+1. Install the [Tampermonkey](https://www.tampermonkey.net/) browser extension.
+2. Open the raw script to trigger a one-click install:
+
+   **[`scripts/moodle-playground-pr-button.user.js`](https://raw.githubusercontent.com/ateeducacion/moodle-playground/main/scripts/moodle-playground-pr-button.user.js)**
+
+   (Tampermonkey detects the `.user.js` URL and shows its install screen.)
+3. Open any Moodle core PR, e.g. <https://github.com/moodle/moodle/pull/532>, and the
+   badge appears in the PR header.
+
+The source lives at [`scripts/moodle-playground-pr-button.user.js`](../scripts/moodle-playground-pr-button.user.js).
+
+## Configure
+
+Edit the constants at the top of the script:
+
+```js
+// Your deployment. Use a branch preview or your own GitHub Pages host.
+const PLAYGROUND_HOST = "https://ateeducacion.github.io/moodle-playground";
+const RUN_UPGRADE = "auto"; // off | on | auto
+```
+
+Point `PLAYGROUND_HOST` at whichever Moodle Playground you run — the production host, a
+GitHub Pages deployment, or a branch preview such as
+`https://feat-pr-overlay-preview.moodle-playground.pages.dev`.
+
+## How it works
+
+The button builds the **same compact `repo` + `pr` blueprint** the GitHub Action emits for
+large PRs, so the URL stays small no matter how many files the PR changes — the runtime
+fetches the changed files itself:
+
+```js
+function buildPlaygroundUrl(repo, pr, baseRef) {
+  const version = BASE_REF_TO_VERSION[baseRef] || "dev";
+  const blueprint = {
+    preferredVersions: { php: "8.3", moodle: version },
+    landingPage: "/admin/index.php",
+    steps: [
+      { step: "installMoodle", options: { siteName: `Moodle core PR #${pr} preview`,
+          adminUser: "admin", adminPass: "password" } },
+      { step: "applyPrOverlay", repo, pr: Number(pr), baseRef: baseRef || "main",
+          runUpgrade: RUN_UPGRADE },
+      { step: "login", username: "admin" },
+    ],
+  };
+  return `${PLAYGROUND_HOST}/?blueprint=${toBase64Url(JSON.stringify(blueprint))}`;
+}
+```
+
+Key behaviours:
+
+- **GitHub PR pages** (`https://github.com/<owner>/moodle/pull/<n>`): reads the owner, repo,
+  and PR number from the URL (only repositories **named `moodle`**, so `moodle/moodle` and
+  its forks), resolves the **base branch** from the PR header (or the public REST API),
+  maps it to a base version, and injects the badge in the PR header.
+- **Action link preference**: if the GitHub Action already posted a preview link in the PR
+  description or a comment, the button reuses that (reproducible, pre-resolved) URL instead
+  of generating its own — `findExistingActionLink()` compares hosts by parsing the URL, not
+  by substring.
+- **Moodle tracker** (`https://moodle.atlassian.net/*`): scans the issue for linked GitHub
+  PR URLs and adds a badge next to each — the tracker equivalent of Sara Arjona's button,
+  but for a pull request rather than a Gitpod branch.
+- **Forks**: fully supported — the overlay resolves the PR head (the fork) from the base
+  repo + PR number, so a fork PR against `moodle/moodle` previews the fork's changes.
+- **SPA-safe**: GitHub and Jira are single-page apps, so the script re-runs on DOM mutations
+  (debounced) and on a short interval, and guards against inserting duplicate buttons.
+
+## Base branch → base version
+
+| PR target branch (`base.ref`) | Base version |
+|-------------------------------|--------------|
+| `MOODLE_404_STABLE`           | 4.4 |
+| `MOODLE_405_STABLE`           | 4.5 |
+| `MOODLE_500_STABLE`           | 5.0 |
+| `MOODLE_501_STABLE`           | 5.1 |
+| `MOODLE_502_STABLE`           | 5.2 |
+| `main` / `master`             | dev |
+
+## Limitations
+
+- The button uses the public GitHub REST API only to read the base branch when it is not in
+  the page DOM (unauthenticated, ~60 requests/hour). The overlay itself runs entirely in your
+  browser.
+- GitHub's and Jira's DOM markup changes over time; if the badge stops appearing, the header
+  selectors in `ghInsertionPoint()` / the tracker scan may need updating.
+- This previews changed **files** over a prebuilt base; the same
+  [limitations as the overlay](blueprint-json.md#limitations) apply (Composer, frontend
+  builds, generated assets, DB upgrades, SQLite/WASM fidelity).
+- It only adds a button for repositories named `moodle`; previewing arbitrary plugin PRs is
+  the job of the [GitHub Action](https://github.com/ateeducacion/action-moodle-playground-pr-preview).
+
+## Credits
+
+Inspired by Sara Arjona ([@sarjona](https://github.com/sarjona)) and Pau Ferrer's
+["Open in Gitpod" tracker userscript](https://gist.github.com/sarjona/9fc728eb2d2b41a783ea03afd6a6161e).

--- a/scripts/moodle-playground-pr-button.user.js
+++ b/scripts/moodle-playground-pr-button.user.js
@@ -1,0 +1,230 @@
+// ==UserScript==
+// @name         Open in Moodle Playground
+// @namespace    https://github.com/ateeducacion/moodle-playground
+// @version      0.1
+// @description  Add an "Open in Moodle Playground" button on Moodle core GitHub pull requests (and Moodle tracker issues that link a PR) to preview the PR with a runtime file overlay. Inspired by Sara Arjona's "Open in Gitpod" tracker userscript.
+// @author       ateeducacion
+// @match        https://github.com/*/pull/*
+// @match        https://moodle.atlassian.net/*
+// @icon         https://www.google.com/s2/favicons?sz=64&domain=moodle.org
+// @grant        none
+// ==/UserScript==
+
+(() => {
+  // ─────────────────────────────────────────────────────────────────────────
+  // Configuration — change PLAYGROUND_HOST to your deployment if needed, e.g.
+  // a branch preview (https://feat-x.moodle-playground.pages.dev) or your own
+  // GitHub Pages host.
+  // ─────────────────────────────────────────────────────────────────────────
+  const PLAYGROUND_HOST = "https://ateeducacion.github.io/moodle-playground";
+  const RUN_UPGRADE = "auto"; // off | on | auto
+  const BUTTON_IMG =
+    "https://raw.githubusercontent.com/ateeducacion/moodle-playground/main/assets/playground-preview-button.svg";
+  const BUTTON_ID = "moodle-playground-preview-button";
+
+  // Map a PR target branch (base.ref) to a Moodle Playground base version. Kept
+  // identical to the action/runtime so the button picks the same base bundle.
+  const BASE_REF_TO_VERSION = {
+    MOODLE_404_STABLE: "4.4",
+    MOODLE_405_STABLE: "4.5",
+    MOODLE_500_STABLE: "5.0",
+    MOODLE_501_STABLE: "5.1",
+    MOODLE_502_STABLE: "5.2",
+    main: "dev",
+    master: "dev",
+  };
+
+  // URL-safe base64 (RFC 4648 §5) of a UTF-8 string, matching how the playground
+  // decodes the ?blueprint= parameter.
+  function toBase64Url(str) {
+    const bytes = new TextEncoder().encode(str);
+    let bin = "";
+    for (const b of bytes) bin += String.fromCharCode(b);
+    return btoa(bin)
+      .replaceAll("+", "-")
+      .replaceAll("/", "_")
+      .replace(/=+$/u, "");
+  }
+
+  // Build a compact repo+pr applyPrOverlay blueprint URL. The runtime fetches the
+  // PR's changed files itself, so the URL stays small regardless of PR size.
+  function buildPlaygroundUrl(repo, pr, baseRef) {
+    const version = BASE_REF_TO_VERSION[baseRef] || "dev";
+    const blueprint = {
+      preferredVersions: { php: "8.3", moodle: version },
+      landingPage: "/admin/index.php",
+      steps: [
+        {
+          step: "installMoodle",
+          options: {
+            siteName: `Moodle core PR #${pr} preview`,
+            adminUser: "admin",
+            adminPass: "password",
+          },
+        },
+        {
+          step: "applyPrOverlay",
+          repo,
+          pr: Number(pr),
+          baseRef: baseRef || "main",
+          runUpgrade: RUN_UPGRADE,
+        },
+        { step: "login", username: "admin" },
+      ],
+    };
+    return `${PLAYGROUND_HOST}/?blueprint=${toBase64Url(JSON.stringify(blueprint))}`;
+  }
+
+  // Build the badge anchor element.
+  function makeButton(url, { block = false } = {}) {
+    const a = document.createElement("a");
+    a.id = BUTTON_ID;
+    a.href = url;
+    a.target = "_blank";
+    a.rel = "noopener noreferrer";
+    a.title = "Preview this pull request in Moodle Playground";
+    a.style.cssText = `display:inline-block;${block ? "margin-top:8px;" : "margin-left:8px;"}vertical-align:middle;`;
+    const img = document.createElement("img");
+    img.src = BUTTON_IMG;
+    img.alt = "Open in Moodle Playground";
+    img.style.cssText = "height:30px;max-width:100%;";
+    a.appendChild(img);
+    return a;
+  }
+
+  // True when an href points at the configured playground host (parsed, not a
+  // substring match).
+  function isPlaygroundLink(href) {
+    try {
+      return (
+        new URL(href, location.href).host === new URL(PLAYGROUND_HOST).host
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  // Prefer a preview link already posted by the GitHub Action (in the PR body or
+  // a comment) so the button matches the action-generated, reproducible preview.
+  function findExistingActionLink() {
+    for (const a of document.querySelectorAll(
+      ".js-comment-body a, .markdown-body a, .comment-body a",
+    )) {
+      if (isPlaygroundLink(a.href)) return a.href;
+    }
+    return null;
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // GitHub pull request pages
+  // ─────────────────────────────────────────────────────────────────────────
+  function githubPrInfo() {
+    const m = location.pathname.match(/^\/([^/]+)\/([^/]+)\/pull\/(\d+)/u);
+    if (!m) return null;
+    const [, owner, repo, pr] = m;
+    // Only Moodle core repositories (moodle/moodle and forks named "moodle").
+    if (repo.toLowerCase() !== "moodle") return null;
+    return { owner, repo, repoFullName: `${owner}/${repo}`, pr };
+  }
+
+  // The base branch shown in the PR header ("base ← compare").
+  function readBaseRefFromDom() {
+    const el = document.querySelector(".base-ref, .commit-ref.base-ref");
+    return el ? el.textContent.trim() : null;
+  }
+
+  async function resolveBaseRef(info) {
+    const fromDom = readBaseRefFromDom();
+    if (fromDom) return fromDom;
+    // Fall back to the public REST API (unauthenticated, CORS-enabled, 60/hour).
+    try {
+      const res = await fetch(
+        `https://api.github.com/repos/${info.repoFullName}/pulls/${info.pr}`,
+        { headers: { Accept: "application/vnd.github+json" } },
+      );
+      if (res.ok) {
+        const data = await res.json();
+        return data?.base?.ref || null;
+      }
+    } catch {
+      /* offline / rate-limited — fall through */
+    }
+    return null;
+  }
+
+  function ghInsertionPoint() {
+    return (
+      document.querySelector(".gh-header-actions") ||
+      document.querySelector(".gh-header-meta") ||
+      document.querySelector(".gh-header-show") ||
+      null
+    );
+  }
+
+  async function injectGithub() {
+    const info = githubPrInfo();
+    if (!info) return;
+    if (document.getElementById(BUTTON_ID)) return; // already injected
+
+    const target = ghInsertionPoint();
+    if (!target) return; // header not rendered yet; the observer will retry
+
+    const baseRef = await resolveBaseRef(info);
+    // Re-check after the await in case another tick already injected it.
+    if (document.getElementById(BUTTON_ID)) return;
+
+    const url =
+      findExistingActionLink() ||
+      buildPlaygroundUrl(info.repoFullName, info.pr, baseRef);
+    target.appendChild(makeButton(url));
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Moodle tracker (Jira) — add a button next to each linked GitHub PR.
+  // Mirrors Sara Arjona's tracker userscript, but resolves a PR (repo + number)
+  // rather than a Gitpod branch, because the overlay previews a pull request.
+  // ─────────────────────────────────────────────────────────────────────────
+  function injectTracker() {
+    for (const a of document.querySelectorAll('a[href*="/pull/"]')) {
+      const m = (() => {
+        try {
+          const u = new URL(a.href, location.href);
+          if (u.host !== "github.com") return null;
+          return u.pathname.match(/^\/([^/]+)\/([^/]+)\/pull\/(\d+)/u);
+        } catch {
+          return null;
+        }
+      })();
+      if (!m) continue;
+      const [, owner, repo, pr] = m;
+      if (repo.toLowerCase() !== "moodle") continue;
+      if (a.dataset.mppButton) continue; // already decorated this link
+      a.dataset.mppButton = "1";
+      const url = buildPlaygroundUrl(`${owner}/${repo}`, pr, null);
+      a.insertAdjacentElement("afterend", makeButton(url, { block: true }));
+    }
+  }
+
+  function tick() {
+    if (location.host === "github.com") injectGithub();
+    else if (location.host === "moodle.atlassian.net") injectTracker();
+  }
+
+  // GitHub and Jira are SPAs: re-run on DOM mutations (debounced) and on a short
+  // interval so the button survives client-side navigation between PRs/issues.
+  let scheduled = false;
+  const schedule = () => {
+    if (scheduled) return;
+    scheduled = true;
+    setTimeout(() => {
+      scheduled = false;
+      tick();
+    }, 400);
+  };
+  new MutationObserver(schedule).observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+  });
+  setInterval(tick, 2000);
+  tick();
+})();

--- a/src/blueprint/php/helpers.js
+++ b/src/blueprint/php/helpers.js
@@ -234,6 +234,66 @@ const PURGE_CACHES_BLOCK = `if (function_exists('theme_reset_all_caches')) {
 }
 purge_all_caches();`;
 
+// Purge Moodle's caches and reset the component registry after core/plugin files
+// have been overwritten at runtime (see the purgeMoodleCaches step and
+// applyPrOverlay). Overwriting core files leaves MUC, the compiled DI container,
+// theme CSS, and the component cache pointing at stale code, so a purge + reset
+// is required before the next request. Wrapped in the graceful exception handler
+// so a failure echoes JSON instead of die(1)-ing the WASM runtime (ADR-0005).
+export function phpPurgeMoodleCaches() {
+  return `${CLI_HEADER}
+${GRACEFUL_HANDLER}
+if (class_exists('core_component')) {
+    \\core_component::reset();
+}
+if (function_exists('theme_reset_all_caches')) {
+    theme_reset_all_caches();
+}
+if (function_exists('purge_all_caches')) {
+    purge_all_caches();
+}
+// Clear the stored version hash so the next request re-detects pending upgrades.
+set_config('allversionshash', '');
+echo json_encode(['ok' => true]);
+`;
+}
+
+// Best-effort Moodle upgrade after a core-file overlay. Mirrors the essential
+// steps of admin/cli/upgrade.php: reset the component cache, load the (overlaid)
+// version.php, run upgrade_core() when the code version is newer than the
+// installed one, then upgrade_noncore(). SQLite/WASM has lower schema-upgrade
+// fidelity than a full Moodle environment (nested savepoints, see ADR-0003), so
+// the inner try/catch reports failures honestly rather than faking success; the
+// caller additionally wraps php.run() in JS try/catch because a DB error can
+// trigger Moodle's default_exception_handler (die(1)) before this catch runs.
+// See ADR-0016. config.php and version.php are loaded by absolute path because
+// php.run() executes without a script file.
+export function phpRunCoreUpgrade() {
+  return `${CLI_HEADER}
+@set_time_limit(0);
+require_once($CFG->libdir . '/upgradelib.php');
+require_once($CFG->libdir . '/adminlib.php');
+require_once($CFG->libdir . '/environmentlib.php');
+\\core_component::reset();
+if (function_exists('purge_all_caches')) { purge_all_caches(); }
+set_config('allversionshash', '');
+$version = null;
+$release = null;
+$branch = null;
+$maturity = null;
+require($CFG->dirroot . '/version.php');
+try {
+    if (isset($version) && $version > $CFG->version) {
+        upgrade_core($version, true);
+    }
+    upgrade_noncore(true);
+    echo json_encode(['ok' => true, 'version' => $version]);
+} catch (\\Throwable $e) {
+    echo json_encode(['ok' => false, 'error' => $e->getMessage()]);
+}
+`;
+}
+
 // Build the optional metadata lines for a Moodle file record. Only emitted when
 // provided; each value is escaped for a single-quoted PHP literal.
 function fileMetaEntries({ author, license, source }) {

--- a/src/blueprint/php/helpers.js
+++ b/src/blueprint/php/helpers.js
@@ -252,6 +252,27 @@ if (function_exists('theme_reset_all_caches')) {
 if (function_exists('purge_all_caches')) {
     purge_all_caches();
 }
+// OPcache holds compiled bytecode for files already included this session. The
+// runtime runs with opcache.validate_timestamps=0 and opcache.file_cache_only=1,
+// so an overwritten core/plugin file would keep serving its OLD bytecode. Reset
+// the cache (mirrors the plugin-manager opcache_reset patch in bootstrap.js) and,
+// because file_cache_only keeps bytecode on disk where reset() may not reach it,
+// delete the on-disk file cache so the next request recompiles from the current
+// sources. All best-effort and non-fatal.
+if (function_exists('opcache_reset')) {
+    @opcache_reset();
+}
+$ocdir = @ini_get('opcache.file_cache');
+if (is_string($ocdir) && $ocdir !== '' && is_dir($ocdir)) {
+    $ocit = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($ocdir, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+    foreach ($ocit as $ocentry) {
+        if ($ocentry->isDir()) { @rmdir($ocentry->getPathname()); }
+        else { @unlink($ocentry->getPathname()); }
+    }
+}
 // Clear the stored version hash so the next request re-detects pending upgrades.
 set_config('allversionshash', '');
 echo json_encode(['ok' => true]);

--- a/src/blueprint/pr-overlay.js
+++ b/src/blueprint/pr-overlay.js
@@ -1,0 +1,252 @@
+/**
+ * Pure helpers for the `applyPrOverlay` blueprint step.
+ *
+ * These functions are intentionally synchronous and side-effect free so they
+ * can be unit tested without a PHP runtime or the network. The step handler in
+ * steps/pr-overlay.js wires them to php.run()/php.writeFile() and fetch().
+ *
+ * The overlay applies the *final* contents of a pull request's changed files on
+ * top of a prebuilt Moodle base in the browser filesystem (whole-file
+ * replacement, never a unified diff). See
+ * docs/decisions/0016-runtime-pr-file-overlay.md for the rationale.
+ */
+
+// Default safety caps. Both can be overridden per step via maxFiles /
+// maxFileBytes. They guard against a runaway PR (thousands of files) or a
+// single huge blob exhausting the WASM heap.
+export const DEFAULT_MAX_OVERLAY_FILES = 200;
+export const DEFAULT_MAX_OVERLAY_FILE_BYTES = 5 * 1024 * 1024; // 5 MiB
+
+// GitHub PR file paths are relative to the repository root. Moodle Playground's
+// Moodle repository root is /www/moodle. For Moodle 5.1+ the web docroot is
+// /www/moodle/public, but PR paths already carry the `public/` prefix, so the
+// overlay root stays /www/moodle and is NOT auto-prefixed.
+export const DEFAULT_OVERLAY_ROOT = "/www/moodle";
+
+// GitHub change statuses mapped to the canonical operations the overlay
+// performs. "changed" and "copied" are GitHub variants we fold into the
+// closest write operation. Anything else is rejected so a misleading preview is
+// never silently produced.
+const STATUS_MAP = {
+  added: "added",
+  modified: "modified",
+  changed: "modified",
+  copied: "added",
+  removed: "removed",
+  deleted: "removed",
+  renamed: "renamed",
+};
+
+// Paths (relative to the repo root) whose change indicates a Moodle upgrade is
+// likely required: the core version file, the public-docroot version file, and
+// any plugin/subsystem db/{install.xml,install.php,upgrade.php}. Kept identical
+// to the action's classifier so both sides agree on `runUpgrade: auto`.
+const UPGRADE_TRIGGER_RE =
+  /^(?:(?:public\/)?version\.php|(?:.*\/)?db\/(?:install\.xml|install\.php|upgrade\.php))$/u;
+
+/**
+ * Validate a single repo-relative overlay path. Throws on anything unsafe.
+ * Returns the path unchanged on success.
+ *
+ * @param {unknown} relPath
+ * @returns {string}
+ */
+export function validateOverlayPath(relPath) {
+  if (typeof relPath !== "string" || relPath.trim() === "") {
+    throw new Error("applyPrOverlay: file path must be a non-empty string.");
+  }
+  if (relPath.includes("\0")) {
+    throw new Error("applyPrOverlay: file path must not contain a null byte.");
+  }
+  // Reject other control characters (anything below U+0020).
+  for (let i = 0; i < relPath.length; i++) {
+    if (relPath.charCodeAt(i) < 0x20) {
+      throw new Error(
+        "applyPrOverlay: file path must not contain control characters.",
+      );
+    }
+  }
+  if (relPath.includes("\\")) {
+    throw new Error(
+      `applyPrOverlay: file path must use '/' separators, not backslashes: ${relPath}`,
+    );
+  }
+  if (relPath.startsWith("/")) {
+    throw new Error(
+      `applyPrOverlay: file path must be relative, not absolute: ${relPath}`,
+    );
+  }
+  const segments = relPath.split("/");
+  for (const seg of segments) {
+    if (seg === "" || seg === "." || seg === "..") {
+      throw new Error(
+        `applyPrOverlay: file path has an unsafe segment ('${seg}'): ${relPath}`,
+      );
+    }
+  }
+  return relPath;
+}
+
+/**
+ * Join a validated repo-relative path onto the overlay root. Defense in depth:
+ * re-checks containment so a write can never escape the root.
+ *
+ * @param {string} root absolute root (e.g. "/www/moodle")
+ * @param {string} relPath repo-relative path
+ * @returns {string} absolute path inside the root
+ */
+export function joinRoot(root, relPath) {
+  const safe = validateOverlayPath(relPath);
+  const base = String(root).replace(/\/+$/u, "");
+  const full = `${base}/${safe}`;
+  if (!full.startsWith(`${base}/`)) {
+    throw new Error(`applyPrOverlay: refusing to write outside root: ${full}`);
+  }
+  return full;
+}
+
+/**
+ * Normalize a raw GitHub change status to a canonical operation.
+ *
+ * @param {unknown} status
+ * @returns {"added"|"modified"|"removed"|"renamed"}
+ */
+export function normalizeStatus(status) {
+  const mapped = STATUS_MAP[String(status || "").toLowerCase()];
+  if (!mapped) {
+    throw new Error(
+      `applyPrOverlay: unsupported file status '${status}'. ` +
+        "Expected one of: added, modified, changed, removed, renamed, copied.",
+    );
+  }
+  return mapped;
+}
+
+/**
+ * Normalize an overlay manifest into validated operations. Each entry becomes
+ * `{ path, status, rawUrl, previousPath, size }`. Throws on any structural or
+ * path-safety problem so a malformed manifest fails loudly instead of producing
+ * a misleading preview.
+ *
+ * @param {unknown} files
+ * @returns {Array<{path: string, status: string, rawUrl: string|null, previousPath: string|null, size: number|null}>}
+ */
+export function normalizeOverlayManifest(files) {
+  if (!Array.isArray(files)) {
+    throw new Error("applyPrOverlay: 'files' must be an array.");
+  }
+  return files.map((file, i) => {
+    if (!file || typeof file !== "object" || Array.isArray(file)) {
+      throw new Error(`applyPrOverlay: files[${i}] must be an object.`);
+    }
+    const status = normalizeStatus(file.status);
+    validateOverlayPath(file.path);
+
+    const op = {
+      path: file.path,
+      status,
+      rawUrl: typeof file.rawUrl === "string" ? file.rawUrl : null,
+      previousPath:
+        typeof file.previousPath === "string" ? file.previousPath : null,
+      size: typeof file.size === "number" ? file.size : null,
+    };
+
+    if (status === "renamed") {
+      if (!op.previousPath) {
+        throw new Error(
+          `applyPrOverlay: files[${i}] is renamed but has no 'previousPath'.`,
+        );
+      }
+      validateOverlayPath(op.previousPath);
+    }
+
+    // Added/modified/renamed entries need a rawUrl to fetch the new content;
+    // removed entries do not.
+    if (status !== "removed" && !op.rawUrl) {
+      throw new Error(
+        `applyPrOverlay: files[${i}] (${status}) requires a 'rawUrl' to fetch its contents.`,
+      );
+    }
+
+    return op;
+  });
+}
+
+/**
+ * Decide whether the changed files indicate a Moodle upgrade is likely needed.
+ * Accepts either raw manifest entries or normalized operations (objects with a
+ * `path`) or bare path strings.
+ *
+ * @param {Array<string|{path?: string, previousPath?: string}>} files
+ * @returns {boolean}
+ */
+export function overlayNeedsUpgrade(files) {
+  const list = Array.isArray(files) ? files : [];
+  return list.some((entry) => {
+    const candidates =
+      typeof entry === "string" ? [entry] : [entry?.path, entry?.previousPath];
+    return candidates.some(
+      (p) => typeof p === "string" && UPGRADE_TRIGGER_RE.test(p),
+    );
+  });
+}
+
+/**
+ * Normalize the runUpgrade option to one of "off" | "on" | "auto".
+ * Defaults to "auto" when unset. Throws on an unrecognized value.
+ *
+ * @param {unknown} value
+ * @returns {"off"|"on"|"auto"}
+ */
+export function normalizeRunUpgrade(value) {
+  if (value === undefined || value === null || value === "") {
+    return "auto";
+  }
+  const v = String(value).toLowerCase();
+  if (["off", "false", "no", "0"].includes(v)) return "off";
+  if (["on", "true", "yes", "1"].includes(v)) return "on";
+  if (v === "auto") return "auto";
+  throw new Error(
+    `applyPrOverlay: invalid runUpgrade '${value}' (expected off, on, or auto).`,
+  );
+}
+
+/**
+ * Build the GitHub REST API URL listing a pull request's changed files.
+ *
+ * @param {string} repo "owner/name"
+ * @param {number|string} pr pull request number
+ * @param {{page?: number, perPage?: number}} [opts]
+ * @returns {string}
+ */
+export function buildPrFilesApiUrl(repo, pr, { page = 1, perPage = 100 } = {}) {
+  const prNumber = parseInt(pr, 10);
+  if (!repo || !/^[^/]+\/[^/]+$/u.test(String(repo))) {
+    throw new Error(
+      `applyPrOverlay: invalid repo '${repo}' (expected owner/name).`,
+    );
+  }
+  if (!Number.isInteger(prNumber) || prNumber <= 0) {
+    throw new Error(`applyPrOverlay: invalid pr '${pr}'.`);
+  }
+  return (
+    `https://api.github.com/repos/${repo}/pulls/${prNumber}/files` +
+    `?per_page=${perPage}&page=${page}`
+  );
+}
+
+/**
+ * Optionally route a GitHub URL through a CORS/caching proxy. When no proxy is
+ * given the URL is returned unchanged (direct GitHub endpoints are the default
+ * and work for public repos). The proxy is expected to accept a URL-passthrough
+ * `?url=` parameter.
+ *
+ * @param {string} url
+ * @param {string} [proxy] proxy base URL
+ * @returns {string}
+ */
+export function applyProxy(url, proxy) {
+  if (!proxy) return url;
+  const base = String(proxy).replace(/\/+$/u, "");
+  return `${base}/?url=${encodeURIComponent(url)}`;
+}

--- a/src/blueprint/pr-overlay.js
+++ b/src/blueprint/pr-overlay.js
@@ -236,6 +236,50 @@ export function buildPrFilesApiUrl(repo, pr, { page = 1, perPage = 100 } = {}) {
 }
 
 /**
+ * Build the GitHub REST API URL for a single pull request (used to resolve the
+ * head repo + head SHA before building raw file URLs).
+ *
+ * @param {string} repo "owner/name"
+ * @param {number|string} pr pull request number
+ * @returns {string}
+ */
+export function buildPrApiUrl(repo, pr) {
+  const prNumber = parseInt(pr, 10);
+  if (!repo || !/^[^/]+\/[^/]+$/u.test(String(repo))) {
+    throw new Error(
+      `applyPrOverlay: invalid repo '${repo}' (expected owner/name).`,
+    );
+  }
+  if (!Number.isInteger(prNumber) || prNumber <= 0) {
+    throw new Error(`applyPrOverlay: invalid pr '${pr}'.`);
+  }
+  return `https://api.github.com/repos/${repo}/pulls/${prNumber}`;
+}
+
+/**
+ * Build a CORS-accessible raw.githubusercontent.com URL for a file at a commit.
+ *
+ * The GitHub pulls/files API returns `raw_url` as a `github.com/<o>/<r>/raw/...`
+ * URL, which is a 302 redirect that browsers CANNOT fetch cross-origin (no CORS
+ * headers). raw.githubusercontent.com serves the same content with
+ * `access-control-allow-origin: *`, including a PR head commit referenced via
+ * either the head (fork) repo or the base repo. Each path segment is URL-encoded
+ * while `/` separators are preserved.
+ *
+ * @param {string} repoFullName "owner/name"
+ * @param {string} sha commit SHA
+ * @param {string} filename repo-relative path
+ * @returns {string}
+ */
+export function buildRawGithubUrl(repoFullName, sha, filename) {
+  const encodedPath = String(filename)
+    .split("/")
+    .map(encodeURIComponent)
+    .join("/");
+  return `https://raw.githubusercontent.com/${repoFullName}/${sha}/${encodedPath}`;
+}
+
+/**
  * Optionally route a GitHub URL through a CORS/caching proxy. When no proxy is
  * given the URL is returned unchanged (direct GitHub endpoints are the default
  * and work for public repos). The proxy is expected to accept a URL-passthrough

--- a/src/blueprint/schema.js
+++ b/src/blueprint/schema.js
@@ -37,10 +37,14 @@ const KNOWN_STEP_NAMES = new Set([
   "writeFiles",
   "copyFile",
   "moveFile",
+  "deleteFile",
+  "deleteFiles",
   "unzip",
   "request",
   "runPhpCode",
   "runPhpScript",
+  "purgeMoodleCaches",
+  "applyPrOverlay",
 ]);
 
 const RESOURCE_TYPE_KEYS = new Set([

--- a/src/blueprint/steps/filesystem.js
+++ b/src/blueprint/steps/filesystem.js
@@ -3,6 +3,7 @@
  */
 import { readZipEntries } from "../../../lib/moodle-loader.js";
 import { escapePhp } from "../php/helpers.js";
+import { checkPhpResult } from "./check-result.js";
 
 export function registerFilesystemSteps(register) {
   register("mkdir", handleMkdir);
@@ -11,6 +12,8 @@ export function registerFilesystemSteps(register) {
   register("writeFiles", handleWriteFiles);
   register("copyFile", handleCopyFile);
   register("moveFile", handleMoveFile);
+  register("deleteFile", handleDeleteFile);
+  register("deleteFiles", handleDeleteFiles);
   register("unzip", handleUnzip);
 }
 
@@ -104,6 +107,32 @@ async function handleMoveFile(step, { php }) {
   const data = await php.readFile(from);
   await php.writeFile(to, data);
   await php.run(`<?php @unlink('${escapePhp(from)}');`);
+}
+
+async function handleDeleteFile(step, { php }) {
+  const path = step.path;
+  if (!path) throw new Error("deleteFile: 'path' is required.");
+
+  // Idempotent: a missing file is not an error (echo skipped), but a real
+  // unlink failure is surfaced via checkPhpResult.
+  const result = await php.run(`<?php
+$p = '${escapePhp(path)}';
+if (!file_exists($p)) { echo json_encode(['ok' => true, 'skipped' => true]); }
+else if (@unlink($p)) { echo json_encode(['ok' => true]); }
+else { echo json_encode(['ok' => false, 'error' => 'Could not delete ' . $p]); }
+`);
+  checkPhpResult(result, "deleteFile");
+}
+
+async function handleDeleteFiles(step, context) {
+  if (!Array.isArray(step.files))
+    throw new Error("deleteFiles: 'files' must be an array.");
+
+  // Each entry may be a string path or an object with a `path` property.
+  for (const entry of step.files) {
+    const path = typeof entry === "string" ? entry : entry?.path;
+    await handleDeleteFile({ path }, context);
+  }
 }
 
 async function handleUnzip(step, { php, resources }) {

--- a/src/blueprint/steps/index.js
+++ b/src/blueprint/steps/index.js
@@ -13,6 +13,7 @@ import { registerMoodleRestoreSteps } from "./moodle-restore.js";
 import { registerMoodleRoleSteps } from "./moodle-roles.js";
 import { registerMoodleScaleSteps } from "./moodle-scales.js";
 import { registerMoodleUserSteps } from "./moodle-users.js";
+import { registerPrOverlaySteps } from "./pr-overlay.js";
 import { registerRequestSteps } from "./request.js";
 
 /** @type {Map<string, (step: object, context: object) => Promise<void>>} */
@@ -47,3 +48,4 @@ registerMoodlePluginSteps(registerStep);
 registerMoodleRoleSteps(registerStep);
 registerMoodleScaleSteps(registerStep);
 registerMoodleCohortSteps(registerStep);
+registerPrOverlaySteps(registerStep);

--- a/src/blueprint/steps/pr-overlay.js
+++ b/src/blueprint/steps/pr-overlay.js
@@ -79,27 +79,46 @@ async function handleApplyPrOverlay(step, { php, publish }) {
   }
 
   // 2. Apply each operation. Whole-file replacement handles add/modify/remove/
-  //    rename predictably; paths are validated by joinRoot before any write.
+  //    rename predictably; paths were validated by normalizeOverlayManifest.
+  //    Each file is applied independently: a single unreachable / oversized /
+  //    failed file is skipped with a visible warning rather than aborting the
+  //    whole preview (so the remaining files and the login step still run).
   let written = 0;
   let removed = 0;
+  let skipped = 0;
   for (const op of ops) {
-    if (op.status === "removed") {
-      await deletePath(php, joinRoot(root, op.path));
-      removed++;
-    } else if (op.status === "renamed") {
-      await deletePath(php, joinRoot(root, op.previousPath));
-      const bytes = await fetchBytes(op.rawUrl, step.proxy, maxFileBytes);
-      await writePath(php, joinRoot(root, op.path), bytes);
-      written++;
-    } else {
-      // added | modified
-      const bytes = await fetchBytes(op.rawUrl, step.proxy, maxFileBytes);
-      await writePath(php, joinRoot(root, op.path), bytes);
-      written++;
+    try {
+      if (op.status === "removed") {
+        await deletePath(php, joinRoot(root, op.path));
+        removed++;
+      } else if (op.status === "renamed") {
+        await deletePath(php, joinRoot(root, op.previousPath));
+        const bytes = await fetchBytes(op.rawUrl, step.proxy, maxFileBytes);
+        await writePath(php, joinRoot(root, op.path), bytes);
+        written++;
+      } else {
+        // added | modified
+        const bytes = await fetchBytes(op.rawUrl, step.proxy, maxFileBytes);
+        await writePath(php, joinRoot(root, op.path), bytes);
+        written++;
+      }
+    } catch (err) {
+      skipped++;
+      if (publish) {
+        publish(
+          `Overlay: skipped ${op.path} (${String(err?.message || err).slice(0, 160)})`,
+          0.94,
+        );
+      }
     }
   }
   if (publish) {
-    publish(`Overlay applied: ${written} written, ${removed} removed.`, 0.94);
+    publish(
+      `Overlay applied: ${written} written, ${removed} removed${
+        skipped ? `, ${skipped} skipped` : ""
+      }.`,
+      0.94,
+    );
   }
 
   // 3. Purge caches by default (core files just changed under MUC's feet).
@@ -174,6 +193,16 @@ async function fetchBytes(rawUrl, proxy, maxBytes) {
     throw new Error(
       `applyPrOverlay: failed to fetch ${rawUrl} (HTTP ${res.status}).`,
     );
+  }
+  // Reject oversized files by their declared length before buffering the body,
+  // so a huge blob never gets fully materialized into the worker heap.
+  if (maxBytes) {
+    const declared = Number(res.headers?.get?.("content-length"));
+    if (Number.isFinite(declared) && declared > maxBytes) {
+      throw new Error(
+        `applyPrOverlay: ${rawUrl} is ${declared} bytes (> maxFileBytes=${maxBytes}).`,
+      );
+    }
   }
   const bytes = new Uint8Array(await res.arrayBuffer());
   if (maxBytes && bytes.byteLength > maxBytes) {

--- a/src/blueprint/steps/pr-overlay.js
+++ b/src/blueprint/steps/pr-overlay.js
@@ -1,0 +1,243 @@
+/**
+ * PR overlay step handlers: purgeMoodleCaches, applyPrOverlay.
+ *
+ * applyPrOverlay applies the final contents of a pull request's changed files on
+ * top of an already-booted, prebuilt Moodle base (whole-file replacement), then
+ * purges caches and optionally runs Moodle's upgrade. It powers the "PR Overlay
+ * Preview" feature: a Moodle core PR is previewed by booting the base for its
+ * target branch and overlaying the changed files at runtime in the browser
+ * filesystem — no per-PR WASM bundle is built.
+ *
+ * See docs/decisions/0016-runtime-pr-file-overlay.md.
+ */
+import {
+  escapePhp,
+  phpPurgeMoodleCaches,
+  phpRunCoreUpgrade,
+} from "../php/helpers.js";
+import {
+  applyProxy,
+  buildPrFilesApiUrl,
+  DEFAULT_MAX_OVERLAY_FILE_BYTES,
+  DEFAULT_MAX_OVERLAY_FILES,
+  DEFAULT_OVERLAY_ROOT,
+  joinRoot,
+  normalizeOverlayManifest,
+  normalizeRunUpgrade,
+  overlayNeedsUpgrade,
+} from "../pr-overlay.js";
+import { checkPhpResult } from "./check-result.js";
+
+export function registerPrOverlaySteps(register) {
+  register("purgeMoodleCaches", handlePurgeMoodleCaches);
+  register("applyPrOverlay", handleApplyPrOverlay);
+}
+
+/**
+ * Purge Moodle's caches and reset the component registry. Safe to run after
+ * core files are overwritten. Surfaces a failure by throwing (checkPhpResult).
+ */
+async function handlePurgeMoodleCaches(_step, { php }) {
+  const result = await php.run(phpPurgeMoodleCaches());
+  checkPhpResult(result, "purgeMoodleCaches");
+}
+
+/**
+ * Apply a pull request's changed files over the booted Moodle base.
+ */
+async function handleApplyPrOverlay(step, { php, publish }) {
+  const root = step.root || DEFAULT_OVERLAY_ROOT;
+  const maxFiles = Number.isFinite(step.maxFiles)
+    ? step.maxFiles
+    : DEFAULT_MAX_OVERLAY_FILES;
+  const maxFileBytes = Number.isFinite(step.maxFileBytes)
+    ? step.maxFileBytes
+    : DEFAULT_MAX_OVERLAY_FILE_BYTES;
+  const runUpgrade = normalizeRunUpgrade(step.runUpgrade);
+
+  // 1. Resolve the manifest: an explicit pre-resolved `files` list, or a
+  //    `repo` + `pr` pair fetched from the GitHub API at runtime.
+  let rawFiles;
+  if (Array.isArray(step.files)) {
+    rawFiles = step.files;
+  } else if (step.repo && step.pr) {
+    if (publish) {
+      publish(`Fetching changed files for ${step.repo}#${step.pr}…`, 0.93);
+    }
+    rawFiles = await fetchPrFiles(step.repo, step.pr, step.proxy);
+  } else {
+    throw new Error(
+      "applyPrOverlay: provide a 'files' manifest, or both 'repo' and 'pr'.",
+    );
+  }
+
+  const ops = normalizeOverlayManifest(rawFiles);
+  if (ops.length > maxFiles) {
+    throw new Error(
+      `applyPrOverlay: ${ops.length} changed files exceed maxFiles=${maxFiles}.`,
+    );
+  }
+
+  // 2. Apply each operation. Whole-file replacement handles add/modify/remove/
+  //    rename predictably; paths are validated by joinRoot before any write.
+  let written = 0;
+  let removed = 0;
+  for (const op of ops) {
+    if (op.status === "removed") {
+      await deletePath(php, joinRoot(root, op.path));
+      removed++;
+    } else if (op.status === "renamed") {
+      await deletePath(php, joinRoot(root, op.previousPath));
+      const bytes = await fetchBytes(op.rawUrl, step.proxy, maxFileBytes);
+      await writePath(php, joinRoot(root, op.path), bytes);
+      written++;
+    } else {
+      // added | modified
+      const bytes = await fetchBytes(op.rawUrl, step.proxy, maxFileBytes);
+      await writePath(php, joinRoot(root, op.path), bytes);
+      written++;
+    }
+  }
+  if (publish) {
+    publish(`Overlay applied: ${written} written, ${removed} removed.`, 0.94);
+  }
+
+  // 3. Purge caches by default (core files just changed under MUC's feet).
+  if (step.purgeCaches !== false) {
+    await runPhpGraceful(
+      php,
+      phpPurgeMoodleCaches(),
+      "applyPrOverlay cache purge",
+      publish,
+    );
+  }
+
+  // 4. Run the upgrade according to runUpgrade (off | on | auto).
+  const shouldUpgrade =
+    runUpgrade === "on" || (runUpgrade === "auto" && overlayNeedsUpgrade(ops));
+  if (shouldUpgrade) {
+    if (publish) publish("Running Moodle upgrade after overlay…", 0.945);
+    const res = await runPhpGraceful(
+      php,
+      phpRunCoreUpgrade(),
+      "applyPrOverlay upgrade",
+      publish,
+    );
+    if (!res.ok && publish) {
+      publish(
+        "Moodle upgrade did not complete cleanly; this runtime preview may be " +
+          "partial (SQLite/WASM has lower schema-upgrade fidelity). See KNOWN-ISSUES.",
+        0.95,
+      );
+    }
+  }
+}
+
+/**
+ * Delete a file if it exists. Idempotent (a missing file is not an error), but a
+ * real unlink failure is surfaced via checkPhpResult.
+ */
+async function deletePath(php, fullPath) {
+  const result = await php.run(`<?php
+$p = '${escapePhp(fullPath)}';
+if (!file_exists($p)) { echo json_encode(['ok' => true, 'skipped' => true]); }
+else if (@unlink($p)) { echo json_encode(['ok' => true]); }
+else { echo json_encode(['ok' => false, 'error' => 'Could not delete ' . $p]); }
+`);
+  checkPhpResult(result, "applyPrOverlay:delete");
+}
+
+/**
+ * Write bytes to a path, creating parent directories first. Binary-safe: bytes
+ * are written verbatim via php.writeFile().
+ */
+async function writePath(php, fullPath, bytes) {
+  const parent = fullPath.substring(0, fullPath.lastIndexOf("/"));
+  if (parent) {
+    if (php._php?.mkdirTree) {
+      php._php.mkdirTree(parent);
+    } else {
+      await php.run(`<?php @mkdir('${escapePhp(parent)}', 0777, true);`);
+    }
+  }
+  await php.writeFile(fullPath, bytes);
+}
+
+/**
+ * Fetch a single file's bytes, optionally through a proxy, enforcing a per-file
+ * size cap.
+ */
+async function fetchBytes(rawUrl, proxy, maxBytes) {
+  const target = applyProxy(rawUrl, proxy);
+  const res = await fetch(target);
+  if (!res.ok) {
+    throw new Error(
+      `applyPrOverlay: failed to fetch ${rawUrl} (HTTP ${res.status}).`,
+    );
+  }
+  const bytes = new Uint8Array(await res.arrayBuffer());
+  if (maxBytes && bytes.byteLength > maxBytes) {
+    throw new Error(
+      `applyPrOverlay: ${rawUrl} is ${bytes.byteLength} bytes (> maxFileBytes=${maxBytes}).`,
+    );
+  }
+  return bytes;
+}
+
+/**
+ * Fetch the changed-files manifest for a PR from the GitHub REST API, following
+ * pagination. Each entry's raw_url is already pinned to the PR head SHA.
+ */
+async function fetchPrFiles(repo, pr, proxy) {
+  const out = [];
+  for (let page = 1; page <= 100; page++) {
+    const url = applyProxy(buildPrFilesApiUrl(repo, pr, { page }), proxy);
+    const res = await fetch(url, {
+      headers: { Accept: "application/vnd.github+json" },
+    });
+    if (!res.ok) {
+      throw new Error(
+        `applyPrOverlay: GitHub API returned HTTP ${res.status} for ${repo}#${pr}.`,
+      );
+    }
+    const batch = await res.json();
+    if (!Array.isArray(batch) || batch.length === 0) break;
+    for (const f of batch) {
+      out.push({
+        path: f.filename,
+        status: f.status,
+        rawUrl: f.raw_url || null,
+        previousPath: f.previous_filename || null,
+        size: null,
+      });
+    }
+    if (batch.length < 100) break;
+  }
+  return out;
+}
+
+/**
+ * Run a PHP generator, treating failures as non-fatal: a crash (non-zero exit)
+ * or a JSON {"ok":false} result is reported via publish() instead of aborting
+ * the blueprint, because the overlay files are already in place.
+ */
+async function runPhpGraceful(php, code, label, publish) {
+  let result;
+  try {
+    result = await php.run(code);
+  } catch (err) {
+    if (publish) {
+      publish(
+        `${label} crashed: ${String(err?.message || err).slice(0, 200)}`,
+        0.95,
+      );
+    }
+    return { ok: false, crashed: true };
+  }
+  const text = result?.text || "";
+  if (result?.errors && publish) {
+    publish(`${label} warnings: ${String(result.errors).slice(0, 200)}`, 0.95);
+  }
+  const ok = !text.includes('"ok":false');
+  return { ok, text };
+}

--- a/src/blueprint/steps/pr-overlay.js
+++ b/src/blueprint/steps/pr-overlay.js
@@ -17,7 +17,9 @@ import {
 } from "../php/helpers.js";
 import {
   applyProxy,
+  buildPrApiUrl,
   buildPrFilesApiUrl,
+  buildRawGithubUrl,
   DEFAULT_MAX_OVERLAY_FILE_BYTES,
   DEFAULT_MAX_OVERLAY_FILES,
   DEFAULT_OVERLAY_ROOT,
@@ -218,6 +220,26 @@ async function fetchBytes(rawUrl, proxy, maxBytes) {
  * pagination. Each entry's raw_url is already pinned to the PR head SHA.
  */
 async function fetchPrFiles(repo, pr, proxy) {
+  // Resolve the PR head repo + SHA first. The pulls/files API's own `raw_url`
+  // is a github.com/.../raw/... redirect that is NOT CORS-accessible from the
+  // browser, so we build raw.githubusercontent.com URLs from the head instead.
+  const prRes = await fetch(applyProxy(buildPrApiUrl(repo, pr), proxy), {
+    headers: { Accept: "application/vnd.github+json" },
+  });
+  if (!prRes.ok) {
+    throw new Error(
+      `applyPrOverlay: GitHub API returned HTTP ${prRes.status} for ${repo}#${pr}.`,
+    );
+  }
+  const prData = await prRes.json();
+  const headRepoFullName = prData?.head?.repo?.full_name || repo;
+  const headSha = prData?.head?.sha;
+  if (!headSha) {
+    throw new Error(
+      `applyPrOverlay: could not resolve the head SHA for ${repo}#${pr}.`,
+    );
+  }
+
   const out = [];
   for (let page = 1; page <= 100; page++) {
     const url = applyProxy(buildPrFilesApiUrl(repo, pr, { page }), proxy);
@@ -232,10 +254,13 @@ async function fetchPrFiles(repo, pr, proxy) {
     const batch = await res.json();
     if (!Array.isArray(batch) || batch.length === 0) break;
     for (const f of batch) {
+      const removed = String(f.status || "").toLowerCase() === "removed";
       out.push({
         path: f.filename,
         status: f.status,
-        rawUrl: f.raw_url || null,
+        rawUrl: removed
+          ? null
+          : buildRawGithubUrl(headRepoFullName, headSha, f.filename),
         previousPath: f.previous_filename || null,
         size: null,
       });

--- a/tests/blueprint/php-helpers.test.js
+++ b/tests/blueprint/php-helpers.test.js
@@ -604,6 +604,10 @@ describe("PHP helpers: phpPurgeMoodleCaches", () => {
     assert.ok(script.includes("purge_all_caches()"));
     assert.ok(script.includes("core_component::reset()"));
     assert.ok(script.includes("theme_reset_all_caches()"));
+    // OPcache must be reset (and its file cache cleared) so overwritten files
+    // do not keep serving stale bytecode under validate_timestamps=0.
+    assert.ok(script.includes("opcache_reset()"));
+    assert.ok(script.includes("opcache.file_cache"));
     assert.ok(script.includes("set_config('allversionshash', '')"));
     assert.ok(script.includes('"ok"') || script.includes("'ok'"));
   });

--- a/tests/blueprint/php-helpers.test.js
+++ b/tests/blueprint/php-helpers.test.js
@@ -9,6 +9,8 @@ import {
   phpCreateUsers,
   phpEnrolUser,
   phpLogin,
+  phpPurgeMoodleCaches,
+  phpRunCoreUpgrade,
   phpSetAdminAccount,
   phpSetConfig,
   phpSetConfigFile,
@@ -592,5 +594,29 @@ describe("PHP helpers: setConfigFiles", () => {
       }),
     );
     assert.ok(script.includes("x\\'y.jpg"));
+  });
+});
+
+describe("PHP helpers: phpPurgeMoodleCaches", () => {
+  it("bootstraps Moodle and purges caches + component registry", () => {
+    const script = phpPurgeMoodleCaches();
+    assert.ok(script.includes("require('/www/moodle/config.php')"));
+    assert.ok(script.includes("purge_all_caches()"));
+    assert.ok(script.includes("core_component::reset()"));
+    assert.ok(script.includes("theme_reset_all_caches()"));
+    assert.ok(script.includes("set_config('allversionshash', '')"));
+    assert.ok(script.includes('"ok"') || script.includes("'ok'"));
+  });
+});
+
+describe("PHP helpers: phpRunCoreUpgrade", () => {
+  it("loads the overlaid version.php and runs core + noncore upgrade", () => {
+    const script = phpRunCoreUpgrade();
+    assert.ok(script.includes("require($CFG->dirroot . '/version.php')"));
+    assert.ok(script.includes("upgrade_core($version, true)"));
+    assert.ok(script.includes("upgrade_noncore(true)"));
+    // Honest reporting: a Throwable becomes ok:false rather than faked success.
+    assert.ok(script.includes("'ok' => false"));
+    assert.ok(script.includes("'ok' => true"));
   });
 });

--- a/tests/blueprint/pr-overlay.test.js
+++ b/tests/blueprint/pr-overlay.test.js
@@ -52,6 +52,7 @@ function okBytesResponse(bytes) {
   return {
     ok: true,
     status: 200,
+    headers: { get: () => String(bytes.byteLength) },
     async arrayBuffer() {
       return bytes.buffer.slice(
         bytes.byteOffset,
@@ -291,6 +292,7 @@ describe("purgeMoodleCaches step", () => {
     const code = php.runCalls[0];
     assert.match(code, /purge_all_caches/);
     assert.match(code, /core_component::reset/);
+    assert.match(code, /opcache_reset/);
     assert.match(code, /allversionshash/);
   });
 });
@@ -415,6 +417,44 @@ describe("applyPrOverlay step", () => {
     await assert.rejects(
       () => handler({}, { php: createMockPhp() }),
       /provide a 'files' manifest/,
+    );
+  });
+
+  it("skips a single failing file instead of aborting the whole overlay", async () => {
+    const php = createMockPhp();
+    const handler = getStepHandler("applyPrOverlay");
+    // First fetch fails (e.g. 404 from a force-pushed SHA), second succeeds.
+    let call = 0;
+    await withFetch(
+      async () => {
+        call++;
+        if (call === 1) return { ok: false, status: 404 };
+        return okBytesResponse(new Uint8Array([1, 2]));
+      },
+      () =>
+        handler(
+          {
+            runUpgrade: "off",
+            files: [
+              {
+                path: "lib/bad.php",
+                status: "modified",
+                rawUrl: "https://raw/bad",
+              },
+              {
+                path: "lib/good.php",
+                status: "modified",
+                rawUrl: "https://raw/good",
+              },
+            ],
+          },
+          { php },
+        ),
+    );
+    // The good file is still written even though the bad one failed.
+    assert.deepStrictEqual(
+      php.writes.map((w) => w.path),
+      ["/www/moodle/lib/good.php"],
     );
   });
 });

--- a/tests/blueprint/pr-overlay.test.js
+++ b/tests/blueprint/pr-overlay.test.js
@@ -267,7 +267,8 @@ describe("buildPrApiUrl / buildRawGithubUrl", () => {
       url,
       "https://raw.githubusercontent.com/nadeemmhdm/moodle/952df34/public/mod/quiz/view.php",
     );
-    assert.ok(!url.includes("github.com/")); // must not be the redirect host
+    // Must be the CORS-enabled raw host, not the github.com redirect host.
+    assert.strictEqual(new URL(url).host, "raw.githubusercontent.com");
   });
 
   it("URL-encodes path segments but keeps slashes", () => {
@@ -495,13 +496,13 @@ describe("applyPrOverlay step", () => {
     const rawFetch = fetched.find((u) =>
       u.includes("public/mod/quiz/view.php"),
     );
+    assert.strictEqual(new URL(rawFetch).host, "raw.githubusercontent.com");
     assert.ok(
       rawFetch.startsWith(
         "https://raw.githubusercontent.com/fork/moodle/deadbeef/",
       ),
       `expected raw.githubusercontent URL, got ${rawFetch}`,
     );
-    assert.ok(!rawFetch.includes("github.com/fork/moodle/raw"));
     // Modified file written, removed file deleted.
     assert.deepStrictEqual(
       php.writes.map((w) => w.path),

--- a/tests/blueprint/pr-overlay.test.js
+++ b/tests/blueprint/pr-overlay.test.js
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   applyProxy,
+  buildPrApiUrl,
   buildPrFilesApiUrl,
+  buildRawGithubUrl,
   DEFAULT_OVERLAY_ROOT,
   joinRoot,
   normalizeOverlayManifest,
@@ -246,6 +248,36 @@ describe("buildPrFilesApiUrl / applyProxy", () => {
   });
 });
 
+describe("buildPrApiUrl / buildRawGithubUrl", () => {
+  it("builds the single-PR API URL", () => {
+    assert.strictEqual(
+      buildPrApiUrl("moodle/moodle", 532),
+      "https://api.github.com/repos/moodle/moodle/pulls/532",
+    );
+    assert.throws(() => buildPrApiUrl("nope", 1), /invalid repo/);
+  });
+
+  it("builds a CORS-accessible raw.githubusercontent.com URL (never github.com/raw)", () => {
+    const url = buildRawGithubUrl(
+      "nadeemmhdm/moodle",
+      "952df34",
+      "public/mod/quiz/view.php",
+    );
+    assert.strictEqual(
+      url,
+      "https://raw.githubusercontent.com/nadeemmhdm/moodle/952df34/public/mod/quiz/view.php",
+    );
+    assert.ok(!url.includes("github.com/")); // must not be the redirect host
+  });
+
+  it("URL-encodes path segments but keeps slashes", () => {
+    assert.strictEqual(
+      buildRawGithubUrl("o/r", "sha", "lang/en/a b.php"),
+      "https://raw.githubusercontent.com/o/r/sha/lang/en/a%20b.php",
+    );
+  });
+});
+
 describe("deleteFile / deleteFiles steps", () => {
   it("deleteFile runs an idempotent unlink", async () => {
     const php = createMockPhp();
@@ -417,6 +449,68 @@ describe("applyPrOverlay step", () => {
     await assert.rejects(
       () => handler({}, { php: createMockPhp() }),
       /provide a 'files' manifest/,
+    );
+  });
+
+  it("repo+pr mode resolves the head and fetches CORS-friendly raw URLs", async () => {
+    const php = createMockPhp();
+    const handler = getStepHandler("applyPrOverlay");
+    const fetched = [];
+    await withFetch(
+      async (url) => {
+        fetched.push(url);
+        if (/\/pulls\/532$/.test(url)) {
+          // The single-PR API call resolves the head repo + SHA.
+          return {
+            ok: true,
+            status: 200,
+            async json() {
+              return {
+                head: { repo: { full_name: "fork/moodle" }, sha: "deadbeef" },
+              };
+            },
+          };
+        }
+        if (/\/pulls\/532\/files/.test(url)) {
+          return {
+            ok: true,
+            status: 200,
+            async json() {
+              return [
+                { filename: "public/mod/quiz/view.php", status: "modified" },
+                { filename: "lib/old.php", status: "removed" },
+              ];
+            },
+          };
+        }
+        // Raw file content.
+        return okBytesResponse(new Uint8Array([1, 2, 3]));
+      },
+      () =>
+        handler({ repo: "moodle/moodle", pr: 532, runUpgrade: "off" }, { php }),
+    );
+
+    // The raw fetch must hit raw.githubusercontent.com (NOT github.com/raw,
+    // which 302s without CORS and broke the first live test).
+    const rawFetch = fetched.find((u) =>
+      u.includes("public/mod/quiz/view.php"),
+    );
+    assert.ok(
+      rawFetch.startsWith(
+        "https://raw.githubusercontent.com/fork/moodle/deadbeef/",
+      ),
+      `expected raw.githubusercontent URL, got ${rawFetch}`,
+    );
+    assert.ok(!rawFetch.includes("github.com/fork/moodle/raw"));
+    // Modified file written, removed file deleted.
+    assert.deepStrictEqual(
+      php.writes.map((w) => w.path),
+      ["/www/moodle/public/mod/quiz/view.php"],
+    );
+    assert.ok(
+      php.runCalls.some(
+        (c) => c.includes("@unlink") && c.includes("lib/old.php"),
+      ),
     );
   });
 

--- a/tests/blueprint/pr-overlay.test.js
+++ b/tests/blueprint/pr-overlay.test.js
@@ -1,0 +1,420 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  applyProxy,
+  buildPrFilesApiUrl,
+  DEFAULT_OVERLAY_ROOT,
+  joinRoot,
+  normalizeOverlayManifest,
+  normalizeRunUpgrade,
+  normalizeStatus,
+  overlayNeedsUpgrade,
+  validateOverlayPath,
+} from "../../src/blueprint/pr-overlay.js";
+import { getStepHandler } from "../../src/blueprint/steps/index.js";
+
+// A fake PHP instance that records executed code, file writes, and mkdir calls.
+function createMockPhp() {
+  const runCalls = [];
+  const writes = [];
+  const mkdirs = [];
+  return {
+    runCalls,
+    writes,
+    mkdirs,
+    async run(code) {
+      runCalls.push(code);
+      return { text: '{"ok":true}', errors: "" };
+    },
+    async writeFile(path, data) {
+      writes.push({ path, data });
+    },
+    _php: {
+      mkdirTree(dir) {
+        mkdirs.push(dir);
+      },
+    },
+  };
+}
+
+// Stub globalThis.fetch and run `fn`, always restoring the original afterwards.
+async function withFetch(impl, fn) {
+  const original = globalThis.fetch;
+  globalThis.fetch = impl;
+  try {
+    return await fn();
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+function okBytesResponse(bytes) {
+  return {
+    ok: true,
+    status: 200,
+    async arrayBuffer() {
+      return bytes.buffer.slice(
+        bytes.byteOffset,
+        bytes.byteOffset + bytes.byteLength,
+      );
+    },
+  };
+}
+
+describe("validateOverlayPath", () => {
+  it("accepts a normal repo-relative path", () => {
+    assert.strictEqual(
+      validateOverlayPath("lib/classes/example.php"),
+      "lib/classes/example.php",
+    );
+    assert.strictEqual(
+      validateOverlayPath("public/course/view.php"),
+      "public/course/view.php",
+    );
+  });
+
+  it("rejects empty, non-string, absolute, and traversal paths", () => {
+    assert.throws(() => validateOverlayPath(""), /non-empty/);
+    assert.throws(() => validateOverlayPath("   "), /non-empty/);
+    assert.throws(() => validateOverlayPath(null), /non-empty/);
+    assert.throws(() => validateOverlayPath("/etc/passwd"), /absolute/);
+    assert.throws(
+      () => validateOverlayPath("../../etc/passwd"),
+      /unsafe segment/,
+    );
+    assert.throws(() => validateOverlayPath("a/../b"), /unsafe segment/);
+  });
+
+  it("rejects backslashes, null bytes, control chars, and dot segments", () => {
+    assert.throws(() => validateOverlayPath("a\\b"), /backslash/);
+    assert.throws(() => validateOverlayPath("a\0b"), /null byte/);
+    assert.throws(() => validateOverlayPath("a\tb"), /control/);
+    assert.throws(() => validateOverlayPath("./a"), /unsafe segment/);
+    assert.throws(() => validateOverlayPath("a//b"), /unsafe segment/);
+  });
+});
+
+describe("joinRoot", () => {
+  it("joins a relative path onto the root", () => {
+    assert.strictEqual(
+      joinRoot("/www/moodle", "lib/classes/example.php"),
+      "/www/moodle/lib/classes/example.php",
+    );
+  });
+
+  it("never auto-prefixes public/ (path carries it) and strips trailing slash", () => {
+    assert.strictEqual(
+      joinRoot("/www/moodle/", "public/course/view.php"),
+      "/www/moodle/public/course/view.php",
+    );
+  });
+
+  it("refuses to escape the root", () => {
+    assert.throws(
+      () => joinRoot("/www/moodle", "../evil.php"),
+      /unsafe segment/,
+    );
+  });
+});
+
+describe("normalizeStatus", () => {
+  it("maps GitHub statuses to canonical operations", () => {
+    assert.strictEqual(normalizeStatus("added"), "added");
+    assert.strictEqual(normalizeStatus("modified"), "modified");
+    assert.strictEqual(normalizeStatus("changed"), "modified");
+    assert.strictEqual(normalizeStatus("copied"), "added");
+    assert.strictEqual(normalizeStatus("removed"), "removed");
+    assert.strictEqual(normalizeStatus("renamed"), "renamed");
+  });
+
+  it("throws on an unsupported status", () => {
+    assert.throws(() => normalizeStatus("exploded"), /unsupported file status/);
+  });
+});
+
+describe("normalizeOverlayManifest", () => {
+  it("normalizes added/modified/removed/renamed entries", () => {
+    const ops = normalizeOverlayManifest([
+      { path: "a.php", status: "added", rawUrl: "https://raw/a", size: 10 },
+      { path: "b.php", status: "modified", rawUrl: "https://raw/b" },
+      { path: "c.php", status: "removed" },
+      {
+        path: "new.php",
+        previousPath: "old.php",
+        status: "renamed",
+        rawUrl: "https://raw/new",
+      },
+    ]);
+    assert.strictEqual(ops.length, 4);
+    assert.deepStrictEqual(ops[0], {
+      path: "a.php",
+      status: "added",
+      rawUrl: "https://raw/a",
+      previousPath: null,
+      size: 10,
+    });
+    assert.strictEqual(ops[2].status, "removed");
+    assert.strictEqual(ops[2].rawUrl, null);
+    assert.strictEqual(ops[3].previousPath, "old.php");
+  });
+
+  it("requires rawUrl for non-removed entries", () => {
+    assert.throws(
+      () => normalizeOverlayManifest([{ path: "a.php", status: "modified" }]),
+      /requires a 'rawUrl'/,
+    );
+  });
+
+  it("requires previousPath for renamed entries", () => {
+    assert.throws(
+      () =>
+        normalizeOverlayManifest([
+          { path: "new.php", status: "renamed", rawUrl: "https://raw/new" },
+        ]),
+      /no 'previousPath'/,
+    );
+  });
+
+  it("rejects a non-array and validates every path", () => {
+    assert.throws(() => normalizeOverlayManifest("nope"), /must be an array/);
+    assert.throws(
+      () =>
+        normalizeOverlayManifest([
+          { path: "../evil.php", status: "added", rawUrl: "x" },
+        ]),
+      /unsafe segment/,
+    );
+  });
+});
+
+describe("overlayNeedsUpgrade", () => {
+  it("returns true for version and db upgrade files", () => {
+    assert.ok(overlayNeedsUpgrade([{ path: "version.php" }]));
+    assert.ok(overlayNeedsUpgrade([{ path: "public/version.php" }]));
+    assert.ok(overlayNeedsUpgrade([{ path: "lib/db/upgrade.php" }]));
+    assert.ok(overlayNeedsUpgrade([{ path: "mod/quiz/db/install.xml" }]));
+    assert.ok(overlayNeedsUpgrade(["lib/db/install.php"]));
+  });
+
+  it("returns false for ordinary code changes", () => {
+    assert.ok(!overlayNeedsUpgrade([{ path: "lib/classes/example.php" }]));
+    assert.ok(!overlayNeedsUpgrade([{ path: "lib/version.php" }])); // not core/public version.php
+    assert.ok(!overlayNeedsUpgrade([]));
+  });
+});
+
+describe("normalizeRunUpgrade", () => {
+  it("defaults to auto and accepts off/on/auto plus aliases", () => {
+    assert.strictEqual(normalizeRunUpgrade(undefined), "auto");
+    assert.strictEqual(normalizeRunUpgrade(""), "auto");
+    assert.strictEqual(normalizeRunUpgrade("auto"), "auto");
+    assert.strictEqual(normalizeRunUpgrade("off"), "off");
+    assert.strictEqual(normalizeRunUpgrade("false"), "off");
+    assert.strictEqual(normalizeRunUpgrade("on"), "on");
+    assert.strictEqual(normalizeRunUpgrade("true"), "on");
+  });
+
+  it("throws on an invalid value", () => {
+    assert.throws(() => normalizeRunUpgrade("maybe"), /invalid runUpgrade/);
+  });
+});
+
+describe("buildPrFilesApiUrl / applyProxy", () => {
+  it("builds a paginated PR files API URL", () => {
+    assert.strictEqual(
+      buildPrFilesApiUrl("moodle/moodle", 1234),
+      "https://api.github.com/repos/moodle/moodle/pulls/1234/files?per_page=100&page=1",
+    );
+    assert.strictEqual(
+      buildPrFilesApiUrl("moodle/moodle", 1234, { page: 3 }),
+      "https://api.github.com/repos/moodle/moodle/pulls/1234/files?per_page=100&page=3",
+    );
+  });
+
+  it("rejects a malformed repo or pr", () => {
+    assert.throws(() => buildPrFilesApiUrl("not-a-repo", 1), /invalid repo/);
+    assert.throws(() => buildPrFilesApiUrl("a/b", 0), /invalid pr/);
+  });
+
+  it("passes URLs through unchanged without a proxy and wraps with one", () => {
+    assert.strictEqual(applyProxy("https://raw/x", ""), "https://raw/x");
+    assert.strictEqual(
+      applyProxy("https://raw/x", "https://proxy.dev/"),
+      "https://proxy.dev/?url=https%3A%2F%2Fraw%2Fx",
+    );
+  });
+});
+
+describe("deleteFile / deleteFiles steps", () => {
+  it("deleteFile runs an idempotent unlink", async () => {
+    const php = createMockPhp();
+    const handler = getStepHandler("deleteFile");
+    await handler({ path: "/www/moodle/lib/old.php" }, { php });
+    assert.match(php.runCalls[0], /@unlink/);
+    assert.match(php.runCalls[0], /\/www\/moodle\/lib\/old\.php/);
+  });
+
+  it("deleteFile rejects a missing path", async () => {
+    const handler = getStepHandler("deleteFile");
+    await assert.rejects(
+      () => handler({}, { php: createMockPhp() }),
+      /required/,
+    );
+  });
+
+  it("deleteFiles accepts string and object entries", async () => {
+    const php = createMockPhp();
+    const handler = getStepHandler("deleteFiles");
+    await handler(
+      { files: ["/www/moodle/a.php", { path: "/www/moodle/b.php" }] },
+      { php },
+    );
+    assert.strictEqual(php.runCalls.length, 2);
+    assert.match(php.runCalls[0], /a\.php/);
+    assert.match(php.runCalls[1], /b\.php/);
+  });
+
+  it("deleteFiles rejects a non-array", async () => {
+    const handler = getStepHandler("deleteFiles");
+    await assert.rejects(
+      () => handler({ files: "nope" }, { php: createMockPhp() }),
+      /must be an array/,
+    );
+  });
+});
+
+describe("purgeMoodleCaches step", () => {
+  it("runs a script that purges caches and resets components", async () => {
+    const php = createMockPhp();
+    const handler = getStepHandler("purgeMoodleCaches");
+    await handler({}, { php });
+    const code = php.runCalls[0];
+    assert.match(code, /purge_all_caches/);
+    assert.match(code, /core_component::reset/);
+    assert.match(code, /allversionshash/);
+  });
+});
+
+describe("applyPrOverlay step", () => {
+  it("writes added/modified files, deletes removed, and renames", async () => {
+    const php = createMockPhp();
+    const handler = getStepHandler("applyPrOverlay");
+    const bytes = new Uint8Array([1, 2, 3]);
+
+    await withFetch(
+      async () => okBytesResponse(bytes),
+      () =>
+        handler(
+          {
+            root: DEFAULT_OVERLAY_ROOT,
+            runUpgrade: "off",
+            files: [
+              {
+                path: "lib/a.php",
+                status: "modified",
+                rawUrl: "https://raw/a",
+              },
+              { path: "lib/old.php", status: "removed" },
+              {
+                path: "lib/new.php",
+                previousPath: "lib/prev.php",
+                status: "renamed",
+                rawUrl: "https://raw/new",
+              },
+            ],
+          },
+          { php },
+        ),
+    );
+
+    // Two writes (modified + renamed-new), both under the overlay root.
+    assert.deepStrictEqual(
+      php.writes.map((w) => w.path),
+      ["/www/moodle/lib/a.php", "/www/moodle/lib/new.php"],
+    );
+    // Parent directories created for each written file.
+    assert.ok(php.mkdirs.includes("/www/moodle/lib"));
+    // Removed + renamed-previous both unlinked.
+    const unlinks = php.runCalls.filter((c) => c.includes("@unlink"));
+    assert.ok(unlinks.some((c) => c.includes("lib/old.php")));
+    assert.ok(unlinks.some((c) => c.includes("lib/prev.php")));
+    // Caches purged after overlay.
+    assert.ok(php.runCalls.some((c) => c.includes("purge_all_caches")));
+    // runUpgrade=off: no upgrade run.
+    assert.ok(!php.runCalls.some((c) => c.includes("upgrade_noncore")));
+  });
+
+  it("runs the upgrade automatically when version.php changes", async () => {
+    const php = createMockPhp();
+    const handler = getStepHandler("applyPrOverlay");
+    await withFetch(
+      async () => okBytesResponse(new Uint8Array([1])),
+      () =>
+        handler(
+          {
+            runUpgrade: "auto",
+            files: [
+              {
+                path: "version.php",
+                status: "modified",
+                rawUrl: "https://raw/v",
+              },
+            ],
+          },
+          { php },
+        ),
+    );
+    assert.ok(php.runCalls.some((c) => c.includes("upgrade_noncore")));
+  });
+
+  it("does not run the upgrade in auto mode for ordinary changes", async () => {
+    const php = createMockPhp();
+    const handler = getStepHandler("applyPrOverlay");
+    await withFetch(
+      async () => okBytesResponse(new Uint8Array([1])),
+      () =>
+        handler(
+          {
+            runUpgrade: "auto",
+            files: [
+              {
+                path: "lib/x.php",
+                status: "modified",
+                rawUrl: "https://raw/x",
+              },
+            ],
+          },
+          { php },
+        ),
+    );
+    assert.ok(!php.runCalls.some((c) => c.includes("upgrade_noncore")));
+  });
+
+  it("enforces the maxFiles cap", async () => {
+    const php = createMockPhp();
+    const handler = getStepHandler("applyPrOverlay");
+    await assert.rejects(
+      () =>
+        handler(
+          {
+            maxFiles: 1,
+            runUpgrade: "off",
+            files: [
+              { path: "a.php", status: "modified", rawUrl: "https://raw/a" },
+              { path: "b.php", status: "modified", rawUrl: "https://raw/b" },
+            ],
+          },
+          { php },
+        ),
+      /exceed maxFiles/,
+    );
+  });
+
+  it("requires a files manifest or repo+pr", async () => {
+    const handler = getStepHandler("applyPrOverlay");
+    await assert.rejects(
+      () => handler({}, { php: createMockPhp() }),
+      /provide a 'files' manifest/,
+    );
+  });
+});

--- a/tests/blueprint/steps.test.js
+++ b/tests/blueprint/steps.test.js
@@ -57,10 +57,14 @@ describe("step registry", () => {
       "writeFiles",
       "copyFile",
       "moveFile",
+      "deleteFile",
+      "deleteFiles",
       "unzip",
       "request",
       "runPhpCode",
       "runPhpScript",
+      "purgeMoodleCaches",
+      "applyPrOverlay",
     ];
     const registered = getRegisteredStepNames();
     for (const name of expected) {


### PR DESCRIPTION
## Summary

Adds a runtime **PR Overlay Preview** capability: preview a Moodle core pull request by booting an
already-prebuilt Moodle Playground base and overlaying the PR's changed files onto the in-browser
Moodle filesystem at runtime (whole-file replacement, not a unified diff), then purging caches and
optionally running Moodle's upgrade. No per-PR WASM bundle is built.

This is the runtime half of the feature; the companion GitHub Action generates the blueprint that
drives it.

## Implementation details

- **Pure helpers** — `src/blueprint/pr-overlay.js`: path validation, root joining, manifest
  normalization, status mapping, upgrade detection, `runUpgrade` normalization, and GitHub/proxy URL
  builders. Side-effect free and unit tested.
- **Step handlers** — `src/blueprint/steps/pr-overlay.js`: `purgeMoodleCaches` and `applyPrOverlay`
  (fetch bytes, write/delete, create parent dirs, purge, best-effort upgrade). Network + PHP effects
  live here; failures in purge/upgrade are non-fatal and reported.
- **Filesystem steps** — `deleteFile` / `deleteFiles` added to `src/blueprint/steps/filesystem.js`.
- **PHP generators** — `phpPurgeMoodleCaches()` and `phpRunCoreUpgrade()` in
  `src/blueprint/php/helpers.js` (CLI bootstrap; honest `ok:true/false` reporting).
- **Allowlists** — the four step names added to `src/blueprint/schema.js`,
  `assets/blueprints/blueprint-schema.json`, and the `tests/blueprint/steps.test.js` registry test.
- **Overlay root** is `/www/moodle`; the `public/` prefix (Moodle 5.1+) comes from the PR path and is
  never auto-prepended. Paths are sanitized (empty / absolute / `..` / backslash / null / control).

## Runtime steps added

| Step | Description |
|------|-------------|
| `deleteFile` | Delete a file (idempotent; surfaces real errors) |
| `deleteFiles` | Delete a batch (string paths or `{ "path": … }`) |
| `purgeMoodleCaches` | `core_component::reset` + `theme_reset_all_caches` + `purge_all_caches` + clear `allversionshash` |
| `applyPrOverlay` | Overlay a PR's changed files (`files` manifest or `repo`+`pr`); purge; `runUpgrade` off/on/auto |

## Tests

- `tests/blueprint/pr-overlay.test.js` — helpers (path validation, joinRoot, manifest, status,
  upgrade detection, runUpgrade, URL builders) and handlers (deleteFile/deleteFiles,
  purgeMoodleCaches, applyPrOverlay add/modify/remove/rename, auto-upgrade, maxFiles cap).
- `tests/blueprint/php-helpers.test.js` — assertions for the two new PHP generators.
- `tests/blueprint/steps.test.js` — registry coverage for the four new steps.

`make test` → **634 tests pass** (node --test). `make lint` clean (Biome). `npm run build-worker`
succeeds (bundle resolves the new imports; `dist/` is git-ignored and not committed).

## Limitations

SQLite-vs-real-DB fidelity; Composer/frontend/generated-asset changes are not reproduced; database
upgrades may not fully apply under SQLite/WASM; binary/large files are capped; base drift; no code
editor; no Tampermonkey; no per-PR bundle builder. See ADR-0016 and `docs/blueprint-json.md`.

## Security notes

PR file paths/contents are untrusted: paths are sanitized and size/count-capped before any write;
fetches go to `raw.githubusercontent.com` / `api.github.com` only (never `github.com` `.diff` HTML).
The runtime executes PR code only inside the user's browser/WASM sandbox.

## Related issue

Closes #155.

## Companion PR

ateeducacion/action-moodle-playground-pr-preview#42 — *Add Moodle core PR overlay preview mode*.

## How to test it (live)

This branch is deployed at the Cloudflare Pages preview:
**https://feat-pr-overlay-preview.moodle-playground.pages.dev**

You can exercise `applyPrOverlay` there directly — no GitHub Action needed. The compact
`repo` + `pr` form keeps the URL tiny regardless of PR size.

**One click — preview a real Moodle core PR** ([`moodle/moodle#532`](https://github.com/moodle/moodle/pull/532), a **fork** PR targeting `main`):

https://feat-pr-overlay-preview.moodle-playground.pages.dev/?blueprint=eyJwcmVmZXJyZWRWZXJzaW9ucyI6eyJwaHAiOiI4LjMiLCJtb29kbGUiOiJkZXYifSwibGFuZGluZ1BhZ2UiOiIvYWRtaW4vaW5kZXgucGhwIiwic3RlcHMiOlt7InN0ZXAiOiJpbnN0YWxsTW9vZGxlIiwib3B0aW9ucyI6eyJzaXRlTmFtZSI6IkNvcmUgUFIgIzUzMiBwcmV2aWV3IiwiYWRtaW5Vc2VyIjoiYWRtaW4iLCJhZG1pblBhc3MiOiJwYXNzd29yZCJ9fSx7InN0ZXAiOiJhcHBseVByT3ZlcmxheSIsInJlcG8iOiJtb29kbGUvbW9vZGxlIiwicHIiOjUzMiwiYmFzZVJlZiI6Im1haW4iLCJydW5VcGdyYWRlIjoiYXV0byJ9LHsic3RlcCI6ImxvZ2luIiwidXNlcm5hbWUiOiJhZG1pbiJ9XX0

It boots the `main`/dev base, overlays the PR's changed files at runtime, purges caches + OPcache,
runs `runUpgrade: auto`, and auto-logs in as `admin` / `password`. The decoded blueprint is:

```json
{
  "preferredVersions": { "php": "8.3", "moodle": "dev" },
  "landingPage": "/admin/index.php",
  "steps": [
    { "step": "installMoodle", "options": { "siteName": "Core PR #532 preview", "adminUser": "admin", "adminPass": "password" } },
    { "step": "applyPrOverlay", "repo": "moodle/moodle", "pr": 532, "baseRef": "main", "runUpgrade": "auto" },
    { "step": "login", "username": "admin" }
  ]
}
```

**Any other PR** — change `repo` / `pr` / `baseRef`, base64url-encode the JSON, and open
`…pages.dev/?blueprint=<base64url>`. For a stable branch use e.g. `"baseRef": "MOODLE_501_STABLE"`
with `"moodle": "5.1"` (target branch → base version per the table in `docs/blueprint-json.md`).

**Forks are supported** (this very example is a fork PR): in `repo` + `pr` mode you pass the base
repo + PR number and the GitHub API resolves the fork head; in `files` mode the raw URLs point at
the fork's head commit.

> The runtime fetches `raw.githubusercontent.com` / `api.github.com` directly (CORS-enabled for
> public repos). Unauthenticated browser API calls are rate-limited to 60/hour; the action's `files`
> mode avoids runtime API calls. Reset Playground (or open in a fresh tab) to re-run cleanly.
