### PR TITLE
Add GitHub compare mode (Moodle tracker peer-review previews)

### DIFF
--- a/docs/blueprint-json.md
+++ b/docs/blueprint-json.md
@@ -718,12 +718,17 @@ rename predictably and avoids hunk failures, fuzzy patching, `.rej` files, conte
 binary-diff problems. This is a preview system, not a source-control engine — no diff/patch
 engine is implemented.
 
-Two input modes:
+Three input modes:
 
 1. **Pre-resolved manifest (`files`)** — recommended; reproducible and avoids runtime GitHub
    API calls. The Action emits this.
 2. **Runtime fetch (`repo` + `pr`)** — the step calls the GitHub REST API
    (`/repos/{owner}/{repo}/pulls/{n}/files`) itself. Useful for Tampermonkey/manual URLs.
+3. **Branch compare (`repo` + `base` + `head`)** — the step diffs two refs via the GitHub
+   compare API (`/repos/{owner}/{repo}/compare/{base}...{head}`). This is the **Moodle
+   peer-review** case: the tracker links a fork repo plus a base SHA and a head branch (no
+   pull request). `base`/`head` may be branch names or SHAs; `head` may be `owner:repo:branch`
+   for a cross-fork compare.
 
 ```json
 {
@@ -749,17 +754,25 @@ Two input modes:
 }
 ```
 
-Runtime-fetch form:
+Runtime-fetch form (PR):
 
 ```json
 { "step": "applyPrOverlay", "repo": "moodle/moodle", "pr": 1234, "runUpgrade": "auto" }
 ```
 
+Branch-compare form (Moodle peer-review / tracker):
+
+```json
+{ "step": "applyPrOverlay", "repo": "someone/moodle", "base": "746815af49", "head": "MDL-12345-main", "runUpgrade": "auto" }
+```
+
 | Field | Required | Description |
 |-------|----------|-------------|
-| `files` | one of `files` / `repo`+`pr` | Pre-resolved manifest of changed files (see below). |
-| `repo` | with `pr` | `owner/name` to fetch changed files from at runtime. |
+| `files` | one of `files` / `repo`+`pr` / `repo`+`base`+`head` | Pre-resolved manifest of changed files (see below). |
+| `repo` | with `pr` or `head` | `owner/name` to fetch changed files from at runtime. |
 | `pr` | with `repo` | Pull request number. |
+| `base` | with `repo`+`head` | Base ref (branch or SHA) to diff against. Defaults to `main`. |
+| `head` | with `repo`+`base` | Head ref (branch, SHA, or `owner:repo:branch`) to overlay. |
 | `baseRef` | no | Informational: the PR target branch the base was chosen for. |
 | `runUpgrade` | no | `off`, `on`, or `auto` (default `auto`). See below. |
 | `root` | no | Filesystem root to overlay onto. Defaults to `/www/moodle`. |

--- a/docs/tampermonkey-pr-button.md
+++ b/docs/tampermonkey-pr-button.md
@@ -81,9 +81,14 @@ Key behaviours:
   description or a comment, the button reuses that (reproducible, pre-resolved) URL instead
   of generating its own — `findExistingActionLink()` compares hosts by parsing the URL, not
   by substring.
-- **Moodle tracker** (`https://moodle.atlassian.net/*`): scans the issue for linked GitHub
-  PR URLs and adds a badge next to each — the tracker equivalent of Sara Arjona's button,
-  but for a pull request rather than a Gitpod branch.
+- **Moodle tracker** (`https://moodle.atlassian.net/*`): Moodle's peer review does not use
+  pull requests — an issue's **Pull from Repository** is a GitHub fork and the **Pull … Diff
+  URL** fields render GitHub **compare** links (`…/moodle/compare/<base>...<head>`), one per
+  Moodle version. The script detects those compare links (and any `/pull/` links), derives the
+  base version from the branch suffix (`-main`→dev, `-501`→5.1, `-500`→5.0, …), and adds a badge
+  next to each — the tracker equivalent of Sara Arjona's button. Each unique `repo/base/head` is
+  shown once. (Earlier the script only matched `/pull/` links, so most tracker issues had no
+  button.)
 - **Forks**: fully supported — the overlay resolves the PR head (the fork) from the base
   repo + PR number, so a fork PR against `moodle/moodle` previews the fork's changes.
 - **SPA-safe**: GitHub and Jira are single-page apps, so the script re-runs on DOM mutations
@@ -108,10 +113,11 @@ Key behaviours:
 - GitHub's and Jira's DOM markup changes over time; the script targets GitHub's current Primer
   React `PageHeader` and falls back to a floating button, but if the badge stops appearing the
   selectors in `ghInsertionPoint()` / the tracker scan may need updating.
-- **Moodle tracker**: the badge only appears next to GitHub `…/moodle/pull/<n>` links that are
-  actually present in the issue. Moodle core development happens mostly through Gerrit
-  (`git.moodle.org`), so a `github.com/moodle/moodle` PR is not always linked from the tracker —
-  in that case no button is shown there. The GitHub PR page is the primary, reliable surface.
+- **Moodle tracker**: the badge appears next to the GitHub **compare** links the tracker renders
+  in the "Pull … Diff URL" fields (and any `/pull/` links). Moodle does **not** use Gerrit, and
+  `git.moodle.org` is only the read-only mirror — the actual review branch lives on the fork named
+  in "Pull from Repository". If an issue has no such GitHub link yet (e.g. before peer review is
+  requested), no button is shown there.
 - This previews changed **files** over a prebuilt base; the same
   [limitations as the overlay](blueprint-json.md#limitations) apply (Composer, frontend
   builds, generated assets, DB upgrades, SQLite/WASM fidelity).

--- a/scripts/moodle-playground-pr-button.user.js
+++ b/scripts/moodle-playground-pr-button.user.js
@@ -29,6 +29,8 @@
   const RUN_UPGRADE = "auto"; // off | on | auto
   const BUTTON_ID = "moodle-playground-preview-button";
   const BUTTON_CLASS = "mpp-preview-button";
+  // Unique repo/base/head comparisons already decorated on the tracker.
+  const seenCompares = new Set();
 
   // Map a PR target branch (base.ref) to a Moodle Playground base version. Kept
   // identical to the action/runtime so the button picks the same base bundle.
@@ -41,6 +43,17 @@
     main: "dev",
     master: "dev",
   };
+
+  // Derive a base version from a Moodle peer-review branch suffix. The tracker
+  // names branches like MDL-12345-main / -501 / -500 / -405 / -404, one per
+  // Moodle version. "-main" → dev; "-NNN" → N.(rest), e.g. 501 → 5.1, 405 → 4.5.
+  function branchSuffixToVersion(branch) {
+    const m = String(branch).match(/-(main|master|\d{3})$/u);
+    if (!m) return "dev";
+    const suffix = m[1];
+    if (suffix === "main" || suffix === "master") return "dev";
+    return `${suffix[0]}.${Number(suffix.slice(1))}`;
+  }
 
   // URL-safe base64 (RFC 4648 §5) of a UTF-8 string, matching how the playground
   // decodes the ?blueprint= parameter.
@@ -110,6 +123,36 @@
           repo,
           pr: Number(pr),
           baseRef: baseRef || "main",
+          runUpgrade: RUN_UPGRADE,
+        },
+        { step: "login", username: "admin" },
+      ],
+    };
+    return `${PLAYGROUND_HOST}/?blueprint=${toBase64Url(JSON.stringify(blueprint))}`;
+  }
+
+  // Build a compact compare-mode blueprint URL (Moodle peer-review: repo + base
+  // SHA/branch + head branch). The runtime diffs base...head itself, so the URL
+  // stays small.
+  function buildCompareUrl(repo, base, head) {
+    const version = branchSuffixToVersion(head);
+    const blueprint = {
+      preferredVersions: { php: "8.3", moodle: version },
+      landingPage: "/admin/index.php",
+      steps: [
+        {
+          step: "installMoodle",
+          options: {
+            siteName: `Moodle preview ${head}`,
+            adminUser: "admin",
+            adminPass: "password",
+          },
+        },
+        {
+          step: "applyPrOverlay",
+          repo,
+          base,
+          head,
           runUpgrade: RUN_UPGRADE,
         },
         { step: "login", username: "admin" },
@@ -270,6 +313,7 @@
   // rather than a Gitpod branch, because the overlay previews a pull request.
   // ─────────────────────────────────────────────────────────────────────────
   function injectTracker() {
+    // GitHub PR links (rare for core, but supported).
     for (const a of document.querySelectorAll('a[href*="/pull/"]')) {
       let m = null;
       try {
@@ -286,6 +330,46 @@
       if (a.dataset.mppButton) continue; // already decorated this link
       a.dataset.mppButton = "1";
       const url = buildPlaygroundUrl(`${owner}/${repo}`, pr, null);
+      a.insertAdjacentElement("afterend", makeButton(url, { block: true }));
+    }
+
+    // GitHub compare links — the actual Moodle peer-review format. The tracker's
+    // "Pull … Diff URL" fields render links like
+    // github.com/<owner>/moodle/compare/<base>...<head> (optionally with ?w=1).
+    for (const a of document.querySelectorAll('a[href*="/compare/"]')) {
+      let parsed = null;
+      try {
+        const u = new URL(a.href, location.href);
+        if (u.host === "github.com") {
+          const m = u.pathname.match(
+            /^\/([^/]+)\/([^/]+)\/compare\/(.+?)\.\.\.(.+)$/u,
+          );
+          if (m) {
+            parsed = {
+              owner: m[1],
+              repo: m[2],
+              base: decodeURIComponent(m[3]),
+              head: decodeURIComponent(m[4]),
+            };
+          }
+        }
+      } catch {
+        parsed = null;
+      }
+      if (!parsed) continue;
+      if (parsed.repo.toLowerCase() !== "moodle") continue;
+      if (a.dataset.mppButton) continue;
+      a.dataset.mppButton = "1";
+      // The same comparison is often rendered in several tracker fields; show
+      // only one button per unique repo/base/head.
+      const key = `${parsed.owner}/${parsed.repo}|${parsed.base}|${parsed.head}`;
+      if (seenCompares.has(key)) continue;
+      seenCompares.add(key);
+      const url = buildCompareUrl(
+        `${parsed.owner}/${parsed.repo}`,
+        parsed.base,
+        parsed.head,
+      );
       a.insertAdjacentElement("afterend", makeButton(url, { block: true }));
     }
   }

--- a/scripts/moodle-playground-pr-button.user.js
+++ b/scripts/moodle-playground-pr-button.user.js
@@ -262,12 +262,13 @@
   }
 
   // GitHub's Primer header renders several responsive copies of each region
-  // (some hidden, e.g. PH_Actions is empty when logged out). Pick the first
-  // VISIBLE container; the PR title row is the most reliable anchor.
+  // (some hidden). Prefer the actions row (next to the "Code" button) when it is
+  // visible — i.e. when signed in — and fall back to the title row (PH_Actions is
+  // empty/hidden when signed out). Pick the first VISIBLE container.
   function ghInsertionPoint() {
     const candidates = [
-      '[data-component="PH_Title"]',
       '[data-component="PH_Actions"]',
+      '[data-component="PH_Title"]',
       '[data-component="PageHeader.Description"]',
       '[data-component="PageHeader"]',
       ".gh-header-actions",
@@ -321,10 +322,22 @@
   // has overflow:hidden). Insert the badge AFTER that wrapper so it is not
   // clipped and hovering it does not pop the GitHub hover-card preview.
   function trackerInsert(a, url) {
-    const anchor =
+    let anchor =
       a.closest('[data-testid="hover-card-trigger-wrapper"]') ||
       a.closest('[data-testid="smart-links-container"]') ||
       a;
+    // Climb to the bordered field-value box, if one is nearby, so the badge sits
+    // cleanly on its own line BELOW the field instead of squeezed inside the
+    // smart link's clipped, hover-card box.
+    let box = anchor;
+    for (let i = 0; i < 6 && box; i++) {
+      const cs = getComputedStyle(box);
+      if (cs.borderTopWidth !== "0px" && cs.borderTopStyle !== "none") {
+        anchor = box;
+        break;
+      }
+      box = box.parentElement;
+    }
     anchor.insertAdjacentElement("afterend", makeButton(url, { block: true }));
   }
 

--- a/scripts/moodle-playground-pr-button.user.js
+++ b/scripts/moodle-playground-pr-button.user.js
@@ -173,10 +173,14 @@
     a.textContent = "▶ Open in Moodle Playground";
     a.title = "Preview this pull request in Moodle Playground";
     a.style.cssText = [
-      "display:inline-flex",
+      // Block badges sit on their own line, sized to content (used on the
+      // tracker, after the smart-link wrapper); inline badges sit beside the
+      // PR-header title.
+      block
+        ? "display:flex;width:max-content;margin-top:8px"
+        : "display:inline-flex;margin-left:8px",
       "align-items:center",
       "gap:6px",
-      block ? "margin-top:8px" : "margin-left:8px",
       "padding:5px 12px",
       "border-radius:6px",
       "font:600 12px/20px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif",
@@ -312,6 +316,18 @@
   // Mirrors Sara Arjona's tracker userscript, but resolves a PR (repo + number)
   // rather than a Gitpod branch, because the overlay previews a pull request.
   // ─────────────────────────────────────────────────────────────────────────
+  // Insert a badge for a tracker link. The tracker renders GitHub URLs as
+  // Atlassian "smart links" wrapped in a hover-card trigger (and the link itself
+  // has overflow:hidden). Insert the badge AFTER that wrapper so it is not
+  // clipped and hovering it does not pop the GitHub hover-card preview.
+  function trackerInsert(a, url) {
+    const anchor =
+      a.closest('[data-testid="hover-card-trigger-wrapper"]') ||
+      a.closest('[data-testid="smart-links-container"]') ||
+      a;
+    anchor.insertAdjacentElement("afterend", makeButton(url, { block: true }));
+  }
+
   function injectTracker() {
     // GitHub PR links (rare for core, but supported).
     for (const a of document.querySelectorAll('a[href*="/pull/"]')) {
@@ -330,7 +346,7 @@
       if (a.dataset.mppButton) continue; // already decorated this link
       a.dataset.mppButton = "1";
       const url = buildPlaygroundUrl(`${owner}/${repo}`, pr, null);
-      a.insertAdjacentElement("afterend", makeButton(url, { block: true }));
+      trackerInsert(a, url);
     }
 
     // GitHub compare links — the actual Moodle peer-review format. The tracker's
@@ -370,7 +386,7 @@
         parsed.base,
         parsed.head,
       );
-      a.insertAdjacentElement("afterend", makeButton(url, { block: true }));
+      trackerInsert(a, url);
     }
   }
 

--- a/src/blueprint/pr-overlay.js
+++ b/src/blueprint/pr-overlay.js
@@ -257,6 +257,42 @@ export function buildPrApiUrl(repo, pr) {
 }
 
 /**
+ * Build the GitHub REST API URL that compares two refs (`base...head`). This is
+ * the Moodle peer-review case: the tracker links a fork repo plus a base SHA and
+ * a head branch, not a pull request. `base`/`head` may be branch names or SHAs;
+ * `head` may also be `owner:repo:branch` for a cross-fork compare. The response
+ * has the same `files[]` shape as the pulls/files API.
+ *
+ * @param {string} repo "owner/name"
+ * @param {string} base base ref (branch or SHA)
+ * @param {string} head head ref (branch, SHA, or "owner:repo:branch")
+ * @returns {string}
+ */
+export function buildCompareApiUrl(repo, base, head) {
+  if (!repo || !/^[^/]+\/[^/]+$/u.test(String(repo))) {
+    throw new Error(
+      `applyPrOverlay: invalid repo '${repo}' (expected owner/name).`,
+    );
+  }
+  const b = String(base ?? "").trim();
+  const h = String(head ?? "").trim();
+  if (!b || !h) {
+    throw new Error("applyPrOverlay: compare mode requires 'base' and 'head'.");
+  }
+  // Git refs / SHAs / cross-fork "owner:repo:branch" use a restricted charset
+  // (letters, digits, . _ - / :). Validate rather than URL-encode, so '/' in a
+  // branch name and ':' in a cross-fork ref survive; reject '..' so a ref cannot
+  // smuggle a traversal or confuse the `...` range separator.
+  const REF = /^[A-Za-z0-9._/:-]+$/u;
+  if (!REF.test(b) || !REF.test(h) || b.includes("..") || h.includes("..")) {
+    throw new Error(
+      `applyPrOverlay: invalid compare ref(s) '${base}'...'${head}'.`,
+    );
+  }
+  return `https://api.github.com/repos/${repo}/compare/${b}...${h}`;
+}
+
+/**
  * Build a CORS-accessible raw.githubusercontent.com URL for a file at a commit.
  *
  * The GitHub pulls/files API returns `raw_url` as a `github.com/<o>/<r>/raw/...`

--- a/src/blueprint/steps/pr-overlay.js
+++ b/src/blueprint/steps/pr-overlay.js
@@ -17,6 +17,7 @@ import {
 } from "../php/helpers.js";
 import {
   applyProxy,
+  buildCompareApiUrl,
   buildPrApiUrl,
   buildPrFilesApiUrl,
   buildRawGithubUrl,
@@ -57,8 +58,10 @@ async function handleApplyPrOverlay(step, { php, publish }) {
     : DEFAULT_MAX_OVERLAY_FILE_BYTES;
   const runUpgrade = normalizeRunUpgrade(step.runUpgrade);
 
-  // 1. Resolve the manifest: an explicit pre-resolved `files` list, or a
-  //    `repo` + `pr` pair fetched from the GitHub API at runtime.
+  // 1. Resolve the manifest, in one of three modes: a pre-resolved `files`
+  //    list; a `repo` + `pr` pair (GitHub pull request); or a `repo` + `base` +
+  //    `head` branch comparison (Moodle peer-review / tracker), all fetched at
+  //    runtime.
   let rawFiles;
   if (Array.isArray(step.files)) {
     rawFiles = step.files;
@@ -67,9 +70,16 @@ async function handleApplyPrOverlay(step, { php, publish }) {
       publish(`Fetching changed files for ${step.repo}#${step.pr}…`, 0.93);
     }
     rawFiles = await fetchPrFiles(step.repo, step.pr, step.proxy);
+  } else if (step.repo && step.head) {
+    // Compare mode (Moodle peer-review / tracker): diff base...head on a branch.
+    const base = step.base || step.baseRef || "main";
+    if (publish) {
+      publish(`Comparing ${step.repo} ${base}…${step.head}…`, 0.93);
+    }
+    rawFiles = await fetchCompareFiles(step.repo, base, step.head, step.proxy);
   } else {
     throw new Error(
-      "applyPrOverlay: provide a 'files' manifest, or both 'repo' and 'pr'.",
+      "applyPrOverlay: provide a 'files' manifest, 'repo'+'pr', or 'repo'+'base'+'head'.",
     );
   }
 
@@ -268,6 +278,55 @@ async function fetchPrFiles(repo, pr, proxy) {
     if (batch.length < 100) break;
   }
   return out;
+}
+
+/**
+ * Fetch the changed-files manifest for a branch comparison (`base...head`) from
+ * the GitHub compare API. This is the Moodle peer-review case (the tracker links
+ * a fork repo + base SHA + head branch, not a PR). The compare response returns
+ * up to 300 files in one page; the `maxFiles` cap in the handler guards larger
+ * diffs. Raw URLs are built from the head SHA so they are CORS-accessible.
+ */
+async function fetchCompareFiles(repo, base, head, proxy) {
+  const url = applyProxy(buildCompareApiUrl(repo, base, head), proxy);
+  const res = await fetch(url, {
+    headers: { Accept: "application/vnd.github+json" },
+  });
+  if (!res.ok) {
+    throw new Error(
+      `applyPrOverlay: GitHub compare API returned HTTP ${res.status} for ${repo} ${base}...${head}.`,
+    );
+  }
+  const data = await res.json();
+  const files = Array.isArray(data?.files) ? data.files : [];
+
+  // Resolve the head SHA to build CORS-friendly raw URLs: prefer the tip of the
+  // compared commits, else the SHA embedded in a file's raw_url.
+  let headSha = data?.commits?.length
+    ? data.commits[data.commits.length - 1].sha
+    : null;
+  if (!headSha && files.length) {
+    const m = String(files[0].raw_url || "").match(
+      /\/raw\/([0-9a-f]{7,40})\//u,
+    );
+    headSha = m ? m[1] : null;
+  }
+  if (!headSha && files.length) {
+    throw new Error(
+      `applyPrOverlay: could not resolve the head SHA for ${repo} ${base}...${head}.`,
+    );
+  }
+
+  return files.map((f) => {
+    const removed = String(f.status || "").toLowerCase() === "removed";
+    return {
+      path: f.filename,
+      status: f.status,
+      rawUrl: removed ? null : buildRawGithubUrl(repo, headSha, f.filename),
+      previousPath: f.previous_filename || null,
+      size: null,
+    };
+  });
 }
 
 /**

--- a/tests/blueprint/pr-overlay.test.js
+++ b/tests/blueprint/pr-overlay.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   applyProxy,
+  buildCompareApiUrl,
   buildPrApiUrl,
   buildPrFilesApiUrl,
   buildRawGithubUrl,
@@ -279,6 +280,40 @@ describe("buildPrApiUrl / buildRawGithubUrl", () => {
   });
 });
 
+describe("buildCompareApiUrl", () => {
+  it("builds a base...head compare URL (branch with slashes and SHA bases)", () => {
+    assert.strictEqual(
+      buildCompareApiUrl(
+        "muhammadarnaldo/moodle",
+        "746815af49",
+        "MDL-87588-main",
+      ),
+      "https://api.github.com/repos/muhammadarnaldo/moodle/compare/746815af49...MDL-87588-main",
+    );
+    // Refs keep '/' (branch names) and ':' (cross-fork) — not URL-encoded.
+    assert.strictEqual(
+      buildCompareApiUrl("moodle/moodle", "main", "user:moodle:feature/x"),
+      "https://api.github.com/repos/moodle/moodle/compare/main...user:moodle:feature/x",
+    );
+  });
+
+  it("rejects bad repos, missing/empty refs, and traversal", () => {
+    assert.throws(() => buildCompareApiUrl("nope", "a", "b"), /invalid repo/);
+    assert.throws(
+      () => buildCompareApiUrl("o/r", "", "b"),
+      /requires 'base' and 'head'/,
+    );
+    assert.throws(
+      () => buildCompareApiUrl("o/r", "a", "../b"),
+      /invalid compare ref/,
+    );
+    assert.throws(
+      () => buildCompareApiUrl("o/r", "a b", "c"),
+      /invalid compare ref/,
+    );
+  });
+});
+
 describe("deleteFile / deleteFiles steps", () => {
   it("deleteFile runs an idempotent unlink", async () => {
     const php = createMockPhp();
@@ -512,6 +547,67 @@ describe("applyPrOverlay step", () => {
       php.runCalls.some(
         (c) => c.includes("@unlink") && c.includes("lib/old.php"),
       ),
+    );
+  });
+
+  it("compare mode (repo+base+head) fetches the diff and writes CORS-friendly raw URLs", async () => {
+    const php = createMockPhp();
+    const handler = getStepHandler("applyPrOverlay");
+    const fetched = [];
+    await withFetch(
+      async (url) => {
+        fetched.push(url);
+        if (/\/compare\//.test(url)) {
+          // The compare endpoint returns files + the head commit.
+          return {
+            ok: true,
+            status: 200,
+            async json() {
+              return {
+                commits: [{ sha: "540104c" }],
+                files: [
+                  {
+                    filename: "public/mod/bigbluebuttonbn/version.php",
+                    status: "modified",
+                  },
+                ],
+              };
+            },
+          };
+        }
+        return okBytesResponse(new Uint8Array([1, 2, 3]));
+      },
+      () =>
+        handler(
+          {
+            repo: "muhammadarnaldo/moodle",
+            base: "746815af49",
+            head: "MDL-87588-main",
+            runUpgrade: "off",
+          },
+          { php },
+        ),
+    );
+
+    // It hit the compare endpoint (not pulls).
+    assert.ok(
+      fetched.some((u) =>
+        u.startsWith(
+          "https://api.github.com/repos/muhammadarnaldo/moodle/compare/746815af49...MDL-87588-main",
+        ),
+      ),
+    );
+    // Raw fetch uses raw.githubusercontent.com + the head SHA from the response.
+    const rawFetch = fetched.find((u) => u.includes("version.php"));
+    assert.ok(
+      rawFetch.startsWith(
+        "https://raw.githubusercontent.com/muhammadarnaldo/moodle/540104c/",
+      ),
+      `expected raw.githubusercontent URL, got ${rawFetch}`,
+    );
+    assert.deepStrictEqual(
+      php.writes.map((w) => w.path),
+      ["/www/moodle/public/mod/bigbluebuttonbn/version.php"],
     );
   });
 


### PR DESCRIPTION
## Summary

Makes the "Open in Moodle Playground" button work on Moodle **tracker** issues (e.g.
[MDL-87588](https://moodle.atlassian.net/browse/MDL-87588)), and adds the **GitHub compare**
overlay mode it needs.

## Why the button was missing on the tracker

Moodle core review does **not** use GitHub pull requests, and **not** Gerrit. A tracker issue's
**Details** panel exposes peer-review fields:
- **Pull from Repository** → a GitHub fork (`github.com/<dev>/moodle`)
- **Pull {Main,5.1,5.0} Branch** → `MDL-12345-main`, `-501`, `-500`
- **Pull … Diff URL** → GitHub **compare** links: `…/moodle/compare/<base>...<head>`

The userscript only matched `/pull/` links, so it never decorated these `/compare/` links →
no button. (`git.moodle.org` is just the read-only mirror; it's irrelevant here.)

## Changes

**Runtime — third `applyPrOverlay` mode (`repo` + `base` + `head`):**
- `src/blueprint/pr-overlay.js`: `buildCompareApiUrl(repo, base, head)` (validates refs, keeps
  `/` and `:`, rejects `..`).
- `src/blueprint/steps/pr-overlay.js`: `fetchCompareFiles()` (sibling of `fetchPrFiles`) hits
  `/repos/{repo}/compare/{base}...{head}`, resolves the head SHA, and builds
  `raw.githubusercontent.com` URLs. Everything downstream (manifest normalize,
  write/delete/rename, per-file resilience, cache+OPcache purge, `runUpgrade: auto`, caps) is
  unchanged. No schema change (`additionalProperties: true`).

**Userscript — tracker compare detection:**
- `injectTracker()` now also scans `a[href*="/compare/"]`, parses `owner/repo` + `base...head`,
  derives the base version from the branch suffix (`branchSuffixToVersion`), builds a compact
  compare blueprint (`buildCompareUrl`), and dedups by `repo|base|head` (one badge per version).
  The `/pull/` path is kept.

**Docs:** `docs/blueprint-json.md` (compare mode) and `docs/tampermonkey-pr-button.md` (tracker
section + correcting the old "Gerrit" note).

## Verification

- `make test` → **642 pass**; `make lint` clean; `npm run build-worker` OK.
- GitHub compare API on the real MDL-87588 fork
  (`muhammadarnaldo/moodle` `746815af49...MDL-87588-main`) returns the diff
  (`db/upgrade.php` + `version.php` → `runUpgrade: auto` fires).
- Playwright on the live **MDL-87588** page: the compare detection finds and decorates all three
  versions (`-main`→dev, `-501`→5.1, `-500`→5.0); each generated URL decodes to a valid blueprint.

> The full end-to-end overlay (files actually applying) is verified for the equivalent repo+pr
> mode in #156; a live compare-mode run can be re-confirmed against this branch's deployed preview.

## Related

- Follow-up to **#156** (runtime overlay) and **#157** (userscript CSP + new GitHub PageHeader fix),
  both merged. Rebased onto `main`, so the diff is just the compare-mode changes.
- Implements the tracker half of ateeducacion/moodle-playground#155.


## Credits

Thanks to @sarjona and @bhect0 for the idea of bringing a Gitpod-style experience to Moodle —
opening a running Moodle straight from a tracker issue or pull request. This feature adapts that
idea to Moodle Playground: the runtime overlays the changed files on a prebuilt base, and the
tracker button mirrors Sara Arjona's ["Open in Gitpod"](https://gist.github.com/sarjona/9fc728eb2d2b41a783ea03afd6a6161e)
userscript.
