### PR TITLE
Add a generic phpConstants blueprint capability (define PHP constants in config.php)

### DIFF
--- a/assets/blueprints/blueprint-schema.json
+++ b/assets/blueprints/blueprint-schema.json
@@ -24,6 +24,12 @@
       "type": "object",
       "additionalProperties": { "type": "string" }
     },
+    "phpConstants": {
+      "type": "object",
+      "description": "PHP constants defined in config.php (guarded by !defined and emitted before lib/setup.php) so a plugin blueprint can enable plugin-specific behaviour without the engine knowing the constant names.",
+      "propertyNames": { "pattern": "^[A-Z_][A-Z0-9_]*$" },
+      "additionalProperties": { "type": ["boolean", "string", "number"] }
+    },
     "resources": {
       "type": "object",
       "additionalProperties": {

--- a/docs/blueprints/reference.md
+++ b/docs/blueprints/reference.md
@@ -32,6 +32,7 @@ boot. Steps run in order.
 | `constants` | object | no | `{{KEY}}` → string map, substituted everywhere before steps run. |
 | `resources` | object | no | Named file descriptors referenced as `@name`. |
 | `runtime` | object | no | Boot-time `config.php` settings: `debug` (`0`/`5`/`15`/`32767`) and `debugdisplay` (`0`/`1`). See [Runtime and versions](runtime.md). |
+| `phpConstants` | object | no | PHP constants defined in `config.php` before `lib/setup.php`. Name → boolean / string / number. See [PHP constants](#php-constants). |
 | `landingPage` | string | no | Path opened after boot. Must start with `/`. |
 | `preferredVersions` | object | no | `{ "php": "8.3", "moodle": "5.0" }` — preferred runtime, subject to compatibility fallback. See [Runtime and versions](runtime.md). |
 | `$schema` | string | no | Informational schema reference. |
@@ -54,6 +55,38 @@ Context constants `{{REPO}}`, `{{OWNER}}`, `{{REF}}` / `{{BRANCH}}` are derived
 from the `repo` / `owner` / `branch` (alias `ref`) URL parameters and merged
 *over* the blueprint's own `constants`. This lets one committed blueprint target
 the branch it is previewed for. See [URL parameters](../url-parameters.md).
+
+## PHP constants
+
+`phpConstants` defines PHP constants in the booted Moodle's `config.php`, before
+`require_once(lib/setup.php)`, so they are available on every request. Each entry is
+emitted as a guarded `define()`:
+
+```json
+{
+  "phpConstants": {
+    "MY_FLAG": true,
+    "MY_LABEL": "demo",
+    "MY_LIMIT": 50
+  }
+}
+```
+
+produces, in `config.php`:
+
+```php
+if (!defined('MY_FLAG')) { define('MY_FLAG', true); }
+if (!defined('MY_LABEL')) { define('MY_LABEL', 'demo'); }
+if (!defined('MY_LIMIT')) { define('MY_LIMIT', 50); }
+```
+
+Values may be boolean, string or number; constant names must match
+`^[A-Z_][A-Z0-9_]*$` (other names are skipped). This lets a plugin's own blueprint
+enable plugin-specific configuration without the playground engine knowing anything
+plugin-specific. For example, `mod_exelearning` declares
+`"phpConstants": { "EXELEARNING_UNSAFE_LEGACY_IFRAME": true }` so its demo renders the
+content iframe same-origin (the php-wasm service worker cannot serve an opaque subframe);
+real Moodle never defines that constant.
 
 ## Resources
 

--- a/lib/config-template.js
+++ b/lib/config-template.js
@@ -4,6 +4,45 @@ function escapePhpSingleQuoted(value) {
   return String(value).replaceAll("\\", "\\\\").replaceAll("'", "\\'");
 }
 
+// PHP constant names allowed in a blueprint's `phpConstants` map. Anything that
+// does not match this pattern is silently skipped so a blueprint can never emit
+// invalid PHP into config.php.
+const PHP_CONSTANT_NAME = /^[A-Z_][A-Z0-9_]*$/;
+
+// Encode a JS value as a PHP literal for use inside define(): booleans become
+// the bare keywords true/false, numbers become numeric literals and everything
+// else is treated as a single-quoted PHP string.
+function encodePhpConstantValue(value) {
+  if (typeof value === "boolean") {
+    return value ? "true" : "false";
+  }
+  if (typeof value === "number") {
+    return String(value);
+  }
+  return `'${escapePhpSingleQuoted(value)}'`;
+}
+
+// Render a blueprint's `phpConstants` map as guarded define() blocks. Each entry
+// is emitted as `if (!defined('NAME')) { define('NAME', <value>); }` so the
+// engine never overrides a constant Moodle (or another runtime hook) already set.
+// Returns "" when there is nothing to emit so the caller can interpolate it
+// directly without producing stray whitespace.
+function renderPhpConstantDefines(phpConstants) {
+  if (!phpConstants || typeof phpConstants !== "object") {
+    return "";
+  }
+  const blocks = [];
+  for (const [name, value] of Object.entries(phpConstants)) {
+    if (!PHP_CONSTANT_NAME.test(name)) {
+      continue;
+    }
+    blocks.push(
+      `if (!defined('${name}')) {\n    define('${name}', ${encodePhpConstantValue(value)});\n}`,
+    );
+  }
+  return blocks.length ? `${blocks.join("\n")}\n\n` : "";
+}
+
 export function createMoodleConfigPhp({
   origin,
   adminUser,
@@ -13,8 +52,13 @@ export function createMoodleConfigPhp({
   dbPassword,
   dbUser,
   prefix,
+  phpConstants = {},
 }) {
   const wwwroot = `${origin}${MOODLE_BASE_PATH}`;
+  // Blueprint-driven PHP constants are defined before lib/setup.php loads so a
+  // plugin blueprint can enable plugin-specific behaviour without the engine
+  // knowing which constants exist.
+  const phpConstantDefines = renderPhpConstantDefines(phpConstants);
 
   return `<?php
 unset($CFG);
@@ -114,7 +158,7 @@ if (!isset($_SERVER['SERVER_NAME'])) {
     $_SERVER['SERVER_NAME'] = 'localhost';
 }
 
-require_once('${escapePhpSingleQuoted(MOODLE_ROOT)}/lib/setup.php');
+${phpConstantDefines}require_once('${escapePhpSingleQuoted(MOODLE_ROOT)}/lib/setup.php');
 `;
 }
 

--- a/src/runtime/bootstrap.js
+++ b/src/runtime/bootstrap.js
@@ -2567,6 +2567,12 @@ export async function bootstrapMoodle({
     },
     debug: effectiveDebug,
     debugdisplay: effectiveDebugDisplay,
+    // Carry the blueprint's top-level `phpConstants` map into config.php so a
+    // plugin blueprint can declare PHP constants the engine knows nothing about.
+    phpConstants:
+      blueprint?.phpConstants && typeof blueprint.phpConstants === "object"
+        ? blueprint.phpConstants
+        : {},
   };
   const phases = createBootstrapTracker();
 
@@ -2662,6 +2668,8 @@ export async function bootstrapMoodle({
     // Re-enable cachejs only when the manifest advertises the build-time
     // RequireJS combined seed (ADR 0013); legacy bundles keep cachejs=false.
     requirejsSeeded: Boolean(archive.manifest?.snapshot?.requirejs),
+    // Blueprint-declared PHP constants, defined in config.php before setup.php.
+    phpConstants: effectiveConfig.phpConstants,
   });
 
   // Kick off the install snapshot + localcache seed downloads NOW so the

--- a/src/runtime/config-template.js
+++ b/src/runtime/config-template.js
@@ -8,6 +8,45 @@ function escapePhpSingleQuoted(value) {
   return String(value).replaceAll("\\", "\\\\").replaceAll("'", "\\'");
 }
 
+// PHP constant names allowed in a blueprint's `phpConstants` map. Anything that
+// does not match this pattern is silently skipped so a blueprint can never emit
+// invalid PHP into config.php.
+const PHP_CONSTANT_NAME = /^[A-Z_][A-Z0-9_]*$/;
+
+// Encode a JS value as a PHP literal for use inside define(): booleans become
+// the bare keywords true/false, numbers become numeric literals and everything
+// else is treated as a single-quoted PHP string.
+function encodePhpConstantValue(value) {
+  if (typeof value === "boolean") {
+    return value ? "true" : "false";
+  }
+  if (typeof value === "number") {
+    return String(value);
+  }
+  return `'${escapePhpSingleQuoted(value)}'`;
+}
+
+// Render a blueprint's `phpConstants` map as guarded define() blocks. Each entry
+// is emitted as `if (!defined('NAME')) { define('NAME', <value>); }` so the
+// engine never overrides a constant Moodle (or another runtime hook) already set.
+// Returns "" when there is nothing to emit so the caller can interpolate it
+// directly without producing stray whitespace.
+function renderPhpConstantDefines(phpConstants) {
+  if (!phpConstants || typeof phpConstants !== "object") {
+    return "";
+  }
+  const blocks = [];
+  for (const [name, value] of Object.entries(phpConstants)) {
+    if (!PHP_CONSTANT_NAME.test(name)) {
+      continue;
+    }
+    blocks.push(
+      `if (!defined('${name}')) {\n    define('${name}', ${encodePhpConstantValue(value)});\n}`,
+    );
+  }
+  return blocks.length ? `${blocks.join("\n")}\n\n` : "";
+}
+
 export function buildComponentCachePath(moodleRoot) {
   return `${moodleRoot}/.playground/core_component.php`;
 }
@@ -26,9 +65,14 @@ export function createMoodleConfigPhp({
   playgroundProxyUrl = "",
   debugdisplay = 0,
   requirejsSeeded = false,
+  phpConstants = {},
 }) {
   const resolvedComponentCachePath =
     componentCachePath || buildComponentCachePath(moodleRoot);
+  // Blueprint-driven PHP constants are defined before lib/setup.php loads so a
+  // plugin blueprint can enable plugin-specific behaviour without the engine
+  // knowing which constants exist.
+  const phpConstantDefines = renderPhpConstantDefines(phpConstants);
   return `<?php
 unset($CFG);
 global $CFG;
@@ -205,7 +249,7 @@ spl_autoload_register(function ($class) {
     }
 });
 
-require_once('${escapePhpSingleQuoted(moodleRoot)}/lib/setup.php');
+${phpConstantDefines}require_once('${escapePhpSingleQuoted(moodleRoot)}/lib/setup.php');
 `;
 }
 


### PR DESCRIPTION
## Why

Plugins need a way to define a PHP constant in the booted Moodle's `config.php` from their own blueprint, without the playground engine knowing anything plugin-specific. Concretely, the eXeLearning plugin renders untrusted package content in an opaque-origin iframe in production; under php-wasm the service worker only serves same-origin documents, so the demo needs the plugin's dev-only `EXELEARNING_UNSAFE_LEGACY_IFRAME` constant set — and that decision belongs in the **plugin's** `blueprint.json`, not here. This mirrors how WordPress Playground exposes a generic `writeFile`/`defineWpConfigConsts` step and the plugin's blueprint uses it.

## What

Add a generic, optional top-level blueprint property **`phpConstants`** (object: constant name → boolean | string | number). The engine emits a guarded `if (!defined('NAME')) { define('NAME', <value>); }` for each entry in `config.php`, right before `require_once(lib/setup.php)`, so the constants are available on every request. No eXeLearning-specific value is hardcoded in the engine.

- `src/runtime/config-template.js` — emit the defines before `lib/setup.php` (booleans → `true`/`false`, numbers → literal, strings → single-quoted/escaped; names must match `^[A-Z_][A-Z0-9_]*$`).
- `src/runtime/bootstrap.js` — read `blueprint.phpConstants` and pass it to `createMoodleConfigPhp`.
- `assets/blueprints/blueprint-schema.json` — document the new property.

A blueprint then opts in with:
```json
"phpConstants": { "EXELEARNING_UNSAFE_LEGACY_IFRAME": true }
```

Consumed by `exelearning/mod_exelearning` PR #80 (its `blueprint.json` declares the constant; the plugin reads it via `player_iframe::is_unsafe_legacy()`).