### PR TITLE
fix: open external Moodle links (plugin directory) in a new tab

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -490,6 +490,51 @@ function rewriteHtmlAttributeUrl(rawValue, scope) {
   }
 }
 
+// Anchors that point to a different origin — most notably the Moodle plugin
+// directory ("Browse new plugins" -> marketplace.moodle.com / moodle.org) —
+// cannot be shown inside the playground's nested iframe: those sites send
+// `X-Frame-Options: sameorigin` (and `frame-ancestors 'self'`), so the browser
+// refuses to frame them and logs "Refused to display '…' in a frame". A Service
+// Worker never sees these navigations (they target an out-of-scope origin), so
+// the only place we can intervene is the same-origin HTML Moodle serves. Force
+// cross-origin links to open in a new top-level tab, which is exactly what a
+// normal Moodle does anyway — the plugin directory is meant to open in the
+// browser, not be embedded. Same-origin links are left untouched so scoped
+// in-iframe navigation and Moodle's own JS keep working.
+function markExternalAnchorsBlank(html, origin) {
+  return html.replace(/<a\b([^>]*)>/giu, (match, attrs) => {
+    // Respect an explicit target the markup already set.
+    if (/\btarget\s*=/iu.test(attrs)) {
+      return match;
+    }
+    const hrefMatch = attrs.match(/\bhref\s*=\s*(["'])([^"']*)\1/iu);
+    if (!hrefMatch) {
+      return match;
+    }
+    const href = decodeHtmlAttributeEntities(hrefMatch[2]);
+    if (!href) {
+      return match;
+    }
+    let absolute;
+    try {
+      absolute = new URL(href, origin);
+    } catch {
+      // Relative URLs and unparsable values resolve against `origin`, so a throw
+      // here means the value isn't a navigable link — leave it alone.
+      return match;
+    }
+    // Only re-target real cross-origin web links; leave mailto:/tel:/#fragments,
+    // and any same-origin (scoped) navigation, exactly as they are.
+    if (absolute.protocol !== "http:" && absolute.protocol !== "https:") {
+      return match;
+    }
+    if (absolute.origin === origin) {
+      return match;
+    }
+    return `<a${attrs} target="_blank" rel="noopener noreferrer">`;
+  });
+}
+
 function rewriteHtmlDocument(html, scope) {
   const { origin, scopeId, runtimeId } = scope;
   const scopedBasePath = getScopedBasePath(scopeId, runtimeId);
@@ -557,6 +602,10 @@ function rewriteHtmlDocument(html, scope) {
     `"apibase":"${jsonEscapedOrigin}\\/r.php\\/api"`,
     `"apibase":"${jsonEscapedBase}\\/r.php\\/api"`,
   );
+
+  // External links (plugin directory, docs, etc.) can't be framed — open them
+  // in a new top-level tab instead of failing with X-Frame-Options.
+  result = markExternalAnchorsBlank(result, origin);
 
   return result;
 }

--- a/tests/sw/sw-helpers.test.js
+++ b/tests/sw/sw-helpers.test.js
@@ -580,3 +580,92 @@ describe("buildScopedCacheKey", () => {
     );
   });
 });
+
+// Replicate markExternalAnchorsBlank from sw.js. External links (e.g. the Moodle
+// plugin directory) can't be shown inside the playground iframe because those
+// sites send X-Frame-Options: sameorigin, so we re-target them to a new tab.
+function markExternalAnchorsBlank(html, origin) {
+  return html.replace(/<a\b([^>]*)>/giu, (match, attrs) => {
+    if (/\btarget\s*=/iu.test(attrs)) {
+      return match;
+    }
+    const hrefMatch = attrs.match(/\bhref\s*=\s*(["'])([^"']*)\1/iu);
+    if (!hrefMatch) {
+      return match;
+    }
+    const href = decodeHtmlAttributeEntities(hrefMatch[2]);
+    if (!href) {
+      return match;
+    }
+    let absolute;
+    try {
+      absolute = new URL(href, origin);
+    } catch {
+      return match;
+    }
+    if (absolute.protocol !== "http:" && absolute.protocol !== "https:") {
+      return match;
+    }
+    if (absolute.origin === origin) {
+      return match;
+    }
+    return `<a${attrs} target="_blank" rel="noopener noreferrer">`;
+  });
+}
+
+describe("markExternalAnchorsBlank", () => {
+  const origin = "https://ateeducacion.github.io";
+
+  it("opens the plugin directory link in a new tab", () => {
+    const html =
+      '<a href="https://marketplace.moodle.com/?site=eyJ4IjoxfQ%3D%3D">Browse new plugins</a>';
+    assert.strictEqual(
+      markExternalAnchorsBlank(html, origin),
+      '<a href="https://marketplace.moodle.com/?site=eyJ4IjoxfQ%3D%3D" target="_blank" rel="noopener noreferrer">Browse new plugins</a>',
+    );
+  });
+
+  it("re-targets moodle.org links too", () => {
+    const html = '<a class="btn" href="https://moodle.org/plugins/">dir</a>';
+    assert.strictEqual(
+      markExternalAnchorsBlank(html, origin),
+      '<a class="btn" href="https://moodle.org/plugins/" target="_blank" rel="noopener noreferrer">dir</a>',
+    );
+  });
+
+  it("leaves same-origin links untouched", () => {
+    const html =
+      '<a href="https://ateeducacion.github.io/admin/index.php">Home</a>';
+    assert.strictEqual(markExternalAnchorsBlank(html, origin), html);
+  });
+
+  it("leaves relative links untouched", () => {
+    const html = '<a href="../course/view.php?id=2">Course</a>';
+    assert.strictEqual(markExternalAnchorsBlank(html, origin), html);
+  });
+
+  it("ignores mailto:, tel: and #fragment links", () => {
+    const html =
+      '<a href="mailto:a@b.com">m</a><a href="tel:+1">t</a><a href="#top">up</a>';
+    assert.strictEqual(markExternalAnchorsBlank(html, origin), html);
+  });
+
+  it("respects an existing target attribute", () => {
+    const html = '<a target="_self" href="https://moodle.org/">x</a>';
+    assert.strictEqual(markExternalAnchorsBlank(html, origin), html);
+  });
+
+  it("decodes HTML entities before checking the origin", () => {
+    const html =
+      '<a href="https://marketplace.moodle.com/?a=1&amp;b=2">plugins</a>';
+    assert.strictEqual(
+      markExternalAnchorsBlank(html, origin),
+      '<a href="https://marketplace.moodle.com/?a=1&amp;b=2" target="_blank" rel="noopener noreferrer">plugins</a>',
+    );
+  });
+
+  it("does not match unrelated tags like <area> or <abbr>", () => {
+    const html = '<area href="https://moodle.org/"><abbr>a</abbr>';
+    assert.strictEqual(markExternalAnchorsBlank(html, origin), html);
+  });
+});


### PR DESCRIPTION
## Problem

On the deployed playground, going to **Site administration → Plugins → Install plugins → Browse new plugins** throws:

```
Refused to display 'https://moodle.org/' in a frame because it set 'X-Frame-Options' to 'sameorigin'.
```

The "Browse new plugins" button links to the Moodle plugin directory (`marketplace.moodle.com` / `moodle.org`) with a `?site=<base64>` payload. Those external sites send `X-Frame-Options: sameorigin` (and `Content-Security-Policy: frame-ancestors 'self'`), so the browser refuses to render them inside the playground's nested iframe.

## Why the existing guard doesn't catch it

`sw.js` already has an origin-gate branch (`sw.js:679-703`) that returns a friendly "Moodle Plugin Directory unavailable" notice for `moodle.org`. **It never fires for this case**, because:

- A Service Worker only intercepts requests to URLs **within its scope** (our origin). The iframe navigation to `marketplace.moodle.com` / `moodle.org` targets a different, out-of-scope origin, so the `fetch` handler is never invoked for it. The browser makes the request directly and enforces `X-Frame-Options` itself.
- `marketplace.moodle.com` isn't even in that hostname list.

So the notice is effectively dead code for the actual navigation. The only place we can intervene is the **same-origin HTML that Moodle serves** — which the SW already rewrites (`rewriteHtmlDocument`).

## Fix

Rewrite cross-origin anchors during the existing HTML rewrite so they open in a **new top-level tab** (`target="_blank" rel="noopener noreferrer"`). As a top-level document the external site is no longer framed, `X-Frame-Options: sameorigin` is satisfied, and the plugin directory loads — exactly how a normal Moodle opens the directory in your browser rather than embedding it.

A proxy that strips `X-Frame-Options` was considered and rejected: it would require reverse-proxying and URL-rewriting the entire external marketplace (its own JS, login, redirects, sub-resources) — a fragile, heavyweight MITM of a large third-party site, for a page that is meant to be browsed top-level anyway.

### What the new `markExternalAnchorsBlank(html, origin)` does
- Runs as the last step of `rewriteHtmlDocument`, after URL/`wwwroot` rewriting.
- Adds `target="_blank" rel="noopener noreferrer"` **only** to `<a>` tags whose `href` resolves to a **different origin** over http/https.
- Leaves untouched: same-origin/scoped links (so in-iframe navigation and Moodle's JS keep working), relative links, `mailto:`/`tel:`/`#fragment` links, and any anchor that already declares a `target`.
- Decodes HTML entities before checking the origin (Moodle emits `&amp;`, and sometimes `&colon;`/`&sol;`), and uses `\b` so it won't match `<area>`, `<abbr>`, etc.

## Tests

Added 8 unit tests in `tests/sw/sw-helpers.test.js` (same "replicate the pure helper" pattern used for the other `sw.js` helpers):

- opens the plugin-directory link (`marketplace.moodle.com/?site=…`) in a new tab
- re-targets `moodle.org` links (preserving other attributes)
- leaves same-origin and relative links untouched
- ignores `mailto:` / `tel:` / `#fragment`
- respects an existing `target`
- decodes `&amp;` before checking the origin
- does not match `<area>` / `<abbr>`

```
make test   → 723 pass, 0 fail
make lint   → clean
```

## Notes

- Change is confined to `sw.js` (source) + a unit test. `sw.bundle.js` is git-ignored and rebuilt by CI (`npm run build-worker`); rebuilt locally to confirm the bundle picks up the change.
- The existing `moodle.org` origin-gate notice is left in place as a harmless fallback for any cross-origin **sub-resource** fetch.

## Manual verification

1. Boot the playground, go to **Site administration → Plugins → Install plugins → Browse new plugins**.
2. The link now opens the Moodle plugin directory in a **new browser tab** instead of logging the `X-Frame-Options` error in the embedded iframe.