### PR TITLE
docs: add Moodle™ trademark and non-affiliation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 > Run a full Moodle site in the browser — no server required.
 
-Moodle Playground runs [Moodle](https://moodle.org) entirely in the browser using WebAssembly, powered by [WordPress Playground](https://github.com/WordPress/wordpress-playground)'s `@php-wasm/web` runtime. Every page load boots a fresh Moodle instance with a pre-built SQLite snapshot — nothing is stored on disk and nothing leaves your browser.
+Moodle Playground runs [Moodle™](https://moodle.org) entirely in the browser using WebAssembly, powered by [WordPress Playground](https://github.com/WordPress/wordpress-playground)'s `@php-wasm/web` runtime. Every page load boots a fresh Moodle instance with a pre-built SQLite snapshot — nothing is stored on disk and nothing leaves your browser.
 
 ## Getting Started
 
@@ -128,3 +128,17 @@ Contributions are welcome. See the [development docs](docs/maintainers/contribut
 ## License
 
 See [LICENSE](LICENSE).
+
+## Trademark
+
+"Moodle™" and the Moodle logo are trademarks or registered trademarks of
+[Moodle Pty Ltd](https://moodle.com/) and its associated entities, used here for
+identification and descriptive purposes only.
+
+Moodle Playground is an independent, community-maintained open-source project built by
+[Área de Tecnología Educativa (ATE)](https://www3.gobiernodecanarias.org/medusa/ecoescuela/ate/).
+It is **not** affiliated with, endorsed by, sponsored by, or approved by Moodle Pty Ltd or
+Moodle HQ. It runs the open-source Moodle™ software in the browser for demonstration,
+testing, and educational purposes.
+
+See Moodle's [trademark guidelines](https://moodle.com/trademarks/) for details.

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,3 +74,7 @@ The shell hosts a scoped runtime iframe; a service worker routes requests to a P
 ---
 
 Made with :material-heart:{ .heart } by [Área de Tecnología Educativa](https://www3.gobiernodecanarias.org/medusa/ecoescuela/ate/)
+
+Moodle™ is a registered trademark of [Moodle Pty Ltd](https://moodle.com/trademarks/).
+Moodle Playground is an independent project and is not affiliated with, endorsed by, or
+sponsored by Moodle Pty Ltd.

--- a/index.html
+++ b/index.html
@@ -220,6 +220,11 @@
 
           <footer class="side-panel__footer">
             <p>Made with &#10084;&#65039; by <a href="https://www3.gobiernodecanarias.org/medusa/ecoescuela/ate/" target="_blank" rel="noreferrer">Área de Tecnología Educativa</a></p>
+            <p class="side-panel__footer-disclaimer">
+              Moodle&#8482; is a registered trademark of
+              <a href="https://moodle.com/trademarks/" target="_blank" rel="noreferrer">Moodle Pty Ltd</a>.
+              This project is not affiliated with Moodle Pty Ltd.
+            </p>
             <a
               class="side-panel__footer-link"
               href="https://github.com/ateeducacion/moodle-playground"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,11 @@ edit_uri: edit/main/docs/
 docs_dir: docs
 site_dir: site
 
+copyright: >
+  Moodle&trade; is a registered trademark of
+  <a href="https://moodle.com/trademarks/">Moodle Pty Ltd</a>.
+  Moodle Playground is an independent project and is not affiliated with Moodle Pty Ltd.
+
 theme:
   name: material
   language: en

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -453,6 +453,12 @@ button.danger:hover {
   margin: 0;
 }
 
+.side-panel__footer-disclaimer {
+  font-size: 11px;
+  line-height: 1.4;
+  opacity: 0.85;
+}
+
 .side-panel__footer a {
   color: var(--chrome-text);
   text-decoration: none;


### PR DESCRIPTION
Adds a trademark and non-affiliation notice across the README, documentation, and the app's side-panel footer.

**Why:** the project carried no trademark/non-affiliation notice anywhere. The "Moodle" name and logo are trademarks of Moodle Pty Ltd, and the GPL does not grant trademark rights (see https://moodle.com/trademarks/). This adds a clear, polite notice in good faith.

**What:**
- **README** — new `## Trademark` section (and `™` on the first prominent mention).
- **Docs** — global MkDocs footer via the `copyright:` key (shows on every page) plus a short non-affiliation note on the landing page.
- **App** — a condensed disclaimer line in the shell's side-panel footer.

Wording uses nominative/descriptive phrasing ("runs the open-source Moodle™ software"), names Moodle Pty Ltd as the owner, links to the official policy, and mirrors the conventions used by LibreWolf, Bitnami, WP Engine, and PostgreSQL.

**Verification:** `make test` (642/642 pass), `make lint` (clean), `mkdocs build` (footer renders on every page), and a manual check of the running app's side-panel footer.
