### PR TITLE
fix: preserve empty directories in tar.zst Moodle bundle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -423,6 +423,7 @@ so that future contributors (human or AI) understand **why** a choice was made �
 | [0017](docs/decisions/0017-tracker-scenario-blueprints.md) | Explicit Moodle Playground scenario blocks in tracker issues (+ starter preset) | Accepted |
 | [0018](docs/decisions/0018-core-bundle-solid-compression-experiment.md) | Solid compression for core bundles (tar.zst) — experiment that led to adoption | Accepted |
 | [0019](docs/decisions/0019-streaming-tar-zstd-core-bundle-extraction.md) | Streaming (bounded-memory) extraction for tar.zst core bundles — now the sole format | Accepted |
+| [0020](docs/decisions/0020-preserve-empty-directories-in-tar-bundle.md) | Preserve empty plugin-type-root directories in the tar.zst bundle (fixes "Plugin type location does not exist!") | Accepted |
 
 ## Debugging
 

--- a/docs/decisions/0019-streaming-tar-zstd-core-bundle-extraction.md
+++ b/docs/decisions/0019-streaming-tar-zstd-core-bundle-extraction.md
@@ -3,6 +3,11 @@
 ## Status
 
 Accepted (2026-07-05). Continues (and supersedes the "keep experimental" verdict of) ADR 0018.
+**Amended by [ADR 0020](0020-preserve-empty-directories-in-tar-bundle.md)** (2026-07-06): the
+"files-only (no directory members)" policy below is relaxed — the writer now also emits directory
+entries for the few directories that ship empty after the build trim (e.g. `local/`), so Moodle's
+empty plugin-type roots survive. `bundle.fileCount` stays files-only, so the parity tripwire is
+unchanged.
 
 **`tar.zst` streaming is now the sole core-bundle format.** The ZIP core path and its PHP
 `ZipArchive` extractor were removed: there is **no `?bundle-format=` flag, no `bundleAlternatives`

--- a/docs/decisions/0020-preserve-empty-directories-in-tar-bundle.md
+++ b/docs/decisions/0020-preserve-empty-directories-in-tar-bundle.md
@@ -1,0 +1,101 @@
+# 0020 — Preserve semantically-meaningful empty directories in the tar.zst core bundle
+
+* Status: Accepted
+* Date: 2026-07-06
+
+Amends the "files-only" determinism policy of [ADR 0018](0018-core-bundle-solid-compression-experiment.md)
+and [ADR 0019](0019-streaming-tar-zstd-core-bundle-extraction.md): the tar writer now also emits
+directory members for the handful of directories that ship empty after the build trim.
+
+## Context and Problem
+
+After the ZIP → `tar.zst` core-bundle migration (#176, ADR 0018/0019), installing the Moodle
+Accessibility plugin (`local_accessibility`) — and in fact **any** `local` plugin — from a ZIP
+fails during validation with:
+
+> Coding error detected, it must be fixed by a programmer: Plugin type location does not exist!
+
+The same plugin installs fine on a native Moodle. Root cause, traced end to end:
+
+1. Moodle's `/local` directory ships with **only** `readme.txt` + `upgrade.txt`.
+2. The bundle trim in `scripts/build-moodle-bundle.sh` excludes both (`-x "*/readme*"`,
+   `-x "*/upgrade.txt"`). The trimmed core ZIP therefore carries `local/` **only as an explicit
+   empty directory entry** (Info-ZIP keeps the directory member; it is not matched by any `-x`
+   file pattern).
+3. `normalizeEntries()` in `scripts/lib/tar-ustar.mjs` **dropped every directory member**
+   (files-only policy, ADR 0018/0019), so `local/` never made it into the tar.
+4. The streaming extractor reconstructs directories **only** from the parent path of each file it
+   writes. With no file under `local/`, `<dirroot>/local` was never created at runtime.
+5. `tool_installaddon`'s `\core\update\validator::validate_target_location()` does
+   `if (!is_dir($plugintypepath)) throw new coding_exception('Plugin type location does not
+   exist!');` — for a `local` plugin `$plugintypepath` is `<dirroot>/local`.
+
+A census of the real `MOODLE_500_STABLE` trimmed bundle shows **6** such empty-after-trim
+directories: `local`, `mod/lti/source` (the `ltisource` plugin-type root — same failure mode),
+`backup/util/destinations`, `lang/en/fonts`, `lib/editor/tiny/js/tinymce/langs`, and
+`lib/htmlpurifier/HTMLPurifier/DefinitionCache/Serializer` (HTMLPurifier's serializer cache dir).
+All were silently missing at runtime before this change.
+
+## Options Considered
+
+* **Add `.gitkeep`/placeholder files** to force the directories to exist. Rejected: pollutes
+  Moodle source, is plugin-specific, and fights archive semantics.
+* **Special-case `local/`** (or plugin-type roots) in the trim or extractor. Rejected: a targeted
+  hack that misses the five other empty dirs and any future ones.
+* **Preserve ALL directory members** from the ZIP (every dir gets a typeflag-5 entry). Correct but
+  adds ~5,000 redundant headers the extractor already recreates from file paths.
+* **Preserve only directories with no file descendant** (chosen). The minimal, general set: the
+  semantically-meaningful empty directories that would otherwise vanish. On the real bundle this
+  is exactly 6 entries.
+
+## Decision
+
+**Preserve, as USTAR directory entries (typeflag `5`, size 0), exactly those source-ZIP
+directory members that no kept file will implicitly recreate.** `normalizeEntries()` now returns
+tagged entries (`{ type: "file", name, data }` / `{ type: "dir", name }`); a directory is emitted
+only when its sanitized path is not an ancestor of any file entry. `createUstarTar()` writes a
+trailing-slash typeflag-`5` header (mode `0755`) for those; the streaming extractor already
+materializes directory entries via `mkdirTree`, so no runtime change was needed. Output stays
+deterministic (single byte-wise sort over the combined list) and TAR-slip-safe (directory paths
+run through the same `sanitizeArchivePath()` as files).
+
+## Consequences
+
+### Positive
+* `<dirroot>/local` (and the 5 other empty-after-trim dirs) exist at runtime again — installing
+  `local` and `ltisource` plugins from ZIP works, matching a native Moodle.
+* Generic and future-proof: any directory a trim empties is preserved automatically; no
+  plugin-specific or path-specific special-casing, and no placeholder files in Moodle source.
+* Negligible cost: 6 extra 512-byte headers on the real bundle (compresses to ~nothing); the
+  files-only determinism, checksum, and file-count parity guarantees are unchanged.
+
+### Negative / Risks
+* The tar is no longer strictly files-only, so the ADR 0018/0019 "files-only" wording is amended
+  here. `fileCount` remains files-only (directories are reported separately as `dirCount`), so the
+  manifest `bundle.fileCount` and the runtime parity tripwire (`extractStats.fileCount`) are
+  unaffected.
+* `scripts/lib/tar-ustar.mjs` and `lib/streaming-tar-extract.js` are the **canonical** shared kit,
+  copied verbatim into the sibling `*-playground` repos — this change should be synced there.
+
+## Implementation Notes
+
+* `scripts/lib/tar-ustar.mjs` — `normalizeEntries()` preserves empty directories (ancestors of
+  kept files are excluded via an `impliedDirs` set); `createUstarTar()` emits typeflag-`5`
+  directory headers; `readUstarTar()` surfaces `{ name, type: "dir" }`.
+* `scripts/build-tar-zst-from-zip.mjs` — reports `fileCount` (files only) and `dirCount`
+  separately so the manifest count stays files-only.
+* `lib/streaming-tar-extract.js` — unchanged; it already handles typeflag-`5`/trailing-slash
+  directory entries (`StreamingTarParser` → `ensureDir`/`mkdirTree`).
+* Tests: `tests/scripts/tar-ustar.test.js` (preservation, typeflag-5 round-trip, no-redundant-dir,
+  path-traversal, determinism) and `tests/runtime/streaming-tar-extract.test.js` (writer → parser
+  round-trip; `extractTarStreamToPhp` creates the empty dir via `mkdirTree`).
+* No `npm run build-worker` needed for the runtime (no runtime JS changed), but the core `tar.zst`
+  bundle must be **rebuilt** (`make prepare`) for the fix to reach a running app.
+
+## Review Criteria
+
+* Revisit if the trim's exclusion list changes such that a different set of directories is
+  emptied, or if a plugin-type root is added under a path the trim empties.
+* Revisit if the sibling-repo kit sync introduces a divergent directory policy.
+* Re-measure the preserved-dir census when bumping the Moodle branch (a new empty-after-trim
+  directory should appear here, not as a runtime "location does not exist" error).

--- a/scripts/build-tar-zst-from-zip.mjs
+++ b/scripts/build-tar-zst-from-zip.mjs
@@ -36,6 +36,11 @@ if (!zipPath || !outPath) {
 }
 
 const entries = normalizeEntries(unzipSync(readFileSync(zipPath)));
+// fileCount stays files-only for parity with the ZIP listing (grep -cv '/$' in
+// build-moodle-bundle.sh) and the runtime tripwire (extractStats.fileCount);
+// preserved empty directories are reported separately as dirCount.
+const fileCount = entries.reduce((n, e) => n + (e.type === "dir" ? 0 : 1), 0);
+const dirCount = entries.length - fileCount;
 const tar = createUstarTar(entries, { mtime: 0 });
 const compressed = zlib.zstdCompressSync(tar, {
   params: {
@@ -52,7 +57,8 @@ const compressed = zlib.zstdCompressSync(tar, {
 writeFileSync(outPath, compressed);
 console.log(
   JSON.stringify({
-    fileCount: entries.length,
+    fileCount,
+    dirCount,
     bytes: compressed.length,
     sha256: createHash("sha256").update(compressed).digest("hex"),
   }),

--- a/scripts/lib/tar-ustar.mjs
+++ b/scripts/lib/tar-ustar.mjs
@@ -21,15 +21,17 @@
 // the USTAR prefix split and GNU longlink correctly, and so do bsdtar / GNU tar,
 // so this format keeps full file-count parity with the ZIP baseline.
 //
-// Determinism policy: entries are emitted files-only (no directory members, which
-// the runtime reconstructs anyway) in a fixed byte-wise sort, with mtime=0,
-// uid=gid=0, empty uname/gname, and a fixed mode.
+// Determinism policy: entries are emitted in a fixed byte-wise sort, with
+// mtime=0, uid=gid=0, empty uname/gname, and fixed modes. Files use typeflag '0';
+// semantically-meaningful empty directories (those no file re-creates — see
+// normalizeEntries) use typeflag '5' so Moodle's empty plugin-type roots survive.
 //
 // Reused semantics: entry-name sanitization mirrors sanitizeArchivePath() in
 // lib/moodle-loader.js (reject "..", strip leading "/", drop "." segments) so the
 // tar cannot carry a path-traversal entry — parity with the ZIP boot path.
 
 const BLOCK = 512;
+const EMPTY_DATA = new Uint8Array(0);
 
 // --- name sanitization (parity with lib/moodle-loader.js) --------------------
 
@@ -49,16 +51,28 @@ export function sanitizeArchivePath(name) {
 
 /**
  * Turn a { path -> Uint8Array } map (as produced by fflate `unzipSync`) into a
- * sorted, sanitized, files-only entry list ready for createUstarTar(). Directory
- * keys (trailing "/") are dropped; unsafe paths are skipped. The sort is a stable
- * byte-wise comparison on the sanitized name so two runs over the same input
- * yield an identical archive.
+ * sorted, sanitized entry list ready for createUstarTar(). Each entry is tagged
+ * `{ type: "file", name, data }` or `{ type: "dir", name }`.
+ *
+ * Directory members (trailing "/") are preserved ONLY when no file will create
+ * them implicitly — i.e. semantically-meaningful empty directories. This keeps
+ * Moodle's plugin-type roots alive after the docs trim empties them: e.g.
+ * `local/` ships only readme.txt + upgrade.txt (both excluded by the bundle
+ * trim), yet Moodle's plugin installer requires `<dirroot>/local` to exist or it
+ * fails with "Plugin type location does not exist!". Directories implied by a
+ * file (every ancestor path of a kept file) are NOT emitted as redundant members
+ * — the streaming extractor reconstructs them from each file's parent path.
+ *
+ * Unsafe paths (".." traversal) are skipped for both files and directories. The
+ * sort is a stable byte-wise comparison on the sanitized name so two runs over
+ * the same input yield an identical archive.
  */
 export function normalizeEntries(fileMap) {
-  const entries = [];
+  const files = [];
+  const dirCandidates = [];
   for (const rawName of Object.keys(fileMap)) {
     const normalized = normalizeArchiveName(rawName);
-    if (normalized.endsWith("/")) continue; // directory member, skip
+    const isDir = normalized.endsWith("/");
     let name;
     try {
       name = sanitizeArchivePath(normalized);
@@ -66,8 +80,31 @@ export function normalizeEntries(fileMap) {
       continue; // path traversal — drop, never write outside root
     }
     if (!name) continue;
-    entries.push({ name, data: fileMap[rawName] });
+    if (isDir) dirCandidates.push(name);
+    else files.push({ type: "file", name, data: fileMap[rawName] });
   }
+
+  // Every ancestor directory of a kept file is created implicitly by the
+  // extractor; collect them so we never emit a redundant directory member.
+  const impliedDirs = new Set();
+  for (const file of files) {
+    let idx = file.name.lastIndexOf("/");
+    while (idx > 0) {
+      const dir = file.name.slice(0, idx);
+      if (impliedDirs.has(dir)) break;
+      impliedDirs.add(dir);
+      idx = dir.lastIndexOf("/");
+    }
+  }
+
+  const seenDir = new Set();
+  const entries = files;
+  for (const name of dirCandidates) {
+    if (impliedDirs.has(name) || seenDir.has(name)) continue;
+    seenDir.add(name);
+    entries.push({ type: "dir", name });
+  }
+
   // Byte-wise (codepoint) sort — NOT localeCompare, which is locale-sensitive
   // and would make the archive non-reproducible across environments.
   entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
@@ -161,18 +198,36 @@ function padToBlock(chunks, byteLength) {
  * Options pin the metadata (mtime/uid/gid/mode) so output is reproducible.
  */
 export function createUstarTar(entries, options = {}) {
-  const { mtime = 0, uid = 0, gid = 0, mode = 0o644 } = options;
+  const {
+    mtime = 0,
+    uid = 0,
+    gid = 0,
+    mode = 0o644,
+    dirMode = 0o755,
+  } = options;
   const chunks = [];
 
   for (const entry of entries) {
+    const isDir = entry.type === "dir";
+    // Directory members carry a trailing slash (USTAR convention) and no body;
+    // the trailing slash + typeflag '5' both signal "directory" to the reader.
+    const entryName = isDir
+      ? entry.name.endsWith("/")
+        ? entry.name
+        : `${entry.name}/`
+      : entry.name;
     const data =
-      entry.data instanceof Uint8Array ? entry.data : Buffer.from(entry.data);
-    const split = splitTarName(entry.name);
+      isDir || entry.data == null
+        ? EMPTY_DATA
+        : entry.data instanceof Uint8Array
+          ? entry.data
+          : Buffer.from(entry.data);
+    const split = splitTarName(entryName);
 
     if (split.longLink) {
       // GNU `././@LongLink`: an 'L'-type entry whose body is the full name + NUL,
       // applied to the next entry.
-      const longName = Buffer.from(`${entry.name}\0`, "utf8");
+      const longName = Buffer.from(`${entryName}\0`, "utf8");
       chunks.push(
         headerBlock({
           name: "././@LongLink",
@@ -196,12 +251,14 @@ export function createUstarTar(entries, options = {}) {
         mtime,
         uid,
         gid,
-        mode,
-        typeflag: "0",
+        mode: isDir ? dirMode : mode,
+        typeflag: isDir ? "5" : "0",
       }),
     );
-    chunks.push(Buffer.from(data.buffer, data.byteOffset, data.byteLength));
-    padToBlock(chunks, data.length);
+    if (data.length > 0) {
+      chunks.push(Buffer.from(data.buffer, data.byteOffset, data.byteLength));
+      padToBlock(chunks, data.length);
+    }
   }
 
   // Two zero blocks mark end-of-archive.
@@ -221,9 +278,11 @@ function readOctal(block, offset, length) {
 
 /**
  * Minimal tar reader that understands USTAR entries (incl. the prefix/name
- * split) and GNU `././@LongLink` names. Returns [{ name, data }]. Used by tests
- * to prove round-trip fidelity and as a reference for the runtime streaming
- * extractor prototype.
+ * split) and GNU `././@LongLink` names. Returns file entries as
+ * `{ name, data }` and directory entries (typeflag '5' or a trailing-slash name)
+ * as `{ name, type: "dir" }` — the directory name is returned without its
+ * trailing slash. Used by tests to prove round-trip fidelity and as a reference
+ * for the runtime streaming extractor.
  */
 export function readUstarTar(buffer) {
   const buf = Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer);
@@ -249,10 +308,16 @@ export function readUstarTar(buffer) {
       pendingName = data.toString("utf8").replace(/\0.*$/, "");
       continue;
     }
-    if (typeflag !== "0" && typeflag !== "\0") continue; // ignore non-file types
 
     const name = pendingName ?? (prefix ? `${prefix}/${rawName}` : rawName);
     pendingName = null;
+
+    if (typeflag === "5" || name.endsWith("/")) {
+      entries.push({ name: name.replace(/\/+$/, ""), type: "dir" });
+      continue;
+    }
+    if (typeflag !== "0" && typeflag !== "\0") continue; // ignore exotic types
+
     entries.push({ name, data: Uint8Array.prototype.slice.call(data) });
   }
   return entries;

--- a/tests/runtime/streaming-tar-extract.test.js
+++ b/tests/runtime/streaming-tar-extract.test.js
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  extractTarStreamToPhp,
   StreamingTarParser,
   sanitizeTarPath,
 } from "../../lib/streaming-tar-extract.js";
@@ -187,5 +188,56 @@ describe("StreamingTarParser", () => {
     const parser = new StreamingTarParser({ onEntry: () => {} });
     parser.push(tar.subarray(0, 512 + 400)); // header + partial data
     assert.throws(() => parser.end(), /Truncated/);
+  });
+
+  it("11. surfaces an empty directory written by createUstarTar", () => {
+    // End-to-end regression for the tar.zst core bundle: an empty plugin-type
+    // root such as `local/` must survive the production writer -> streaming
+    // extractor path (see tar-ustar.test.js for the writer-side assertions).
+    const tar = Buffer.from(
+      createUstarTar(
+        normalizeEntries({ "local/": enc(""), "a.txt": enc("a") }),
+      ),
+    );
+    const { entries, stats } = collect(tar, 64);
+    assert.equal(stats.dirCount, 1);
+    const dir = entries.find((e) => e.type === "dir" && e.path === "local");
+    assert.ok(dir, "empty local/ directory must survive writer -> extractor");
+  });
+});
+
+describe("extractTarStreamToPhp", () => {
+  it("creates an empty directory on the filesystem via mkdirTree", async () => {
+    const tar = Buffer.from(
+      createUstarTar(
+        normalizeEntries({
+          "local/": enc(""),
+          "mod/quiz/version.php": enc("<?php"),
+        }),
+      ),
+    );
+    const mkdirs = [];
+    const writes = [];
+    const fakePhp = {
+      _php: {
+        mkdirTree: (d) => mkdirs.push(d),
+        writeFile: (p) => writes.push(p),
+      },
+    };
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(tar);
+        controller.close();
+      },
+    });
+    const stats = await extractTarStreamToPhp(stream, fakePhp, "/www/moodle");
+    // The empty plugin-type root is materialized even though it holds no file.
+    assert.ok(
+      mkdirs.includes("/www/moodle/local"),
+      `expected /www/moodle/local to be created; got ${JSON.stringify(mkdirs)}`,
+    );
+    assert.ok(writes.includes("/www/moodle/mod/quiz/version.php"));
+    assert.equal(stats.dirCount, 1);
+    assert.equal(stats.fileCount, 1);
   });
 });

--- a/tests/scripts/tar-ustar.test.js
+++ b/tests/scripts/tar-ustar.test.js
@@ -12,7 +12,7 @@ const sha256 = (buf) => createHash("sha256").update(buf).digest("hex");
 const bytes = (s) => new Uint8Array(Buffer.from(s));
 
 describe("tar-ustar normalizeEntries", () => {
-  it("drops directory members, sanitizes, and sorts byte-wise", () => {
+  it("preserves empty directory members, sanitizes, and sorts byte-wise", () => {
     const map = {
       "b/second.txt": bytes("2"),
       "a/first.txt": bytes("1"),
@@ -20,10 +20,14 @@ describe("tar-ustar normalizeEntries", () => {
       "z.txt": bytes("z"),
     };
     const entries = normalizeEntries(map);
+    // `dir/` has no file descendant, so it is kept as an explicit directory
+    // member (see the empty-directory-preservation block below); `a/` and `b/`
+    // are implied by their files and are NOT emitted as redundant members.
     assert.deepEqual(
       entries.map((e) => e.name),
-      ["a/first.txt", "b/second.txt", "z.txt"],
+      ["a/first.txt", "b/second.txt", "dir", "z.txt"],
     );
+    assert.equal(entries.find((e) => e.name === "dir").type, "dir");
   });
 
   it("rejects path-traversal entries", () => {
@@ -106,5 +110,111 @@ describe("tar-ustar createUstarTar", () => {
     const deep = back.find((e) => e.name === longName);
     assert.ok(deep, "unsplittable path should round-trip via GNU longlink");
     assert.ok(Buffer.from(deep.data).equals(Buffer.from(bytes("gnu"))));
+  });
+});
+
+describe("tar-ustar empty directory preservation", () => {
+  // Regression (issue: "Plugin type location does not exist!"): the docs trim in
+  // scripts/build-moodle-bundle.sh empties Moodle's plugin-type roots — `local/`
+  // ships only readme.txt + upgrade.txt, both matched by `*/readme*` and
+  // `*/upgrade.txt`. The trimmed core ZIP still carries an explicit `local/`
+  // directory member, but the files-only tar writer used to drop it, so
+  // `<dirroot>/local` never existed at runtime and installing ANY `local` plugin
+  // (e.g. local_accessibility) failed Moodle's validate_target_location().
+
+  it("preserves an explicit empty directory (no file descendant)", () => {
+    const entries = normalizeEntries({
+      "local/": bytes(""),
+      "mod/quiz/version.php": bytes("<?php"),
+    });
+    const dir = entries.find((e) => e.name === "local");
+    assert.ok(dir, "empty local/ directory must be preserved");
+    assert.equal(dir.type, "dir");
+    // Directories implied by a file are NOT emitted as redundant members —
+    // the streaming extractor reconstructs them from each file's parent path.
+    assert.ok(!entries.some((e) => e.type === "dir" && e.name === "mod"));
+    assert.ok(!entries.some((e) => e.type === "dir" && e.name === "mod/quiz"));
+  });
+
+  it("emits a USTAR directory header (typeflag 5, size 0) that round-trips", () => {
+    const tar = createUstarTar(
+      normalizeEntries({ "local/": bytes(""), "a.txt": bytes("a") }),
+      { mtime: 0 },
+    );
+    // Locate the directory header in the raw bytes: typeflag byte at offset 156.
+    const back = readUstarTar(tar);
+    const dir = back.find((e) => e.name === "local");
+    assert.ok(dir, "directory entry should round-trip via the reader");
+    assert.equal(dir.type, "dir");
+    assert.equal(dir.data, undefined);
+    // Files still round-trip alongside directories.
+    const file = back.find((e) => e.name === "a.txt");
+    assert.ok(file && Buffer.from(file.data).equals(Buffer.from(bytes("a"))));
+  });
+
+  it("does not count directories as files", () => {
+    const entries = normalizeEntries({
+      "local/": bytes(""),
+      "a.txt": bytes("a"),
+      "b.txt": bytes("b"),
+    });
+    assert.equal(entries.filter((e) => e.type !== "dir").length, 2);
+    assert.equal(entries.filter((e) => e.type === "dir").length, 1);
+  });
+
+  it("drops populated directory members that a file recreates (real fflate shape)", () => {
+    // fflate's unzipSync() yields an EXPLICIT trailing-slash member for EVERY
+    // directory in the ZIP, including populated ones — this is the real input
+    // shape build-tar-zst-from-zip.mjs feeds normalizeEntries(). Only the truly
+    // empty `local/` must survive; `mod/`, `mod/quiz/`, `lib/` are recreated by
+    // their files and MUST be dropped (invariant: no redundant directory
+    // members, else the tar gains thousands of typeflag-5 entries and dirCount
+    // and the sha256 drift). Guards the impliedDirs dedup, which is otherwise
+    // never exercised by the empty-only maps in the tests above.
+    const entries = normalizeEntries({
+      "mod/": bytes(""),
+      "mod/quiz/": bytes(""),
+      "mod/quiz/version.php": bytes("<?php"),
+      "lib/": bytes(""),
+      "lib/setup.php": bytes("<?php"),
+      "local/": bytes(""),
+    });
+    const dirs = entries.filter((e) => e.type === "dir").map((e) => e.name);
+    assert.deepEqual(dirs, ["local"]);
+  });
+
+  it("preserves a nested empty directory but not those implied by files", () => {
+    // Mirrors a plugin subtype root: widgets/ is empty; lang/en holds a file.
+    const entries = normalizeEntries({
+      "local/accessibility/version.php": bytes("<?php"),
+      "local/accessibility/lang/en/local_accessibility.php": bytes("<?php"),
+      "local/accessibility/widgets/": bytes(""),
+    });
+    const dirs = entries.filter((e) => e.type === "dir").map((e) => e.name);
+    assert.deepEqual(dirs, ["local/accessibility/widgets"]);
+  });
+
+  it("skips unsafe directory paths (path traversal)", () => {
+    const entries = normalizeEntries({
+      "../evil/": bytes(""),
+      "local/accessibility/../../evil/": bytes(""),
+      "ok/": bytes(""),
+    });
+    const dirs = entries.filter((e) => e.type === "dir").map((e) => e.name);
+    assert.deepEqual(dirs, ["ok"]);
+  });
+
+  it("is deterministic with directory entries (stable sha256 across two builds)", () => {
+    const map = {
+      "local/": bytes(""),
+      "admin/tool/": bytes(""),
+      "mod/quiz/version.php": bytes("<?php"),
+      "z.txt": bytes("z"),
+    };
+    const a = createUstarTar(normalizeEntries(map), { mtime: 0 });
+    const b = createUstarTar(normalizeEntries(map), { mtime: 0 });
+    assert.ok(Buffer.from(a).equals(Buffer.from(b)));
+    assert.equal(sha256(a), sha256(b));
+    assert.equal(a.length % 512, 0);
   });
 });


### PR DESCRIPTION
## Summary

Fixes a regression reported by @HenarLG where installing the Moodle Accessibility plugin (`local_accessibility`) — and in fact **any** `local` plugin — in Moodle Playground failed during ZIP validation with:

> Coding error detected, it must be fixed by a programmer: Plugin type location does not exist!

After #176 the Moodle core bundle is generated as a streaming `tar.zst`. The tar writer emitted **file entries only** and dropped explicit directory members from the source ZIP. Moodle's `/local` ships with only `readme.txt` + `upgrade.txt`, both removed by the docs trim, so the trimmed ZIP carried `local/` **only as an empty directory entry** — which the writer then dropped. At runtime `<dirroot>/local` never existed, and `\core\update\validator::validate_target_location()` throws the error above (`is_dir()` check on the plugin-type root).

This preserves the semantically-meaningful empty directories when converting the trimmed core ZIP to `tar.zst`.

## Changes

- **`scripts/lib/tar-ustar.mjs`** — `normalizeEntries()` now tags entries `{type:'file'|'dir'}` and preserves directory members that no file will recreate (dirs implied by a kept file are excluded via an `impliedDirs` set, so no redundant entries). `createUstarTar()` emits USTAR directory headers (typeflag `5`, size 0, mode `0755`, trailing-slash name). `readUstarTar()` surfaces `{name, type:'dir'}`.
- **`scripts/build-tar-zst-from-zip.mjs`** — reports `fileCount` (files only) and `dirCount` separately, so the manifest `bundle.fileCount` and the runtime parity tripwire stay files-only.
- **`lib/streaming-tar-extract.js`** — unchanged: it already materializes typeflag-`5`/trailing-slash directory entries via `mkdirTree`.
- Regression tests for empty-directory preservation, typeflag-5 round-trip, no-redundant-dir, path-traversal skipping, determinism, and `extractTarStreamToPhp` creating the empty dir.
- ADR 0020 (amends ADR 0018/0019's files-only policy); ADR 0019 + AGENTS.md cross-referenced.

## Verification

Three tiers, all green:

1. **Unit** — `make test` (all suites) + `make lint` pass; 28 tests in the two tar suites.
2. **Real-bundle census** — reproduced the exact bundle trim on the cached `MOODLE_500_STABLE` checkout; the fixed writer preserves exactly **6** empty dirs: `local`, `mod/lti/source`, `backup/util/destinations`, `lang/en/fonts`, `lib/editor/tiny/js/tinymce/langs`, `lib/htmlpurifier/HTMLPurifier/DefinitionCache/Serializer`.
3. **Shipped-artifact round-trip** — real ZIP → fixed writer + real zstd L19 → runtime streaming decoder (`createDecodedTarStream` + `StreamingTarParser`): `local` present, `fileCount=23324` (unchanged — matches ADR 0019's documented parity, so the tripwire stays green; the 6 dirs are `dirCount`).

- [x] `make test`
- [x] `make lint`
- [x] Real-bundle census + compressed-artifact decode confirm `/local` survives
- [ ] Manual: install a `local` plugin ZIP in a rebuilt playground and confirm the error is gone (requires `make prepare` to rebuild the bundle)

## Notes

- No plugin-specific workarounds and no placeholder files — the fix preserves archive semantics, so any directory the trim empties (present + future) is handled.
- `scripts/lib/tar-ustar.mjs` and `lib/streaming-tar-extract.js` are the **canonical** shared kit copied verbatim into the sibling `*-playground` repos; this change should be synced there.

Fixes #214
