### PR TITLE
Add new-Moodle-branch alert workflow and show exact release in Info panel

### DIFF
--- a/.github/workflows/check-new-moodle-branch.yml
+++ b/.github/workflows/check-new-moodle-branch.yml
@@ -1,0 +1,110 @@
+# Check for new Moodle stable branches
+#
+# This project builds rolling bundles from a hardcoded set of Moodle stable
+# branches (see `MOODLE_BRANCHES` in src/shared/version-resolver.js and the
+# bundle-* targets in Makefile). Patch releases on an already-tracked branch
+# are absorbed automatically by scheduled-base-rebuild.yml — but nothing
+# notices when Moodle HQ cuts a brand-new stable branch (e.g. a future
+# MOODLE_503_STABLE). This workflow only detects that and opens an issue; it
+# never builds or tags anything, since adding real support for a new branch
+# requires manual work (patches, install snapshot, SQLite compatibility —
+# see the moodle-internals and blueprint-provisioning skills).
+name: Check for new Moodle stable branch
+
+on:
+  schedule:
+    # Daily. Cheap (a couple of GitHub API calls), and new stable branches
+    # are rare, so cadence just needs to be "soon enough", not tight.
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+# Least privilege: only enough to read this repo and open an issue.
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: check-new-moodle-branch
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: List currently tracked branches
+        id: tracked
+        run: |
+          TRACKED=$(node -e "
+            import('./src/shared/version-resolver.js').then((m) => {
+              for (const b of m.MOODLE_BRANCHES) {
+                console.log(b.branch);
+              }
+            });
+          ")
+          echo "Tracked branches:"
+          echo "$TRACKED"
+          {
+            echo "branches<<EOF"
+            echo "$TRACKED"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Find new upstream stable branches
+        id: diff
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRACKED: ${{ steps.tracked.outputs.branches }}
+        run: |
+          UPSTREAM=$(gh api repos/moodle/moodle/branches --paginate --jq '.[].name' \
+            | grep -E '^MOODLE_[0-9]+_STABLE$' || true)
+
+          NEW_BRANCHES=""
+          for branch in $UPSTREAM; do
+            if ! grep -qxF "$branch" <<< "$TRACKED"; then
+              NEW_BRANCHES="$NEW_BRANCHES $branch"
+            fi
+          done
+          NEW_BRANCHES=$(echo "$NEW_BRANCHES" | xargs)
+
+          if [ -z "$NEW_BRANCHES" ]; then
+            echo "No new Moodle stable branches found."
+          else
+            echo "New Moodle stable branches found: $NEW_BRANCHES"
+          fi
+          echo "new_branches=$NEW_BRANCHES" >> "$GITHUB_OUTPUT"
+
+      - name: Open an issue for each new branch
+        if: steps.diff.outputs.new_branches != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_BRANCHES: ${{ steps.diff.outputs.new_branches }}
+        run: |
+          for branch in $NEW_BRANCHES; do
+            title="New Moodle stable branch detected: $branch"
+
+            existing=$(gh issue list --state open --search "$title in:title" --json title \
+              --jq ".[] | select(.title == \"$title\") | .title")
+            if [ -n "$existing" ]; then
+              echo "Issue already open for $branch, skipping."
+              continue
+            fi
+
+            body_lines=(
+              "Moodle has a new stable branch upstream: [\`$branch\`](https://github.com/moodle/moodle/tree/$branch)."
+              ""
+              "It is not yet tracked in this repo. To add support:"
+              ""
+              "- Add an entry for it to \`MOODLE_BRANCHES\` in \`src/shared/version-resolver.js\`."
+              "- Add a \`bundle-$branch\` target to \`Makefile\` (and include it in \`bundle-all\`)."
+              "- Generate patches and an install snapshot for it, following the \`moodle-internals\`"
+              "  and \`blueprint-provisioning\` skills."
+              ""
+              "This issue was opened automatically by \`check-new-moodle-branch.yml\`. It does not"
+              "build or tag anything — adding real support needs manual verification."
+            )
+            body=$(printf '%s\n' "${body_lines[@]}")
+
+            gh issue create --title "$title" --body "$body"
+          done

--- a/index.html
+++ b/index.html
@@ -180,6 +180,10 @@
                     </svg>
                   </button>
                 </div>
+                <div class="value-row">
+                  <span class="vr-key">Moodle release</span>
+                  <span id="moodle-release-value" title="">-</span>
+                </div>
                 <div class="action-row">
                   <button type="button" id="reset-button" class="danger grow">Reset Playground</button>
                 </div>

--- a/src/runtime/manifest.js
+++ b/src/runtime/manifest.js
@@ -20,6 +20,21 @@ export async function fetchManifest(manifestUrl) {
   return response.json();
 }
 
+/**
+ * Extract the leading version from a manifest `release` string, dropping the
+ * " (Build: ...)" / "+" noise Moodle's version.php appends, e.g.
+ * "5.1.5+ (Build: 20260630)" -> "5.1.5", "5.3dev+ (Build: ...)" -> "5.3dev".
+ * Returns the input unchanged if it doesn't start with a version number (or
+ * isn't a string).
+ */
+export function parseReleaseVersion(release) {
+  if (typeof release !== "string") {
+    return release;
+  }
+  const match = release.match(/^[\d.]+[a-zA-Z0-9]*/);
+  return match ? match[0] : release;
+}
+
 export function buildManifestState(manifest, runtimeId, bundleVersion) {
   return {
     runtimeId,

--- a/src/shell/main.js
+++ b/src/shell/main.js
@@ -5,6 +5,11 @@ import {
   resolveBlueprint,
   validateBlueprint,
 } from "../blueprint/index.js";
+import {
+  fetchManifest,
+  parseReleaseVersion,
+  resolveManifestUrl,
+} from "../runtime/manifest.js";
 import { loadPlaygroundConfig } from "../shared/config.js";
 import { blueprintSourceKey, resolveRemoteUrl } from "../shared/paths.js";
 import { createShellChannel, SNAPSHOT_VERSION } from "../shared/protocol.js";
@@ -58,6 +63,7 @@ const els = {
   configApply: document.querySelector("#config-apply"),
   runtimeIdChip: document.querySelector("#runtime-id-chip"),
   runtimeIdValue: document.querySelector("#runtime-id-value"),
+  moodleReleaseValue: document.querySelector("#moodle-release-value"),
   infoPanel: document.querySelector("#info-panel"),
   infoTab: document.querySelector("#info-tab"),
   sidePanel: document.querySelector("#side-panel"),
@@ -545,6 +551,27 @@ function updateConfigState() {
   refreshDirtyState();
 }
 
+// Purely informational: shows the exact Moodle point-release (e.g. "5.1.5")
+// for the active branch in the Info panel, alongside Runtime ID. Fetched
+// separately from the shell rather than piped up from the worker's own
+// manifest fetch, to avoid new cross-context messaging plumbing for a
+// display-only value. Never blocks boot or the address bar.
+async function updateMoodleReleaseInfo(moodleBranch) {
+  if (!els.moodleReleaseValue) {
+    return;
+  }
+  try {
+    const appBaseUrl = new URL("../../", import.meta.url).href;
+    const manifestUrl = await resolveManifestUrl(moodleBranch, appBaseUrl);
+    const manifest = await fetchManifest(manifestUrl);
+    const release = manifest.release;
+    els.moodleReleaseValue.textContent = parseReleaseVersion(release) ?? "-";
+    els.moodleReleaseValue.title = release || "";
+  } catch (error) {
+    console.debug("Unable to load Moodle release info:", error);
+  }
+}
+
 function applyConfigAndReset() {
   const newBranch = els.infoMoodleVersion?.value;
   const newPhp = els.infoPhpVersion?.value;
@@ -620,6 +647,7 @@ async function main() {
 
   populateConfigSelects();
   updateConfigState();
+  updateMoodleReleaseInfo(currentMoodleBranch);
 
   // Configuration (Info panel) event listeners
   if (els.infoMoodleVersion) {

--- a/tests/runtime/manifest.test.js
+++ b/tests/runtime/manifest.test.js
@@ -4,6 +4,7 @@ import {
   buildFallbackManifestUrl,
   buildManifestState,
   fetchManifest,
+  parseReleaseVersion,
   resolveManifestUrl,
 } from "../../src/runtime/manifest.js";
 
@@ -65,6 +66,35 @@ describe("buildManifestState", () => {
     const manifest = { release: "2024-01-01" };
     const state = buildManifestState(manifest, "runtime1", "1.0");
     assert.strictEqual(state.sha256, null);
+  });
+});
+
+describe("parseReleaseVersion", () => {
+  it("strips the build suffix from a stable release string", () => {
+    assert.strictEqual(
+      parseReleaseVersion("5.1.5+ (Build: 20260630)"),
+      "5.1.5",
+    );
+  });
+
+  it("keeps a dev qualifier but strips the build suffix", () => {
+    assert.strictEqual(
+      parseReleaseVersion("5.3dev+ (Build: 20260705)"),
+      "5.3dev",
+    );
+  });
+
+  it("returns a plain release string unchanged", () => {
+    assert.strictEqual(parseReleaseVersion("5.0.7"), "5.0.7");
+  });
+
+  it("returns the input unchanged when it has no leading version number", () => {
+    assert.strictEqual(parseReleaseVersion("unknown"), "unknown");
+  });
+
+  it("returns non-string input unchanged", () => {
+    assert.strictEqual(parseReleaseVersion(null), null);
+    assert.strictEqual(parseReleaseVersion(undefined), undefined);
   });
 });
 


### PR DESCRIPTION
## Summary

- Add `.github/workflows/check-new-moodle-branch.yml`: a daily (+ manual dispatch) workflow that compares `moodle/moodle`'s upstream stable branches against the tracked `MOODLE_BRANCHES` list in `src/shared/version-resolver.js`, and opens a GitHub issue when a new stable branch (e.g. a future `MOODLE_503_STABLE`) isn't tracked yet. It only detects and notifies — it never builds or tags anything, since adding real support requires manual patch/snapshot work. Kept fully separate from the existing `scheduled-base-rebuild.yml`, which only re-triggers builds for the already-known branch list and has no version-discovery logic of its own.
- Add a `parseReleaseVersion()` helper in `src/runtime/manifest.js` that extracts the clean version number from a manifest's `release` string (e.g. `"5.1.5+ (Build: 20260630)"` → `"5.1.5"`), with unit tests.
- Show the exact installed Moodle point-release in the Info panel's Runtime section (next to Runtime ID), fetched from the active branch's manifest and non-blocking with respect to boot. The full raw release string is available as a hover tooltip.

## Context

This originated from a discussion about whether the existing `scheduled-base-rebuild.yml` already covered detecting new Moodle releases (it doesn't — it just rebuilds a static branch list), and whether a workflow like `alpine-moodle`'s tag-sync-and-build pattern made sense here (it doesn't fit, since this project builds rolling per-branch bundles rather than one image per exact release tag). The real gap was the lack of any signal when Moodle cuts a brand-new stable branch, which this PR addresses with a lightweight notify-only workflow.

## Test plan

- [x] `make test` (715 tests, all passing)
- [x] `make lint` (no errors introduced)
- [x] Manually verified in a browser (`make serve` + `npm run build-worker`): the "Moodle release" row shows `5.1.5` with the full build string as tooltip, across fresh boots
- [ ] Manually trigger `check-new-moodle-branch.yml` via `workflow_dispatch` once merged, to confirm it runs cleanly against the real `moodle/moodle` repo