### PR TITLE
Make blueprint panel editable and runnable

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,10 +211,31 @@
             <div class="panel__row">
               <span>Blueprint JSON</span>
               <span class="panel__row-actions">
-                <button type="button" id="run-button" class="primary" disabled>Run</button>
-                <button type="button" id="export-button">Export</button>
-                <label class="import-button" for="import-input">Import</label>
+                <button type="button" id="run-button" class="icon-button icon-button--primary icon-button--wide" title="Run blueprint" disabled>
+                  <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" focusable="false">
+                    <path d="M4 2.5v11l10-5.5-10-5.5Z"/>
+                  </svg>
+                  <span>Run</span>
+                </button>
+                <button type="button" id="export-button" class="icon-button icon-button--icon-only" title="Export blueprint JSON" aria-label="Export blueprint JSON">
+                  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+                    <path d="M8 2v7m0 0L5 6m3 3 3-3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M3 11v1.5A1.5 1.5 0 0 0 4.5 14h7a1.5 1.5 0 0 0 1.5-1.5V11" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+                  </svg>
+                </button>
+                <label class="import-button icon-button icon-button--icon-only" for="import-input" title="Import blueprint JSON" aria-label="Import blueprint JSON">
+                  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+                    <path d="M8 9V2m0 0L5 5m3-3 3 3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M3 11v1.5A1.5 1.5 0 0 0 4.5 14h7a1.5 1.5 0 0 0 1.5-1.5V11" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+                  </svg>
+                </label>
                 <input id="import-input" type="file" accept="application/json" hidden>
+                <button type="button" id="copy-button" class="icon-button icon-button--icon-only" title="Copy blueprint JSON" aria-label="Copy blueprint JSON">
+                  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+                    <rect x="5" y="5" width="8" height="9" rx="1.5" stroke="currentColor" stroke-width="1.3"/>
+                    <path d="M11 5V3.5A1.5 1.5 0 0 0 9.5 2h-5A1.5 1.5 0 0 0 3 3.5v7A1.5 1.5 0 0 0 4.5 12H5" stroke="currentColor" stroke-width="1.3" fill="none"/>
+                  </svg>
+                </button>
               </span>
             </div>
             <div class="blueprint-editor-wrap">

--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
     <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
     <link rel="stylesheet" href="./src/styles/app.css">
+    <link rel="stylesheet" href="./src/styles/blueprint-editor.css">
 
     <script type="application/ld+json">
     {
@@ -210,12 +211,32 @@
             <div class="panel__row">
               <span>Blueprint JSON</span>
               <span class="panel__row-actions">
+                <button type="button" id="run-button" class="primary" disabled>Run</button>
                 <button type="button" id="export-button">Export</button>
                 <label class="import-button" for="import-input">Import</label>
                 <input id="import-input" type="file" accept="application/json" hidden>
               </span>
             </div>
-            <textarea id="blueprint-textarea" class="panel-textarea" spellcheck="false" readonly></textarea>
+            <div class="blueprint-editor-wrap">
+              <div
+                id="blueprint-editor"
+                class="blueprint-editor is-hidden"
+                role="textbox"
+                aria-multiline="true"
+                aria-label="Blueprint JSON editor"
+                tabindex="0"
+                spellcheck="false"
+              ></div>
+              <textarea
+                id="blueprint-textarea"
+                class="panel-textarea blueprint-editor-fallback"
+                spellcheck="false"
+                aria-label="Blueprint JSON editor"
+              ></textarea>
+              <p id="blueprint-status" class="blueprint-status" role="status" aria-live="polite">
+                Loading blueprint…
+              </p>
+            </div>
           </section>
 
           <footer class="side-panel__footer">

--- a/openspec/changes/editable-blueprint-panel/proposal.md
+++ b/openspec/changes/editable-blueprint-panel/proposal.md
@@ -1,0 +1,40 @@
+# Editable Blueprint Panel
+
+## Why
+
+The Blueprint sidebar tab currently renders the active blueprint as read-only
+JSON in a plain `<textarea>`. Users cannot iterate on a blueprint without
+leaving the playground, editing a file externally, and re-importing it. There
+is also no way to re-run the *currently displayed* blueprint from the panel
+itself — only Import (from a file) and Export (to a file) exist.
+
+## What Changes
+
+- Replace the read-only textarea with an editable, syntax-highlighted JSON
+  editor built on [CodeJar](https://medv.io/codejar/), with a plain-textarea
+  fallback if CodeJar cannot be loaded.
+- Add inline JSON/schema validation that runs on every edit and reports
+  errors without touching the page.
+- Add a `Run` button next to Export/Import that re-encodes the edited JSON
+  into the existing `?blueprint=` URL flow and reloads the playground,
+  exactly like Import already does for a picked file.
+- Keep Export/Import working against the *live editor content*, not a stale
+  in-memory copy.
+- Add `src/shell/blueprint-editor-core.js` (pure helpers: HTML escaping, JSON
+  highlighting, formatting, validation-result mapping, run-URL building,
+  fallback encoding) and `src/shell/blueprint-editor.js` (CodeJar wiring /
+  DOM glue) so the logic is unit-testable independent of the DOM.
+
+## Impact
+
+- Affected specs: `blueprint-panel` (new capability spec).
+- Affected code: `index.html`, `src/styles/app.css` (+ new
+  `src/styles/blueprint-editor.css`), `src/shell/main.js`, new
+  `src/shell/blueprint-editor-core.js` and `src/shell/blueprint-editor.js`.
+- No changes to blueprint execution semantics, the runtime/bootstrap flow, or
+  the blueprint parser/validator/compressor — the shell only re-encodes JSON
+  into the existing URL parameter contract (the same contract Import already
+  uses).
+- `tests/e2e/shell.spec.mjs`'s blueprint-tab assertions are updated to
+  reflect that `#blueprint-textarea` becomes a hidden compatibility bridge
+  once the CodeJar editor is active.

--- a/openspec/changes/editable-blueprint-panel/specs/blueprint-panel/spec.md
+++ b/openspec/changes/editable-blueprint-panel/specs/blueprint-panel/spec.md
@@ -1,0 +1,102 @@
+# Blueprint Panel Specification
+
+## ADDED Requirements
+
+### Requirement: Editable blueprint editor
+The Blueprint sidebar tab SHALL display the active blueprint JSON in an
+editable, syntax-highlighted code editor built on CodeJar, instead of a
+read-only textarea.
+
+#### Scenario: Opening the Blueprint tab
+- **WHEN** the user opens the Blueprint tab
+- **THEN** the panel shows the active blueprint JSON with visible syntax
+  highlighting (keys, strings, numbers, booleans, null in distinct colors)
+- **AND** the JSON text is editable via keyboard
+
+#### Scenario: CodeJar fails to load
+- **WHEN** the CodeJar module cannot be loaded (e.g. offline, CDN blocked)
+- **THEN** the panel falls back to a plain editable textarea
+- **AND** validation and the Run button continue to work
+
+### Requirement: Inline validation
+The Blueprint panel SHALL validate the editor's JSON content on every edit,
+without reloading or navigating the page.
+
+#### Scenario: Malformed JSON
+- **WHEN** the editor content is not valid JSON
+- **THEN** an inline status message describes the JSON error
+- **AND** the Run button is disabled
+- **AND** the page is not reloaded
+
+#### Scenario: JSON valid but blueprint schema invalid
+- **WHEN** the editor content parses as JSON but fails `validateBlueprint`
+- **THEN** an inline status message lists the schema error(s)
+- **AND** the Run button is disabled
+- **AND** the page is not reloaded
+
+#### Scenario: Valid blueprint
+- **WHEN** the editor content is valid JSON and passes `validateBlueprint`
+- **THEN** the inline status message confirms the blueprint is valid
+- **AND** the Run button is enabled
+
+### Requirement: Run action
+The Blueprint panel SHALL provide a `Run` button, next to Export and Import,
+that restarts the playground using the edited blueprint via the existing
+`?blueprint=` URL flow.
+
+#### Scenario: Running a valid edited blueprint
+- **WHEN** the user clicks Run while the editor content is valid
+- **THEN** the shell parses the JSON, normalizes it with `parseBlueprint`,
+  and validates it with `validateBlueprint`
+- **AND** the shell encodes the normalized blueprint with
+  `compressBlueprint`, falling back to plain base64url JSON if compression
+  is unavailable
+- **AND** the shell sets `blueprint=<encoded>` on the current URL and
+  deletes any `blueprint-url` parameter
+- **AND** the browser navigates to that URL, causing the playground to
+  reboot with the edited blueprint
+
+#### Scenario: Running an invalid edited blueprint
+- **WHEN** the user attempts to run while the editor content is invalid
+- **THEN** the Run button is disabled and no navigation occurs
+
+### Requirement: Export uses live editor content
+Export SHALL serialize the current editor content (not a stale in-memory
+copy captured at boot).
+
+#### Scenario: Exporting after an edit
+- **WHEN** the user edits the blueprint JSON and clicks Export
+- **THEN** the downloaded file reflects the edited JSON, pretty-printed
+- **AND** if the edited JSON is invalid, Export is blocked with an inline
+  error instead of downloading a broken file
+
+### Requirement: Import updates the editor
+Import SHALL keep updating the editor content, including after the
+full-page reload it triggers.
+
+#### Scenario: Importing a blueprint file
+- **WHEN** the user imports a blueprint JSON file
+- **THEN** the playground reloads with the imported blueprint encoded in the
+  `blueprint` URL parameter
+- **AND** after reload, the editor displays the imported blueprint
+
+### Requirement: Compatibility bridge
+The panel SHALL keep a `#blueprint-textarea` element synchronized with the
+editor content at all times, so existing code and tests that read the active
+blueprint value keep working even when it is not visible.
+
+#### Scenario: CodeJar active
+- **WHEN** CodeJar has loaded successfully
+- **THEN** `#blueprint-textarea` is hidden but its `value` always matches
+  the CodeJar editor content
+
+### Requirement: Accessibility
+The editor SHALL be usable with assistive technology and the keyboard.
+
+#### Scenario: Screen reader and keyboard access
+- **WHEN** a screen reader or keyboard-only user reaches the Blueprint panel
+- **THEN** the editor exposes `role="textbox"`, `aria-multiline="true"`, and
+  a meaningful accessible name
+- **AND** the status message is exposed via `role="status"` (or equivalent
+  live region)
+- **AND** the editor can be focused and edited with the keyboard alone

--- a/openspec/changes/editable-blueprint-panel/tasks.md
+++ b/openspec/changes/editable-blueprint-panel/tasks.md
@@ -1,0 +1,20 @@
+# Tasks: Editable Blueprint Panel
+
+## 1. Pure helpers (TDD)
+- [x] 1.1 Write failing tests for `src/shell/blueprint-editor-core.js` in `tests/shell/blueprint-editor-core.test.js`
+- [x] 1.2 Implement `escapeHtml`, `highlightJson`, `formatBlueprintText`, `getInitialBlueprintCode`
+- [x] 1.3 Implement `createBlueprintValidationResult` (JSON stage + schema stage + valid stage)
+- [x] 1.4 Implement `encodeBlueprintFallback` and `buildBlueprintRunUrl`
+- [x] 1.5 Verify all tests pass (`npm test`)
+
+## 2. Editor wiring
+- [x] 2.1 Implement `src/shell/blueprint-editor.js`: CodeJar dynamic import + fallback textarea, live validation, Run button wiring, `setCode`/`getCode`/`getValidationResult`/`setLocked` API
+- [x] 2.2 Update `index.html`: CodeJar mount element, Run button, status area, accessible labels
+- [x] 2.3 Add `src/styles/blueprint-editor.css`: dark editor surface, token colors, status states
+- [x] 2.4 Wire `src/shell/main.js`: initialize the editor once, delegate `updateBlueprintTextarea`/`exportBlueprint` to it, lock/unlock Run with the rest of the UI
+
+## 3. Verification
+- [x] 3.1 `npm test`
+- [x] 3.2 `make lint`
+- [x] 3.3 Manual verification in a real browser (`make serve`) — CodeJar rendering/highlighting, live JSON/schema validation, Run round-trip (real gzip encoding + reboot), Export using live content, and the plain-textarea fallback all confirmed working
+- [x] 3.4 Update `tests/e2e/shell.spec.mjs` blueprint-tab assertions for the new editor

--- a/src/shell/blueprint-editor-core.js
+++ b/src/shell/blueprint-editor-core.js
@@ -1,0 +1,212 @@
+/**
+ * Pure helpers for the editable Blueprint panel (no DOM access here — see
+ * `blueprint-editor.js` for CodeJar wiring). Kept dependency-free so they can
+ * be unit tested directly.
+ */
+
+/**
+ * Escape a string for safe insertion into HTML text content.
+ *
+ * @param {*} value
+ * @returns {string}
+ */
+export function escapeHtml(value) {
+  if (typeof value !== "string") {
+    return "";
+  }
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+// Matches, in priority order: a quoted string (optionally followed by the
+// colon that marks it as an object key), a boolean literal, a null literal,
+// or a number. Everything else (punctuation, whitespace) falls through
+// untouched between matches.
+const JSON_TOKEN_RE =
+  /("(?:\\.|[^"\\])*")(\s*:)?|\b(true|false)\b|\b(null)\b|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)/gu;
+
+/**
+ * Render JSON source as HTML with `bp-tok-*` span classes for keys, strings,
+ * numbers, booleans and null — a small hand-rolled tokenizer instead of a
+ * full syntax-highlighting dependency.
+ *
+ * @param {string} code
+ * @returns {string} HTML-safe markup.
+ */
+export function highlightJson(code) {
+  const text = typeof code === "string" ? code : "";
+  let html = "";
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(JSON_TOKEN_RE)) {
+    const [
+      full,
+      stringLiteral,
+      colonSuffix,
+      boolLiteral,
+      nullLiteral,
+      numberLiteral,
+    ] = match;
+    html += escapeHtml(text.slice(lastIndex, match.index));
+
+    if (stringLiteral !== undefined) {
+      const cssClass = colonSuffix ? "bp-tok-key" : "bp-tok-string";
+      html += `<span class="${cssClass}">${escapeHtml(stringLiteral)}</span>`;
+      html += escapeHtml(colonSuffix || "");
+    } else if (boolLiteral !== undefined) {
+      html += `<span class="bp-tok-boolean">${escapeHtml(boolLiteral)}</span>`;
+    } else if (nullLiteral !== undefined) {
+      html += `<span class="bp-tok-null">${escapeHtml(nullLiteral)}</span>`;
+    } else if (numberLiteral !== undefined) {
+      html += `<span class="bp-tok-number">${escapeHtml(numberLiteral)}</span>`;
+    }
+
+    lastIndex = match.index + full.length;
+  }
+
+  html += escapeHtml(text.slice(lastIndex));
+  return html;
+}
+
+/**
+ * Pretty-print a JSON string with 2-space indentation.
+ *
+ * @param {string} rawText
+ * @returns {string}
+ * @throws {SyntaxError} if `rawText` is not valid JSON.
+ */
+export function formatBlueprintText(rawText) {
+  return JSON.stringify(JSON.parse(rawText), null, 2);
+}
+
+/**
+ * Compute the code to seed the editor with from source text (typically the
+ * hidden `#blueprint-textarea` value). Pretty-prints valid JSON; falls back
+ * to the raw text unchanged if it can't be parsed, so partially-typed or
+ * externally-supplied text is never discarded.
+ *
+ * @param {*} sourceText
+ * @returns {string}
+ */
+export function getInitialBlueprintCode(sourceText) {
+  const text = typeof sourceText === "string" ? sourceText : "";
+  if (!text.trim()) {
+    return "";
+  }
+  try {
+    return formatBlueprintText(text);
+  } catch {
+    return text;
+  }
+}
+
+function describeBlueprintErrors(errors) {
+  if (!errors || errors.length === 0) {
+    return "Blueprint schema is invalid.";
+  }
+  if (errors.length === 1) {
+    return `Blueprint is invalid: ${errors[0]}`;
+  }
+  return `Blueprint is invalid (${errors.length} issues): ${errors[0]}`;
+}
+
+/**
+ * Run the editor content through the JSON parse -> blueprint normalize ->
+ * blueprint schema validation pipeline, mapping the result to a single
+ * user-facing status. Never throws.
+ *
+ * @param {string} rawText
+ * @param {{parseBlueprint: Function, validateBlueprint: Function}} deps
+ * @returns {{valid: boolean, stage: "json"|"schema"|"valid", message: string, errors: string[], blueprint: object|null}}
+ */
+export function createBlueprintValidationResult(rawText, deps) {
+  const { parseBlueprint, validateBlueprint } = deps;
+
+  const trimmed = typeof rawText === "string" ? rawText.trim() : "";
+  if (!trimmed) {
+    return {
+      valid: false,
+      stage: "json",
+      message: "Blueprint cannot be empty.",
+      errors: [],
+      blueprint: null,
+    };
+  }
+
+  let parsedJson;
+  try {
+    parsedJson = JSON.parse(trimmed);
+  } catch (error) {
+    return {
+      valid: false,
+      stage: "json",
+      message: `Invalid JSON: ${error.message}`,
+      errors: [],
+      blueprint: null,
+    };
+  }
+
+  let blueprint;
+  try {
+    blueprint = parseBlueprint(parsedJson);
+  } catch (error) {
+    return {
+      valid: false,
+      stage: "json",
+      message: `Invalid JSON: ${error.message}`,
+      errors: [],
+      blueprint: null,
+    };
+  }
+
+  const { valid, errors } = validateBlueprint(blueprint);
+  if (!valid) {
+    return {
+      valid: false,
+      stage: "schema",
+      message: describeBlueprintErrors(errors),
+      errors,
+      blueprint,
+    };
+  }
+
+  return {
+    valid: true,
+    stage: "valid",
+    message: "Blueprint is valid.",
+    errors: [],
+    blueprint,
+  };
+}
+
+/**
+ * Base64-encode a blueprint for the `?blueprint=` URL param when
+ * `compressBlueprint` (gzip) is unavailable. Mirrors the fallback already
+ * used by the Import flow in `src/shell/main.js`.
+ *
+ * @param {object} blueprint
+ * @returns {string}
+ */
+export function encodeBlueprintFallback(blueprint) {
+  return btoa(unescape(encodeURIComponent(JSON.stringify(blueprint))));
+}
+
+/**
+ * Build the URL to navigate to in order to run an edited blueprint: sets
+ * `blueprint=<encodedBlueprint>` and removes any `blueprint-url` param,
+ * preserving everything else on the current URL.
+ *
+ * @param {string} currentHref
+ * @param {string} encodedBlueprint
+ * @returns {string}
+ */
+export function buildBlueprintRunUrl(currentHref, encodedBlueprint) {
+  const url = new URL(currentHref);
+  url.searchParams.set("blueprint", encodedBlueprint);
+  url.searchParams.delete("blueprint-url");
+  return url.toString();
+}

--- a/src/shell/blueprint-editor.js
+++ b/src/shell/blueprint-editor.js
@@ -1,0 +1,157 @@
+import {
+  compressBlueprint,
+  parseBlueprint,
+  validateBlueprint,
+} from "../blueprint/index.js";
+import {
+  buildBlueprintRunUrl,
+  createBlueprintValidationResult,
+  encodeBlueprintFallback,
+  highlightJson,
+} from "./blueprint-editor-core.js";
+
+// Pinned version, loaded on demand so the static shell doesn't need a bundler
+// step for it. If the CDN is unreachable the panel falls back to a plain
+// editable textarea (see initBlueprintEditor below).
+const CODEJAR_MODULE_URL =
+  "https://cdn.jsdelivr.net/npm/codejar@4.3.0/dist/codejar.js";
+
+function highlightForCodeJar(editor) {
+  editor.innerHTML = highlightJson(editor.textContent);
+}
+
+/**
+ * Wire the Blueprint panel's editor: CodeJar (with a plain-textarea
+ * fallback), live JSON/schema validation, and the Run button. The hidden
+ * `textarea` stays in sync with the editor content at all times, so any
+ * existing code that reads `#blueprint-textarea` keeps working.
+ *
+ * @param {{mount: HTMLElement|null, textarea: HTMLTextAreaElement, statusEl: HTMLElement|null, runButton: HTMLButtonElement|null}} elements
+ * @param {{location?: Location}} [options]
+ * @returns {{setCode(text: string): void, getCode(): string, getValidationResult(): object, setLocked(locked: boolean): void}}
+ */
+export function initBlueprintEditor(elements, options = {}) {
+  const { mount, textarea, statusEl, runButton } = elements;
+  const loc = options.location || window.location;
+
+  let jar = null;
+  let locked = false;
+  let currentText = textarea ? textarea.value : "";
+  let latestResult = createBlueprintValidationResult(currentText, {
+    parseBlueprint,
+    validateBlueprint,
+  });
+
+  function getText() {
+    return jar ? jar.toString() : currentText;
+  }
+
+  function updateRunButtonState() {
+    if (!runButton) return;
+    runButton.disabled = locked || !latestResult.valid;
+  }
+
+  function applyStatus() {
+    if (!statusEl) return;
+    statusEl.classList.remove("is-valid", "is-invalid", "is-running");
+    statusEl.classList.add(latestResult.valid ? "is-valid" : "is-invalid");
+    statusEl.textContent = latestResult.message;
+  }
+
+  function revalidate(text) {
+    latestResult = createBlueprintValidationResult(text, {
+      parseBlueprint,
+      validateBlueprint,
+    });
+    applyStatus();
+    updateRunButtonState();
+    return latestResult;
+  }
+
+  function handleTextChanged(text) {
+    currentText = text;
+    if (textarea) {
+      textarea.value = text;
+    }
+    revalidate(text);
+  }
+
+  if (textarea) {
+    textarea.readOnly = false;
+    textarea.addEventListener("input", () => {
+      if (jar) return; // CodeJar owns editing once it takes over.
+      handleTextChanged(textarea.value);
+    });
+  }
+
+  revalidate(currentText);
+
+  if (mount) {
+    import(/* webpackIgnore: true */ CODEJAR_MODULE_URL)
+      .then(({ CodeJar }) => {
+        jar = CodeJar(mount, highlightForCodeJar, { tab: "  " });
+        jar.updateCode(currentText, false);
+        highlightForCodeJar(mount);
+        jar.onUpdate((code) => handleTextChanged(code));
+
+        mount.classList.remove("is-hidden");
+        if (textarea) {
+          textarea.classList.add("is-hidden");
+        }
+      })
+      .catch(() => {
+        // CodeJar unavailable — the fallback textarea (already wired above)
+        // stays the active, visible editor.
+      });
+  }
+
+  if (runButton) {
+    runButton.addEventListener("click", async () => {
+      const result = revalidate(getText());
+      if (!result.valid) {
+        return;
+      }
+
+      runButton.disabled = true;
+      if (statusEl) {
+        statusEl.classList.remove("is-valid", "is-invalid");
+        statusEl.classList.add("is-running");
+        statusEl.textContent = "Encoding blueprint and restarting playground…";
+      }
+
+      let encoded;
+      try {
+        encoded = await compressBlueprint(result.blueprint);
+      } catch {
+        encoded = encodeBlueprintFallback(result.blueprint);
+      }
+
+      loc.href = buildBlueprintRunUrl(loc.href, encoded);
+    });
+  }
+
+  return {
+    setCode(text) {
+      const safeText = typeof text === "string" ? text : "";
+      currentText = safeText;
+      if (textarea) {
+        textarea.value = safeText;
+        textarea.scrollTop = 0;
+      }
+      if (jar) {
+        jar.updateCode(safeText, false);
+      }
+      revalidate(safeText);
+    },
+    getCode() {
+      return getText();
+    },
+    getValidationResult() {
+      return latestResult;
+    },
+    setLocked(value) {
+      locked = Boolean(value);
+      updateRunButtonState();
+    },
+  };
+}

--- a/src/shell/blueprint-editor.js
+++ b/src/shell/blueprint-editor.js
@@ -26,12 +26,12 @@ function highlightForCodeJar(editor) {
  * `textarea` stays in sync with the editor content at all times, so any
  * existing code that reads `#blueprint-textarea` keeps working.
  *
- * @param {{mount: HTMLElement|null, textarea: HTMLTextAreaElement, statusEl: HTMLElement|null, runButton: HTMLButtonElement|null}} elements
+ * @param {{mount: HTMLElement|null, textarea: HTMLTextAreaElement, statusEl: HTMLElement|null, runButton: HTMLButtonElement|null, copyButton: HTMLButtonElement|null}} elements
  * @param {{location?: Location}} [options]
  * @returns {{setCode(text: string): void, getCode(): string, getValidationResult(): object, setLocked(locked: boolean): void}}
  */
 export function initBlueprintEditor(elements, options = {}) {
-  const { mount, textarea, statusEl, runButton } = elements;
+  const { mount, textarea, statusEl, runButton, copyButton } = elements;
   const loc = options.location || window.location;
 
   let jar = null;
@@ -89,6 +89,13 @@ export function initBlueprintEditor(elements, options = {}) {
   if (mount) {
     import(/* webpackIgnore: true */ CODEJAR_MODULE_URL)
       .then(({ CodeJar }) => {
+        // The CDN fetch is async, so the user may already be typing in the
+        // fallback textarea by the time this resolves. Carry focus over to
+        // the CodeJar mount so those keystrokes keep landing on the active
+        // editor instead of silently hitting the now-hidden textarea (whose
+        // own input listener turns into a no-op once `jar` is set below).
+        const hadFocus = document.activeElement === textarea;
+
         jar = CodeJar(mount, highlightForCodeJar, { tab: "  " });
         jar.updateCode(currentText, false);
         highlightForCodeJar(mount);
@@ -97,6 +104,9 @@ export function initBlueprintEditor(elements, options = {}) {
         mount.classList.remove("is-hidden");
         if (textarea) {
           textarea.classList.add("is-hidden");
+        }
+        if (hadFocus) {
+          mount.focus();
         }
       })
       .catch(() => {
@@ -127,6 +137,31 @@ export function initBlueprintEditor(elements, options = {}) {
       }
 
       loc.href = buildBlueprintRunUrl(loc.href, encoded);
+    });
+  }
+
+  if (copyButton) {
+    const originalTitle = copyButton.getAttribute("title") || "";
+    const originalAriaLabel = copyButton.getAttribute("aria-label") || "";
+    const originalHtml = copyButton.innerHTML;
+    const checkmarkHtml =
+      '<svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">' +
+      '<path d="M3 8.5 6.5 12 13 4.5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>' +
+      "</svg>";
+    copyButton.addEventListener("click", async () => {
+      try {
+        await navigator.clipboard.writeText(getText());
+      } catch {
+        return;
+      }
+      copyButton.innerHTML = checkmarkHtml;
+      copyButton.setAttribute("title", "Copied!");
+      copyButton.setAttribute("aria-label", "Copied!");
+      setTimeout(() => {
+        copyButton.innerHTML = originalHtml;
+        copyButton.setAttribute("title", originalTitle);
+        copyButton.setAttribute("aria-label", originalAriaLabel);
+      }, 1200);
     });
   }
 

--- a/src/shell/main.js
+++ b/src/shell/main.js
@@ -34,6 +34,7 @@ const els = {
   blueprintTab: document.querySelector("#blueprint-tab"),
   blueprintTextarea: document.querySelector("#blueprint-textarea"),
   clearLogs: document.querySelector("#clear-logs-button"),
+  copyBlueprintButton: document.querySelector("#copy-button"),
   copyLogs: document.querySelector("#copy-logs-button"),
   exportButton: document.querySelector("#export-button"),
   importInput: document.querySelector("#import-input"),
@@ -69,6 +70,7 @@ const blueprintEditor = initBlueprintEditor({
   textarea: els.blueprintTextarea,
   statusEl: els.blueprintStatus,
   runButton: els.runButton,
+  copyButton: els.copyBlueprintButton,
 });
 let config;
 let currentRuntimeId;

--- a/src/shell/main.js
+++ b/src/shell/main.js
@@ -23,17 +23,21 @@ import {
   resolveRuntimeSelection,
   shouldTraceRuntimeSelection,
 } from "../shared/version-resolver.js";
+import { initBlueprintEditor } from "./blueprint-editor.js";
 
 const els = {
   addressForm: document.querySelector("#address-form"),
   address: document.querySelector("#address-input"),
+  blueprintEditorMount: document.querySelector("#blueprint-editor"),
   blueprintPanel: document.querySelector("#blueprint-panel"),
+  blueprintStatus: document.querySelector("#blueprint-status"),
   blueprintTab: document.querySelector("#blueprint-tab"),
   blueprintTextarea: document.querySelector("#blueprint-textarea"),
   clearLogs: document.querySelector("#clear-logs-button"),
   copyLogs: document.querySelector("#copy-logs-button"),
   exportButton: document.querySelector("#export-button"),
   importInput: document.querySelector("#import-input"),
+  runButton: document.querySelector("#run-button"),
   frame: document.querySelector("#site-frame"),
   logPanel: document.querySelector("#log-panel"),
   logsPanel: document.querySelector("#logs-panel"),
@@ -60,6 +64,12 @@ const els = {
 };
 
 const scopeId = getOrCreateScopeId();
+const blueprintEditor = initBlueprintEditor({
+  mount: els.blueprintEditorMount,
+  textarea: els.blueprintTextarea,
+  statusEl: els.blueprintStatus,
+  runButton: els.runButton,
+});
 let config;
 let currentRuntimeId;
 let currentPhpVersion = DEFAULT_PHP_VERSION;
@@ -129,6 +139,7 @@ function setUiLocked(locked) {
   els.exportButton.disabled = locked;
   els.importInput.disabled = locked;
   els.addressForm.classList.toggle("is-disabled", locked);
+  blueprintEditor.setLocked(locked);
 }
 
 async function ensureRuntimeServiceWorker() {
@@ -315,8 +326,13 @@ function saveState(extra = {}) {
 }
 
 function exportBlueprint() {
-  const payload = activeBlueprint || {};
-  const blob = new Blob([JSON.stringify(payload, null, 2)], {
+  const result = blueprintEditor.getValidationResult();
+  if (!result.valid) {
+    appendLog(`Cannot export blueprint: ${result.message}`, true);
+    return;
+  }
+
+  const blob = new Blob([JSON.stringify(result.blueprint, null, 2)], {
     type: "application/json",
   });
   const url = URL.createObjectURL(blob);
@@ -328,12 +344,11 @@ function exportBlueprint() {
 }
 
 function updateBlueprintTextarea() {
-  if (!activeBlueprint || !els.blueprintTextarea) {
+  if (!activeBlueprint) {
     return;
   }
 
-  els.blueprintTextarea.value = JSON.stringify(activeBlueprint, null, 2);
-  els.blueprintTextarea.scrollTop = 0;
+  blueprintEditor.setCode(JSON.stringify(activeBlueprint, null, 2));
 }
 
 async function importPayload(file) {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -530,6 +530,8 @@ button.danger:hover {
 /* ── Panel rows (logs/phpinfo/blueprint headers) ──── */
 .panel__row {
   justify-content: space-between;
+  flex-wrap: wrap;
+  row-gap: var(--space-xs);
   margin-bottom: var(--space-sm);
   font:
     600 11px / 1.2 ui-monospace,
@@ -542,7 +544,16 @@ button.danger:hover {
 
 .panel__row-actions {
   display: flex;
+  flex-wrap: wrap;
+  flex-shrink: 0;
+  justify-content: flex-end;
   gap: var(--space-xs);
+}
+
+.panel__row-actions button,
+.panel__row-actions label {
+  text-transform: none;
+  letter-spacing: normal;
 }
 
 /* ── Log panel ────────────────────────────────────── */

--- a/src/styles/blueprint-editor.css
+++ b/src/styles/blueprint-editor.css
@@ -1,0 +1,103 @@
+/* ── Blueprint editor (CodeJar + fallback textarea) ──────────────── */
+.blueprint-editor-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  min-height: 0;
+  height: 100%;
+}
+
+.blueprint-editor,
+.blueprint-editor-fallback {
+  flex: 1;
+  min-height: 180px;
+  margin: 0;
+}
+
+/* CodeJar mount point. Matches .panel-textarea's dark surface so the
+   fallback and the upgraded editor are visually indistinguishable. */
+.blueprint-editor {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-md);
+  background: var(--color-gray-900);
+  color: #e4e8ec;
+  font:
+    12px / 1.5 ui-monospace,
+    "SFMono-Regular",
+    monospace;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.blueprint-editor.is-hidden,
+.blueprint-editor-fallback.is-hidden {
+  display: none;
+}
+
+.blueprint-editor:focus,
+.blueprint-editor:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--color-orange-light);
+}
+
+/* JSON token colors (dark surface) */
+.blueprint-editor .bp-tok-key {
+  color: #7dd3fc;
+}
+
+.blueprint-editor .bp-tok-string {
+  color: #facc15;
+}
+
+.blueprint-editor .bp-tok-number {
+  color: #c4b5fd;
+}
+
+.blueprint-editor .bp-tok-boolean {
+  color: #fb923c;
+  font-weight: 600;
+}
+
+.blueprint-editor .bp-tok-null {
+  color: var(--color-gray-500);
+  font-style: italic;
+}
+
+.blueprint-status {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--text-muted);
+  min-height: 1.4em;
+}
+
+.blueprint-status.is-valid {
+  color: var(--color-success);
+}
+
+.blueprint-status.is-invalid {
+  color: var(--color-danger);
+}
+
+.blueprint-status.is-running {
+  color: var(--text-muted);
+}
+
+button.primary {
+  color: var(--color-white);
+  background: var(--accent);
+  border-color: transparent;
+}
+
+button.primary:hover {
+  background: var(--accent-hover);
+}
+
+button.primary:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+  background: var(--accent);
+}

--- a/src/styles/blueprint-editor.css
+++ b/src/styles/blueprint-editor.css
@@ -86,17 +86,43 @@
   color: var(--text-muted);
 }
 
-button.primary {
+/* ── Icon buttons: Export/Import/Run/Copy, all in the top row ────── */
+.icon-button {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  gap: 5px;
+  padding: 6px 10px;
+  white-space: nowrap;
+}
+
+.icon-button svg {
+  flex: none;
+}
+
+.icon-button--icon-only {
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+}
+
+.icon-button--wide {
+  min-width: 76px;
+  justify-content: center;
+}
+
+.icon-button--primary {
   color: var(--color-white);
   background: var(--accent);
   border-color: transparent;
 }
 
-button.primary:hover {
+.icon-button--primary:hover {
   background: var(--accent-hover);
 }
 
-button.primary:disabled {
+.icon-button--primary:disabled {
   cursor: not-allowed;
   opacity: 0.45;
   background: var(--accent);

--- a/tests/e2e/shell.spec.mjs
+++ b/tests/e2e/shell.spec.mjs
@@ -152,11 +152,38 @@ test("blueprint tab shows the active blueprint JSON", async ({
 
   await page.locator("#panel-toggle-button").click();
   await page.locator("#blueprint-tab").click();
-  await expect(page.locator("#blueprint-textarea")).toBeVisible();
+  // The CodeJar editor visually supersedes the textarea; #blueprint-textarea
+  // stays in the DOM as a hidden compatibility bridge (see
+  // src/shell/blueprint-editor.js), so its value is still readable here.
+  await expect(page.locator("#blueprint-editor")).toBeVisible();
 
   const blueprintText = await page.locator("#blueprint-textarea").inputValue();
   expect(blueprintText).toContain('"steps"');
   expect(blueprintText).toContain('"installMoodle"');
+});
+
+test("blueprint editor validates edits and gates the Run button", async ({
+  page,
+  playground,
+}) => {
+  await playground.open();
+
+  await page.locator("#panel-toggle-button").click();
+  await page.locator("#blueprint-tab").click();
+
+  await expect(page.locator("#run-button")).toBeEnabled();
+  await expect(page.locator("#blueprint-status")).toHaveText(/valid/i);
+
+  const editor = page.locator("#blueprint-editor");
+  await editor.click();
+  await page.keyboard.press("ControlOrMeta+A");
+  await page.keyboard.type("not json at all");
+
+  await expect(page.locator("#blueprint-status")).toContainText(/invalid/i);
+  await expect(page.locator("#run-button")).toBeDisabled();
+
+  // Invalid content must never trigger a navigation/reload.
+  expect(new URL(page.url()).searchParams.has("blueprint")).toBe(false);
 });
 
 test("info panel hosts the version config with a dirty-state apply", async ({

--- a/tests/shell/blueprint-editor-core.test.js
+++ b/tests/shell/blueprint-editor-core.test.js
@@ -1,0 +1,189 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  buildBlueprintRunUrl,
+  createBlueprintValidationResult,
+  encodeBlueprintFallback,
+  escapeHtml,
+  formatBlueprintText,
+  getInitialBlueprintCode,
+  highlightJson,
+} from "../../src/shell/blueprint-editor-core.js";
+
+describe("escapeHtml", () => {
+  it("escapes ampersands, angle brackets and double quotes", () => {
+    assert.strictEqual(
+      escapeHtml(`<a href="x">Tom & Jerry</a>`),
+      "&lt;a href=&quot;x&quot;&gt;Tom &amp; Jerry&lt;/a&gt;",
+    );
+  });
+
+  it("escapes single quotes", () => {
+    assert.strictEqual(escapeHtml("it's"), "it&#39;s");
+  });
+
+  it("returns an empty string for non-string input", () => {
+    assert.strictEqual(escapeHtml(undefined), "");
+    assert.strictEqual(escapeHtml(null), "");
+  });
+});
+
+describe("highlightJson", () => {
+  it("wraps object keys in a key token class", () => {
+    const html = highlightJson('{"name": "value"}');
+    assert.match(html, /<span class="bp-tok-key">&quot;name&quot;<\/span>/);
+  });
+
+  it("wraps string values in a string token class", () => {
+    const html = highlightJson('{"name": "value"}');
+    assert.match(html, /<span class="bp-tok-string">&quot;value&quot;<\/span>/);
+  });
+
+  it("wraps numbers in a number token class", () => {
+    const html = highlightJson('{"count": 42}');
+    assert.match(html, /<span class="bp-tok-number">42<\/span>/);
+  });
+
+  it("wraps booleans in a boolean token class", () => {
+    const html = highlightJson('{"active": true}');
+    assert.match(html, /<span class="bp-tok-boolean">true<\/span>/);
+  });
+
+  it("wraps null in a null token class", () => {
+    const html = highlightJson('{"value": null}');
+    assert.match(html, /<span class="bp-tok-null">null<\/span>/);
+  });
+
+  it("escapes HTML-sensitive characters inside string values", () => {
+    const html = highlightJson('{"html": "<b>&"}');
+    assert.match(html, /&lt;b&gt;&amp;/);
+    assert.doesNotMatch(html, /<b>/);
+  });
+
+  it("returns an empty string for empty input", () => {
+    assert.strictEqual(highlightJson(""), "");
+  });
+
+  it("tolerates malformed JSON without throwing", () => {
+    assert.doesNotThrow(() => highlightJson('{"broken": '));
+  });
+});
+
+describe("formatBlueprintText", () => {
+  it("pretty-prints valid JSON with 2-space indentation", () => {
+    assert.strictEqual(
+      formatBlueprintText('{"steps":[{"step":"login"}]}'),
+      '{\n  "steps": [\n    {\n      "step": "login"\n    }\n  ]\n}',
+    );
+  });
+
+  it("throws for malformed JSON", () => {
+    assert.throws(() => formatBlueprintText("{invalid"));
+  });
+});
+
+describe("getInitialBlueprintCode", () => {
+  it("pretty-prints valid JSON text", () => {
+    assert.strictEqual(
+      getInitialBlueprintCode('{"steps":[]}'),
+      '{\n  "steps": []\n}',
+    );
+  });
+
+  it("returns the raw text unchanged when JSON is malformed", () => {
+    assert.strictEqual(getInitialBlueprintCode("not json"), "not json");
+  });
+
+  it("returns an empty string for blank or non-string input", () => {
+    assert.strictEqual(getInitialBlueprintCode(""), "");
+    assert.strictEqual(getInitialBlueprintCode("   "), "");
+    assert.strictEqual(getInitialBlueprintCode(undefined), "");
+  });
+});
+
+describe("createBlueprintValidationResult", () => {
+  const parseBlueprint = (input) => {
+    if (typeof input === "object") return input;
+    throw new Error("parseBlueprint expects an object in these tests");
+  };
+
+  it("reports an empty-input error without calling parse/validate", () => {
+    let called = false;
+    const result = createBlueprintValidationResult("   ", {
+      parseBlueprint: () => {
+        called = true;
+      },
+      validateBlueprint: () => {
+        called = true;
+      },
+    });
+    assert.strictEqual(result.valid, false);
+    assert.strictEqual(result.stage, "json");
+    assert.strictEqual(called, false);
+  });
+
+  it("reports a JSON stage error for malformed JSON", () => {
+    const result = createBlueprintValidationResult("{not valid", {
+      parseBlueprint,
+      validateBlueprint: () => ({ valid: true, errors: [] }),
+    });
+    assert.strictEqual(result.valid, false);
+    assert.strictEqual(result.stage, "json");
+    assert.match(result.message, /Invalid JSON/);
+  });
+
+  it("reports a schema stage error when validateBlueprint fails", () => {
+    const result = createBlueprintValidationResult('{"steps": "nope"}', {
+      parseBlueprint,
+      validateBlueprint: () => ({
+        valid: false,
+        errors: ["'steps' must be an array."],
+      }),
+    });
+    assert.strictEqual(result.valid, false);
+    assert.strictEqual(result.stage, "schema");
+    assert.match(result.message, /'steps' must be an array\./);
+  });
+
+  it("returns a valid result with the normalized blueprint", () => {
+    const result = createBlueprintValidationResult('{"steps": []}', {
+      parseBlueprint,
+      validateBlueprint: () => ({ valid: true, errors: [] }),
+    });
+    assert.strictEqual(result.valid, true);
+    assert.strictEqual(result.stage, "valid");
+    assert.deepStrictEqual(result.blueprint, { steps: [] });
+  });
+});
+
+describe("encodeBlueprintFallback", () => {
+  it("base64-encodes JSON safely, round-tripping non-ASCII content", () => {
+    const blueprint = { steps: [{ step: "login" }], note: "café" };
+    const encoded = encodeBlueprintFallback(blueprint);
+    const decoded = JSON.parse(decodeURIComponent(escape(atob(encoded))));
+    assert.deepStrictEqual(decoded, blueprint);
+  });
+});
+
+describe("buildBlueprintRunUrl", () => {
+  it("sets the blueprint param and removes blueprint-url", () => {
+    const url = buildBlueprintRunUrl(
+      "https://example.com/app/?blueprint-url=https://old.example/bp.json&foo=bar",
+      "ENCODED",
+    );
+    const parsed = new URL(url);
+    assert.strictEqual(parsed.searchParams.get("blueprint"), "ENCODED");
+    assert.strictEqual(parsed.searchParams.has("blueprint-url"), false);
+    assert.strictEqual(parsed.searchParams.get("foo"), "bar");
+  });
+
+  it("preserves the origin and path", () => {
+    const url = buildBlueprintRunUrl(
+      "https://example.com/moodle-playground/index.html?x=1",
+      "abc",
+    );
+    assert.ok(
+      url.startsWith("https://example.com/moodle-playground/index.html?"),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Adds an editable CodeJar-based JSON editor to the Blueprint panel.
- Adds inline validation and a Run action for edited blueprints.
- Keeps Export/Import behavior working with the latest editor content.
- Adds OpenSpec coverage and unit tests for editor helpers.

## Tests

- npm test