### PR TITLE
Add blueprint performance timing and diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -424,8 +424,13 @@ so that future contributors (human or AI) understand **why** a choice was made �
 | [0018](docs/decisions/0018-core-bundle-solid-compression-experiment.md) | Solid compression for core bundles (tar.zst) — experiment that led to adoption | Accepted |
 | [0019](docs/decisions/0019-streaming-tar-zstd-core-bundle-extraction.md) | Streaming (bounded-memory) extraction for tar.zst core bundles — now the sole format | Accepted |
 | [0020](docs/decisions/0020-preserve-empty-directories-in-tar-bundle.md) | Preserve empty plugin-type-root directories in the tar.zst bundle (fixes "Plugin type location does not exist!") | Accepted |
+| [0021](docs/decisions/0021-blueprint-per-step-timing-diagnostics.md) | Blueprint per-step timing instrumentation + `[blueprint-perf]` diagnostics channel | Accepted |
 
 ## Debugging
+
+To profile a **slow blueprint** (which provisioning step dominates), see
+`docs/profiling-slow-blueprints.md` — the executor emits a per-step
+`[blueprint-perf]` timing line to the shell Logs panel (ADR 0021).
 
 ### By hand (in the browser)
 

--- a/docs/decisions/0021-blueprint-per-step-timing-diagnostics.md
+++ b/docs/decisions/0021-blueprint-per-step-timing-diagnostics.md
@@ -1,0 +1,96 @@
+# ADR-0021 Blueprint per-step timing instrumentation and `[blueprint-perf]` diagnostics channel
+
+* Status: Accepted
+* Date: 2026-07-08
+
+## Context and Problem
+
+Heavy blueprints (e.g. the user-reported Adaptable demo config with 34 steps: theme ZIP
+installs, a large theme config import, a `.mbz` course restore, SCORM/H5P modules, role
+imports) provision slowly, but there was **no way to tell which step is slow** without
+manually diffing progress-log timestamps.
+
+Before this change the executor (`src/blueprint/executor.js`) published only a *start* line
+per step — `Blueprint step N/M: <stepName>` — carried up to the shell log panel with a
+boot-relative `[<ms>]` prefix. That has three problems for profiling:
+
+1. **No per-step duration or status.** You must subtract consecutive timestamps by hand, and
+   the boot-relative clock resets on a runtime restart, so a naïve diff can go negative.
+2. **No machine-readable event.** A grep for `kind:"perf"` returned nothing; all timing was
+   free-text, so Playwright (or any dashboard) could not consume it reliably.
+3. **No slowest-step ranking**, so the one number a reader wants ("what dominated?") is absent.
+
+See issue #249. We want observability first — measure before optimizing — without changing
+provisioning behavior and without leaking secrets (blueprint steps carry passwords/tokens).
+
+## Options Considered
+
+* **A — Add a new worker→shell message kind (`kind:"perf"`) and a `window.__perfReport` mirror.**
+  Cleanest for a future dashboard, but requires shell-side plumbing (`src/shell/main.js`
+  message switch) and a new protocol surface for what is, today, a diagnostics line.
+* **B — `console.log` a JSON marker from the worker.** Playwright does not reliably capture
+  nested-iframe worker console output, so the spec could not read it.
+* **C — Emit one structured, delimited line at the END of provisioning on the existing
+  progress channel**, so it lands in the shell `#log-panel` (which Playwright already reads)
+  and survives the panel's 500-line prune. Executor returns a structured `timings` array for
+  unit tests; the runtime formats and publishes the line.
+
+## Decision
+
+Chosen: **Option C**, with the timing logic isolated in a new dependency-free module
+`src/blueprint/timing.js` so it is unit-testable in isolation.
+
+* The executor records one `StepTiming` per step — `{ index, step, label, startMs, endMs,
+  durationMs, status }` — and returns them as `result.timings`. `status` is `success`,
+  `skipped` (handler returned `{ skipped: true }`) or `failed` (handler threw). Timing is
+  captured even for a failing step and for an unknown step type. A `context.now` override
+  keeps it deterministically testable.
+* **Secret-safety is by construction (allowlist).** The only human-readable text taken from a
+  step is a *sanitized label* derived solely from the author-provided `comment`/`label`
+  description fields — never the step payload. `formatBlueprintTimings` serializes only
+  `{ i, step, label, ms, status }`, so passwords/tokens/file data cannot appear even if a step
+  object carries them.
+* The runtime (`src/runtime/bootstrap.js`) publishes, after `executeBlueprint`, two lines:
+  * a human summary — `Blueprint timing: N step(s) in Tms. Slowest: #i step (ms), …`
+  * a machine-readable, delimited line —
+    `[blueprint-perf] {"totalMs":..,"steps":[{"i","step","label","ms","status"}]} [/blueprint-perf]`
+  Both are emitted at the end so they survive the log prune. Emission is wrapped in a
+  try/catch — diagnostics never break boot.
+
+## Consequences
+
+### Positive
+* The slowest blueprint step is identifiable from a single log line, in the browser and in CI.
+* Playwright reads the report from `#log-panel` with a stable regex — no deep-iframe access,
+  no new protocol. `tests/e2e/blueprint-perf.spec.mjs` asserts the report exists with the
+  expected step names (not exact durations) and that passwords are redacted.
+* Durations are relative to blueprint start, so they are immune to boot-clock resets.
+* Zero behavior change: step order, halt-on-throw semantics, and ADR-0005 graceful handling
+  are untouched; overhead is a few `Math.round` calls plus one `JSON.stringify` at the end.
+
+### Negative / Risks
+* The machine line couples a format to a consumer (the spec's regex). Mitigated by the
+  explicit `[blueprint-perf] … [/blueprint-perf]` delimiters and a unit-tested formatter.
+* For a very long blueprint the JSON line can reach a few KB — acceptable as a single line;
+  it is namespaced and appears once.
+
+## Implementation Notes
+
+* New: `src/blueprint/timing.js` (`sanitizeStepLabel`, `deriveStepStatus`,
+  `formatBlueprintTimings`, `defaultNow`).
+* Changed: `src/blueprint/executor.js` (collect + return `timings`),
+  `src/runtime/bootstrap.js` (format + publish after `executeBlueprint`).
+* Tests: `tests/blueprint/timing.test.js`, `tests/blueprint/executor.test.js`,
+  `tests/e2e/blueprint-perf.spec.mjs` (CI-safe local blueprint + opt-in external baseline
+  gated by `RUN_EXTERNAL_PERF=1`).
+* Because the code lives under `src/blueprint/**` and `src/runtime/**`, run
+  `npm run build-worker` after changes (bundled into `dist/php-worker.bundle.js`).
+* Profiling guide: `docs/profiling-slow-blueprints.md`.
+
+## Review Criteria
+
+Revisit if: (a) a future dashboard needs a push event, in which case add `kind:"perf"` +
+`window.__perfReport` (Option A) with the spec keeping the log-parse fallback; (b) the log
+panel prune threshold shrinks below a realistic blueprint's line count, breaking end-line
+survival; or (c) per-step sub-timings (download/unzip/write for plugin installs; journal
+flush count × bytes) are needed to attribute cost within a step.

--- a/docs/profiling-slow-blueprints.md
+++ b/docs/profiling-slow-blueprints.md
@@ -1,0 +1,104 @@
+# Profiling a slow blueprint
+
+Heavy blueprints (many plugins, a large theme config import, a `.mbz` course restore,
+SCORM/H5P modules) can make provisioning take tens of seconds. This guide explains how to
+find *which step* is slow, using the per-step timing diagnostics added in
+[ADR-0021](decisions/0021-blueprint-per-step-timing-diagnostics.md).
+
+## The `[blueprint-perf]` line
+
+After a blueprint finishes provisioning, the runtime prints two lines on the normal progress
+channel (visible in the shell **Logs** side panel):
+
+```
+Blueprint timing: 34 step(s) in 49704ms. Slowest: #17 restoreCourse (31760ms), #10 installMoodlePlugin (3198ms), #11 installMoodlePlugin (2137ms).
+[blueprint-perf] {"totalMs":49704,"steps":[{"i":1,"step":"installMoodle","label":"","ms":0,"status":"success"}, ...]} [/blueprint-perf]
+```
+
+* The **human summary** ranks the three slowest steps — usually all you need.
+* The **`[blueprint-perf] … [/blueprint-perf]`** line is machine-readable JSON. Each entry has:
+
+  | Field | Meaning |
+  |-------|---------|
+  | `i` | 1-based step index |
+  | `step` | step type (e.g. `restoreCourse`) |
+  | `label` | sanitized `comment`/`label` from the step (never payload — no passwords/tokens) |
+  | `ms` | step duration in milliseconds |
+  | `status` | `success` \| `skipped` \| `failed` |
+
+  `totalMs` is the total provisioning time (sum of step durations, relative to blueprint
+  start — immune to boot-clock resets on a runtime restart).
+
+Durations are provisioning-relative, so `#17 restoreCourse (31760ms)` means that step alone
+took ~32 s. The **Boot timing summary** line (`Config … | PHP refresh … | Bootstrap … |
+Total …`) gives the surrounding boot cost.
+
+## In the browser (by hand)
+
+1. `make serve` and open `http://localhost:8080/?blueprint-url=<your-blueprint-url>`
+   (or `?blueprint=<base64>`).
+2. Open the side panel → **Logs** tab.
+3. Wait until the URL bar re-enables (provisioning done), then read the
+   `Blueprint timing:` and `[blueprint-perf]` lines. Copy the JSON into a formatter to sort by
+   `ms`.
+
+Tip: add `?debug=true` first if you also want Moodle's own debug output.
+
+## With Playwright
+
+`tests/e2e/blueprint-perf.spec.mjs` contains two tests:
+
+* **CI-safe** (`… emits a structured, secret-free per-step timing report`): a small local
+  blueprint that verifies the report exists, has the expected step names, and redacts
+  passwords. Runs on every `make test-e2e`.
+* **Opt-in baseline** (`external Adaptable blueprint produces a timing report`): loads the
+  heavy external Adaptable demo blueprint and attaches the full report + console errors as
+  test artifacts. It is `test.skip`ped unless you set `RUN_EXTERNAL_PERF=1`, because it needs
+  outbound network (GitHub + the CORS proxies) and takes ~1 min:
+
+  ```bash
+  RUN_EXTERNAL_PERF=1 npx playwright test blueprint-perf.spec.mjs --project=chromium
+  # inspect the attached report:
+  npx playwright show-report
+  ```
+
+The perf report is read from the shell `#log-panel` (see `readPerfReport` in the spec) — no
+deep-iframe access. Assertions check that timing data *exists* with the expected step names,
+never exact durations, so they are stable across machines.
+
+### Local bundles must match the streaming runtime
+
+The runtime streams a `tar.zst` core bundle into MEMFS (ADR-0018/0019). If a locally-built
+`assets/moodle/<branch>/` still ships only the older `.zip` (its manifest `bundle.format` is
+`zip`), boot stalls at *"Writing Moodle bundle into MEMFS"* because the streaming decoder is
+fed ZIP bytes. Rebuild the branch (`make bundle BRANCH=<branch>`) so the manifest advertises
+`tar.zst`.
+
+## What tends to dominate (measured on the Adaptable demo)
+
+Real Chromium measurements of the Adaptable demo blueprint (34 steps) put the cost here:
+
+1. **Course restore (`.mbz`)** — by far the largest single step (~64% of provisioning in the
+   measured run). A `restore_controller` run parses and imports the whole backup under WASM
+   SQLite. Keep backups lean; large ones also risk memory limits (see
+   [TROUBLESHOOTING](TROUBLESHOOTING.md)).
+2. **Plugin/theme ZIP installs** (~18% combined) — download + unzip + `upgrade_noncore()`.
+   A full-repo `archive/refs/heads/main.zip` (e.g. `mod_exelearning`) is the slowest; prefer a
+   pinned release ZIP.
+3. Everything else — role imports, module adds, config writes, the front-page `runPhpCode`
+   fixups — is comparatively cheap (sub-second each).
+
+Notably, the repeated `purge_all_caches()` calls inside custom `runPhpCode` steps were **not**
+a dominant cost in the measured run (tens to low-hundreds of ms each), and an explicit
+`installLanguagePack` for a locale already installed at boot is a near-no-op.
+
+## Recommendations for blueprint authors
+
+* Keep `.mbz` course backups small; they are usually the biggest cost.
+* Prefer pinned release ZIPs over moving `main` archives (reproducible, cacheable, smaller).
+* Put `debug=DEVELOPER` (32767) as the *last* step, or omit it and use `?debug=true` ad hoc —
+  enabling it early makes every later step (including the restore) run in Moodle's most
+  expensive diagnostic mode.
+* Don't repeat `installLanguagePack` for the site locale already set on install.
+* Prefer targeted `theme_reset_all_caches()` / `rebuild_course_cache()` over a full
+  `purge_all_caches()` in custom PHP, and only where a following step needs fresh caches.

--- a/src/blueprint/executor.js
+++ b/src/blueprint/executor.js
@@ -1,6 +1,7 @@
 import { substituteConstants } from "./constants.js";
 import { ResourceRegistry } from "./resources.js";
 import { getStepHandler } from "./steps/index.js";
+import { defaultNow, deriveStepStatus, sanitizeStepLabel } from "./timing.js";
 
 const PROGRESS_START = 0.92;
 const PROGRESS_END = 0.95;
@@ -16,14 +17,16 @@ const PROGRESS_END = 0.95;
  * @param {string} context.webRoot
  * @param {string} context.scopeId
  * @param {string} context.runtimeId
- * @returns {Promise<{success: boolean, landingPage?: string, failedStep?: string, error?: string}>}
+ * @param {Function} [context.now] - Monotonic clock override (ms), for testing.
+ * @returns {Promise<{success: boolean, landingPage?: string, failedStep?: string, error?: string, timings?: import("./timing.js").StepTiming[]}>}
  */
 export async function executeBlueprint(blueprint, context) {
   if (!blueprint?.steps?.length) {
-    return { success: true };
+    return { success: true, timings: [] };
   }
 
   const { publish = () => {} } = context;
+  const now = typeof context.now === "function" ? context.now : defaultNow;
 
   // Substitute constants into the entire blueprint
   const constants = blueprint.constants || {};
@@ -43,9 +46,29 @@ export async function executeBlueprint(blueprint, context) {
 
   let landingPage = resolvedBlueprint.landingPage || null;
 
+  // Per-step timing instrumentation (issue #249). Only the sanitized label —
+  // never the step payload — is recorded, so timings are safe to log.
+  const t0 = now();
+  /** @type {import("./timing.js").StepTiming[]} */
+  const timings = [];
+  const recordTiming = (index, stepName, label, startMs, status) => {
+    const endMs = Math.round(now() - t0);
+    timings.push({
+      index,
+      step: stepName,
+      label,
+      startMs,
+      endMs,
+      durationMs: endMs - startMs,
+      status,
+    });
+  };
+
   for (let i = 0; i < steps.length; i++) {
     const step = steps[i];
     const stepName = step.step;
+    const label = sanitizeStepLabel(step);
+    const startMs = Math.round(now() - t0);
     const progress =
       PROGRESS_START + (i / steps.length) * (PROGRESS_END - PROGRESS_START);
 
@@ -53,11 +76,13 @@ export async function executeBlueprint(blueprint, context) {
 
     const handler = getStepHandler(stepName);
     if (!handler) {
+      recordTiming(i + 1, stepName, label, startMs, "failed");
       return {
         success: false,
         landingPage,
         failedStep: `${i + 1}:${stepName}`,
         error: `Unknown step type: ${stepName}`,
+        timings,
       };
     }
 
@@ -71,7 +96,15 @@ export async function executeBlueprint(blueprint, context) {
       if (result?.landingPage) {
         landingPage = result.landingPage;
       }
+      recordTiming(
+        i + 1,
+        stepName,
+        label,
+        startMs,
+        deriveStepStatus({ result }),
+      );
     } catch (error) {
+      recordTiming(i + 1, stepName, label, startMs, "failed");
       const message = error?.message || String(error);
       publish(`Blueprint step ${stepName} failed: ${message}`, progress);
       return {
@@ -79,6 +112,7 @@ export async function executeBlueprint(blueprint, context) {
         landingPage,
         failedStep: `${i + 1}:${stepName}`,
         error: message,
+        timings,
       };
     }
   }
@@ -86,5 +120,6 @@ export async function executeBlueprint(blueprint, context) {
   return {
     success: true,
     landingPage,
+    timings,
   };
 }

--- a/src/blueprint/timing.js
+++ b/src/blueprint/timing.js
@@ -1,0 +1,123 @@
+/**
+ * Blueprint per-step timing instrumentation (issue #249).
+ *
+ * The executor records one {@link StepTiming} per step it runs. The runtime then
+ * surfaces a single machine-readable diagnostics line on the existing progress
+ * channel so both humans (shell log panel) and Playwright can read it.
+ *
+ * Secret-safety is by construction: only the step *index*, *type name*, a
+ * *sanitized label* (the author-provided `comment`/`label` description), the
+ * *duration* and the *status* are ever emitted. Step payload fields — which may
+ * contain passwords, tokens, or file data — are never read into the timing
+ * output.
+ *
+ * @typedef {object} StepTiming
+ * @property {number} index    1-based position in the blueprint.
+ * @property {string} step     Step type name (e.g. "installTheme").
+ * @property {string} label    Sanitized, secret-free description (may be "").
+ * @property {number} startMs  Start time, ms since blueprint start.
+ * @property {number} endMs    End time, ms since blueprint start.
+ * @property {number} durationMs
+ * @property {"success"|"skipped"|"failed"} status
+ */
+
+const MAX_LABEL_LEN = 80;
+
+/**
+ * Extract a human-readable, secret-free label from a blueprint step.
+ * Reads ONLY the author-provided `comment`/`label` description fields — never the
+ * step payload (username, password, token, data, ...).
+ *
+ * @param {object} step
+ * @returns {string}
+ */
+export function sanitizeStepLabel(step) {
+  if (!step || typeof step !== "object") {
+    return "";
+  }
+  const raw =
+    typeof step.comment === "string"
+      ? step.comment
+      : typeof step.label === "string"
+        ? step.label
+        : "";
+  const oneLine = raw.replace(/\s+/gu, " ").trim();
+  if (oneLine.length <= MAX_LABEL_LEN) {
+    return oneLine;
+  }
+  return `${oneLine.slice(0, MAX_LABEL_LEN - 1)}…`;
+}
+
+/**
+ * Derive a step status from the handler outcome.
+ *
+ * @param {{ error?: unknown, result?: unknown }} [outcome]
+ * @returns {"success"|"skipped"|"failed"}
+ */
+export function deriveStepStatus(outcome = {}) {
+  if (outcome.error) {
+    return "failed";
+  }
+  const result = outcome.result;
+  if (result && typeof result === "object" && result.skipped === true) {
+    return "skipped";
+  }
+  return "success";
+}
+
+/**
+ * Default monotonic clock: `performance.now()` when available, else `Date.now()`.
+ * @returns {number}
+ */
+export function defaultNow() {
+  const perf = globalThis.performance;
+  return perf && typeof perf.now === "function" ? perf.now() : Date.now();
+}
+
+/**
+ * Build the human-readable summary + machine-readable diagnostics line from the
+ * collected step timings. The machine line is delimited so a consumer (Playwright)
+ * can extract it reliably from the shell log:
+ *
+ *   [blueprint-perf] {"totalMs":..,"steps":[{"i","step","label","ms","status"}]} [/blueprint-perf]
+ *
+ * Only allowlisted fields are serialized, so the line is safe to log even when a
+ * step carried a password or token.
+ *
+ * @param {StepTiming[]} timings
+ * @param {{ totalMs?: number }} [options]
+ * @returns {{ perfLine: string, summaryLine: string, report: object }}
+ */
+export function formatBlueprintTimings(timings, options = {}) {
+  const steps = Array.isArray(timings) ? timings : [];
+
+  const totalMs =
+    typeof options.totalMs === "number"
+      ? Math.round(options.totalMs)
+      : steps.reduce((max, t) => Math.max(max, t?.endMs ?? 0), 0);
+
+  const report = {
+    totalMs,
+    steps: steps.map((t) => ({
+      i: t.index,
+      step: t.step,
+      label: t.label || "",
+      ms: t.durationMs,
+      status: t.status,
+    })),
+  };
+
+  const perfLine = `[blueprint-perf] ${JSON.stringify(report)} [/blueprint-perf]`;
+
+  const slowest = [...steps]
+    .filter((t) => typeof t.durationMs === "number")
+    .sort((a, b) => b.durationMs - a.durationMs)
+    .slice(0, 3)
+    .map((t) => `#${t.index} ${t.step} (${t.durationMs}ms)`);
+
+  const summaryLine =
+    `Blueprint timing: ${steps.length} step(s) in ${totalMs}ms.` +
+    (slowest.length ? ` Slowest: ${slowest.join(", ")}.` : "");
+
+  return { perfLine, summaryLine, report };
+}

--- a/src/runtime/bootstrap.js
+++ b/src/runtime/bootstrap.js
@@ -3097,6 +3097,26 @@ export async function bootstrapMoodle({
           0.95,
         );
       }
+      // Surface per-step timing diagnostics (issue #249). A single machine-
+      // readable line survives the shell's log prune and lets Playwright /
+      // humans identify the slowest steps. Never breaks boot on failure.
+      if (result.timings?.length) {
+        try {
+          const { formatBlueprintTimings } = await import(
+            "../blueprint/timing.js"
+          );
+          const { perfLine, summaryLine } = formatBlueprintTimings(
+            result.timings,
+          );
+          publish(summaryLine, 0.95);
+          publish(perfLine, 0.95);
+        } catch (timingError) {
+          publish(
+            `Blueprint timing diagnostics unavailable: ${timingError.message}`,
+            0.95,
+          );
+        }
+      }
     } catch (blueprintError) {
       publish(`Blueprint execution error: ${blueprintError.message}`, 0.95);
     }

--- a/tests/blueprint/executor.test.js
+++ b/tests/blueprint/executor.test.js
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { executeBlueprint } from "../../src/blueprint/executor.js";
+import { registerStep } from "../../src/blueprint/steps/index.js";
 
 // Minimal mock PHP runtime
 function createMockPhp() {
@@ -103,5 +104,113 @@ describe("executeBlueprint", () => {
     );
     assert.strictEqual(result.success, false);
     assert.ok(result.failedStep.includes("createUser"));
+  });
+
+  // ---------------------------------------------------------------------------
+  // Per-step timing instrumentation (issue #249)
+  // ---------------------------------------------------------------------------
+
+  it("records a per-step timing entry for every executed step", async () => {
+    const php = createMockPhp();
+    // Controlled monotonic clock: t0, then (start, end) per step.
+    const ticks = [0, 0, 10, 10, 35];
+    let i = 0;
+    const now = () => ticks[Math.min(i++, ticks.length - 1)];
+
+    const result = await executeBlueprint(
+      {
+        steps: [
+          { step: "installMoodle" },
+          { step: "setLandingPage", path: "/x" },
+        ],
+      },
+      { php, publish: () => {}, now, webRoot: "/www/moodle" },
+    );
+
+    assert.strictEqual(result.success, true);
+    assert.ok(Array.isArray(result.timings));
+    assert.strictEqual(result.timings.length, 2);
+
+    const [a, b] = result.timings;
+    assert.strictEqual(a.index, 1);
+    assert.strictEqual(a.step, "installMoodle");
+    assert.strictEqual(a.status, "success");
+    assert.strictEqual(a.startMs, 0);
+    assert.strictEqual(a.endMs, 10);
+    assert.strictEqual(a.durationMs, 10);
+
+    assert.strictEqual(b.index, 2);
+    assert.strictEqual(b.step, "setLandingPage");
+    assert.strictEqual(b.durationMs, 25);
+  });
+
+  it("times a failed step, marks it failed, and still returns partial timings", async () => {
+    const php = createMockPhp();
+    const result = await executeBlueprint(
+      {
+        steps: [{ step: "installMoodle" }, { step: "createUser" }], // missing username -> throws
+      },
+      { php, publish: () => {} },
+    );
+
+    assert.strictEqual(result.success, false);
+    assert.ok(result.failedStep.includes("createUser"));
+    assert.ok(Array.isArray(result.timings));
+    assert.strictEqual(result.timings.length, 2);
+
+    const failed = result.timings[1];
+    assert.strictEqual(failed.step, "createUser");
+    assert.strictEqual(failed.status, "failed");
+    assert.strictEqual(typeof failed.durationMs, "number");
+    assert.ok(failed.durationMs >= 0);
+  });
+
+  it("records a timing entry for an unknown step", async () => {
+    const php = createMockPhp();
+    const result = await executeBlueprint(
+      { steps: [{ step: "installMoodle" }, { step: "nonExistentStep" }] },
+      { php, publish: () => {} },
+    );
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.timings.length, 2);
+    assert.strictEqual(result.timings[1].step, "nonExistentStep");
+    assert.strictEqual(result.timings[1].status, "failed");
+  });
+
+  it("marks a step whose handler returns { skipped: true }", async () => {
+    registerStep("__test_skipped_step", async () => ({ skipped: true }));
+    const php = createMockPhp();
+    const result = await executeBlueprint(
+      { steps: [{ step: "__test_skipped_step" }] },
+      { php, publish: () => {} },
+    );
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.timings.length, 1);
+    assert.strictEqual(result.timings[0].status, "skipped");
+  });
+
+  it("never leaks step passwords into the timing output", async () => {
+    const php = createMockPhp();
+    const result = await executeBlueprint(
+      {
+        steps: [
+          {
+            step: "createUser",
+            username: "student1",
+            password: "S3cr3t-Password!",
+            email: "s@example.com",
+            firstname: "A",
+            lastname: "B",
+            comment: "make a student",
+          },
+        ],
+      },
+      { php, publish: () => {} },
+    );
+
+    const serialized = JSON.stringify(result.timings);
+    assert.ok(!serialized.includes("S3cr3t-Password!"));
+    assert.strictEqual(result.timings[0].label, "make a student");
+    assert.strictEqual(result.timings[0].status, "success");
   });
 });

--- a/tests/blueprint/timing.test.js
+++ b/tests/blueprint/timing.test.js
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  deriveStepStatus,
+  formatBlueprintTimings,
+  sanitizeStepLabel,
+} from "../../src/blueprint/timing.js";
+
+describe("sanitizeStepLabel", () => {
+  it("uses the step comment when present", () => {
+    assert.strictEqual(
+      sanitizeStepLabel({ step: "runPhpCode", comment: "Fix front page" }),
+      "Fix front page",
+    );
+  });
+
+  it("falls back to the label field", () => {
+    assert.strictEqual(
+      sanitizeStepLabel({ step: "createCourse", label: "Demo course" }),
+      "Demo course",
+    );
+  });
+
+  it("returns an empty string when there is no description", () => {
+    assert.strictEqual(sanitizeStepLabel({ step: "createUser" }), "");
+    assert.strictEqual(sanitizeStepLabel(null), "");
+  });
+
+  it("never reads secret-bearing payload fields", () => {
+    const label = sanitizeStepLabel({
+      step: "createUser",
+      username: "student1",
+      password: "S3cr3t-Password!",
+      token: "abc123token",
+    });
+    assert.ok(!label.includes("S3cr3t-Password!"));
+    assert.ok(!label.includes("abc123token"));
+    assert.ok(!label.includes("student1"));
+    assert.strictEqual(label, "");
+  });
+
+  it("collapses whitespace and truncates long labels", () => {
+    const long = `Import   the\n\tAdaptable ${"x".repeat(120)}`;
+    const label = sanitizeStepLabel({ step: "runPhpCode", comment: long });
+    assert.ok(label.length <= 80);
+    assert.ok(!label.includes("\n"));
+    assert.ok(!label.includes("\t"));
+    assert.ok(label.startsWith("Import the Adaptable"));
+  });
+});
+
+describe("deriveStepStatus", () => {
+  it("maps a thrown error to failed", () => {
+    assert.strictEqual(
+      deriveStepStatus({ error: new Error("boom") }),
+      "failed",
+    );
+  });
+
+  it("maps a skipped result to skipped", () => {
+    assert.strictEqual(
+      deriveStepStatus({ result: { skipped: true } }),
+      "skipped",
+    );
+  });
+
+  it("defaults to success", () => {
+    assert.strictEqual(
+      deriveStepStatus({ result: { landingPage: "/x" } }),
+      "success",
+    );
+    assert.strictEqual(deriveStepStatus({}), "success");
+    assert.strictEqual(deriveStepStatus(), "success");
+  });
+});
+
+describe("formatBlueprintTimings", () => {
+  const timings = [
+    {
+      index: 1,
+      step: "installMoodle",
+      label: "",
+      startMs: 0,
+      endMs: 100,
+      durationMs: 100,
+      status: "success",
+    },
+    {
+      index: 2,
+      step: "restoreCourse",
+      label: "Demo restore",
+      startMs: 100,
+      endMs: 1600,
+      durationMs: 1500,
+      status: "success",
+    },
+    {
+      index: 3,
+      step: "createUser",
+      label: "",
+      startMs: 1600,
+      endMs: 1650,
+      durationMs: 50,
+      status: "failed",
+    },
+  ];
+
+  it("produces a machine-readable [blueprint-perf] line and a human summary", () => {
+    const { perfLine, summaryLine, report } = formatBlueprintTimings(timings);
+    assert.match(perfLine, /^\[blueprint-perf\] \{.*\} \[\/blueprint-perf\]$/);
+    assert.strictEqual(report.steps.length, 3);
+    assert.strictEqual(report.totalMs, 1650);
+    // Human summary ranks the slowest step first.
+    assert.match(summaryLine, /Blueprint timing: 3 step\(s\) in 1650ms\./);
+    assert.match(summaryLine, /Slowest: #2 restoreCourse \(1500ms\)/);
+  });
+
+  it("only emits index, step type, label, ms and status (allowlist — no payload)", () => {
+    const tainted = [
+      {
+        index: 1,
+        step: "createUser",
+        label: "make a user",
+        startMs: 0,
+        endMs: 5,
+        durationMs: 5,
+        status: "success",
+        // fields that must never be serialised:
+        password: "S3cr3t-Password!",
+        token: "abc123token",
+        data: "base64secretpayload==",
+      },
+    ];
+    const { perfLine, report } = formatBlueprintTimings(tainted);
+    const serialized = perfLine + JSON.stringify(report);
+    assert.ok(!serialized.includes("S3cr3t-Password!"));
+    assert.ok(!serialized.includes("abc123token"));
+    assert.ok(!serialized.includes("base64secretpayload"));
+    assert.deepStrictEqual(Object.keys(report.steps[0]).sort(), [
+      "i",
+      "label",
+      "ms",
+      "status",
+      "step",
+    ]);
+  });
+
+  it("handles an empty timing list", () => {
+    const { perfLine, summaryLine, report } = formatBlueprintTimings([]);
+    assert.strictEqual(report.steps.length, 0);
+    assert.strictEqual(report.totalMs, 0);
+    assert.match(perfLine, /\[blueprint-perf\]/);
+    assert.match(summaryLine, /0 step\(s\)/);
+  });
+});

--- a/tests/e2e/blueprint-perf.spec.mjs
+++ b/tests/e2e/blueprint-perf.spec.mjs
@@ -1,0 +1,212 @@
+import { expect, test } from "./fixtures.mjs";
+import {
+  buildBlueprintParam,
+  createDiagnosticsCollector,
+  specTimeoutMs,
+  waitForShellReady,
+} from "./helpers.mjs";
+
+test.describe.configure({ timeout: specTimeoutMs });
+
+// ---------------------------------------------------------------------------
+// Blueprint provisioning performance observability (issue #249)
+//
+// The blueprint executor emits a single machine-readable diagnostics line at
+// the end of provisioning:
+//   [blueprint-perf] {"totalMs":..,"steps":[{"i","step","label","ms","status"}]} [/blueprint-perf]
+// It reaches the shell #log-panel via the normal progress channel, so Playwright
+// can read it without inspecting deep iframe content. The line carries ONLY the
+// step index, type, sanitized label, duration and status — never step payload.
+// ---------------------------------------------------------------------------
+
+const PERF_RE = /\[blueprint-perf\] ([\s\S]*?) \[\/blueprint-perf\]/u;
+
+async function readPerfReport(page) {
+  const logText = (await page.locator("#log-panel").textContent()) || "";
+  const match = logText.match(PERF_RE);
+  if (!match) {
+    return null;
+  }
+  try {
+    return JSON.parse(match[1]);
+  } catch {
+    return null;
+  }
+}
+
+async function openLogsPanel(page) {
+  await page.locator("#panel-toggle-button").click();
+  await page.locator("#logs-tab").click();
+}
+
+// CI-safe: a small local blueprint (no external resources) proves the
+// instrumentation end-to-end in the browser and that secrets are redacted.
+test("blueprint executor emits a structured, secret-free per-step timing report", async ({
+  page,
+}, testInfo) => {
+  const ADMIN_PASS = "SuperSecretAdmin123!";
+  const STUDENT_PASS = "Student1SecretPass!";
+
+  const bp = buildBlueprintParam({
+    landingPage: "/my/",
+    steps: [
+      {
+        step: "installMoodle",
+        options: {
+          adminUser: "admin",
+          adminPass: ADMIN_PASS,
+          adminEmail: "admin@example.com",
+          siteName: "Perf Observability Test",
+        },
+      },
+      { step: "login", username: "admin" },
+      { step: "createCategory", name: "Perf Category" },
+      {
+        step: "createCourse",
+        fullname: "Perf Course",
+        shortname: "PERF1",
+        comment: "demo course for perf test",
+      },
+      {
+        step: "createUser",
+        username: "student1",
+        password: STUDENT_PASS,
+        email: "student1@example.com",
+        firstname: "Alice",
+        lastname: "Test",
+      },
+      { step: "setLandingPage", path: "/my/" },
+    ],
+  });
+
+  const diagnostics = createDiagnosticsCollector(page);
+  await page.goto(`/?blueprint=${bp}`);
+  await waitForShellReady(page);
+  await openLogsPanel(page);
+
+  // Condition-based wait for the report to appear (NOT a fixed timeout).
+  let report = null;
+  await expect
+    .poll(
+      async () => {
+        report = await readPerfReport(page);
+        return report?.steps?.length ?? 0;
+      },
+      { timeout: 30_000 },
+    )
+    .toBeGreaterThan(0);
+
+  // Structured shape assertions (existence + names, NOT exact durations).
+  expect(typeof report.totalMs).toBe("number");
+  const stepNames = report.steps.map((s) => s.step);
+  for (const expected of [
+    "installMoodle",
+    "createCategory",
+    "createCourse",
+    "createUser",
+    "setLandingPage",
+  ]) {
+    expect(
+      stepNames,
+      `expected step "${expected}" in ${stepNames.join(",")}`,
+    ).toContain(expected);
+  }
+  for (const s of report.steps) {
+    expect(["success", "skipped", "failed"]).toContain(s.status);
+    expect(typeof s.i).toBe("number");
+  }
+
+  // Redaction: neither the parsed report nor the raw perf log line contains a password.
+  const logText = (await page.locator("#log-panel").textContent()) || "";
+  const perfLine = logText.match(PERF_RE)?.[0] ?? "";
+  const serialized = JSON.stringify(report) + perfLine;
+  expect(serialized).not.toContain(ADMIN_PASS);
+  expect(serialized).not.toContain(STUDENT_PASS);
+
+  await testInfo.attach("blueprint-perf-report.json", {
+    body: JSON.stringify(report, null, 2),
+    contentType: "application/json",
+  });
+  await testInfo.attach("console.json", {
+    body: JSON.stringify(diagnostics.consoleMessages, null, 2),
+    contentType: "application/json",
+  });
+});
+
+// Opt-in baseline measurement for the heavy external Adaptable blueprint.
+// Requires outbound network to raw.githubusercontent.com + the CORS proxies, so
+// it is NOT run in CI. Enable locally with:  RUN_EXTERNAL_PERF=1 npx playwright test blueprint-perf
+const EXTERNAL_BLUEPRINT_URL =
+  "https://raw.githubusercontent.com/HenarLG/Playground_pruebas/refs/heads/main/moodle-playground-adaptable_config_7_es_acc.json";
+
+test("external Adaptable blueprint produces a timing report (opt-in baseline)", async ({
+  page,
+}, testInfo) => {
+  test.skip(
+    !process.env.RUN_EXTERNAL_PERF,
+    "Set RUN_EXTERNAL_PERF=1 to run the heavy external blueprint baseline measurement",
+  );
+  test.setTimeout(600_000);
+
+  const diagnostics = createDiagnosticsCollector(page);
+  const runtimeRestarts = [];
+  page.on("console", (message) => {
+    const text = message.text();
+    if (/runtime restart|resetRuntime|crash recovery/iu.test(text)) {
+      runtimeRestarts.push(text);
+    }
+  });
+
+  await page.goto(
+    `/?blueprint-url=${encodeURIComponent(EXTERNAL_BLUEPRINT_URL)}`,
+  );
+  await waitForShellReady(page);
+  await openLogsPanel(page);
+
+  let report = null;
+  await expect
+    .poll(
+      async () => {
+        report = await readPerfReport(page);
+        return report?.steps?.length ?? 0;
+      },
+      { timeout: 300_000 },
+    )
+    .toBeGreaterThan(0);
+
+  const stepNames = report.steps.map((s) => s.step);
+  for (const expected of ["installMoodle", "installTheme", "restoreCourse"]) {
+    expect(
+      stepNames,
+      `expected step "${expected}" in ${stepNames.join(",")}`,
+    ).toContain(expected);
+  }
+
+  // Build a slowest-first table as an artifact (baseline evidence).
+  const ranked = [...report.steps]
+    .filter((s) => typeof s.ms === "number")
+    .sort((a, b) => b.ms - a.ms);
+
+  const consoleErrors = diagnostics.consoleMessages.filter(
+    (m) => m.type === "error",
+  );
+
+  await testInfo.attach("external-blueprint-perf-report.json", {
+    body: JSON.stringify(
+      {
+        totalMs: report.totalMs,
+        rankedBySlowest: ranked,
+        steps: report.steps,
+        consoleErrorCount: consoleErrors.length,
+        runtimeRestarts,
+      },
+      null,
+      2,
+    ),
+    contentType: "application/json",
+  });
+  await testInfo.attach("external-console.json", {
+    body: JSON.stringify(diagnostics.consoleMessages, null, 2),
+    contentType: "application/json",
+  });
+});


### PR DESCRIPTION
## Summary

- Adds timing diagnostics for blueprint provisioning.
- Adds tests for performance observability and log redaction.
- Adds Playwright coverage for slow external blueprint investigation.
- Documents how to investigate slow blueprints.

Observability only — **zero change to provisioning behavior** (step order, halt-on-throw and
ADR-0005 graceful handling are untouched). Closes the gap in #249 where the executor emitted
only a boot-relative *start* line per step, so identifying a slow step meant diffing log
timestamps by hand.

The executor now records a structured per-step timing (`index`, `step`, sanitized `label`,
`startMs`, `endMs`, `durationMs`, `status`) and the runtime publishes, at the end of
provisioning, a human summary plus a machine-readable line:

```
Blueprint timing: 34 step(s) in 49704ms. Slowest: #17 restoreCourse (31760ms), #10 installMoodlePlugin (3198ms), #11 installMoodlePlugin (2137ms).
[blueprint-perf] {"totalMs":49704,"steps":[{"i":1,"step":"installMoodle","label":"","ms":0,"status":"success"}, ...]} [/blueprint-perf]
```

**Secret redaction is by construction**: only index / step type / sanitized label
(`comment`/`label` only) / ms / status are ever emitted — never step payload. See ADR-0021.

## Measurements

*Before:* no per-step timing existed — only a start line per step.
*After:* driving the external Adaptable blueprint in headless Chromium (3 clean runs) via the
new opt-in Playwright baseline.

| Run | Total provisioning | Boot total | Slowest step | Dur | 2nd slowest | Restarts | Console errors |
| --- | ---: | ---: | --- | ---: | --- | ---: | --- |
| 1 | 49.7s | 59.4s | `restoreCourse` #17 | 31.8s | `installMoodlePlugin` #10 (3.2s) | 0 | 0 |
| 2 | 64.6s | 73.3s | `restoreCourse` #17 | 45.8s | `installMoodlePlugin` #10 (2.4s) | 0 | 0 |
| 3 | 65.6s | 84.5s | `restoreCourse` #17 | 39.6s | `installMoodlePlugin` #10 (8.7s) | 0 | 0 |

Top steps (avg of 3 runs):

| # | Step | Avg | Range |
| --- | --- | ---: | --- |
| 17 | `restoreCourse` (`.mbz`) | **39.1s** | 31.8–45.8s |
| 10 | `installMoodlePlugin` (mod_exelearning `main` archive) | 4.75s | 2.4–8.7s |
| 15 | `createScales` | 2.28s | 0.5–5.5s |
| 3 | `installTheme` (Adaptable) | 1.66s | 1.4–1.9s |
| 11/12/5 | `installMoodlePlugin` (tiles / accessibility / local_adaptable) | 1.6 / 1.4 / 0.6s | — |

**`restoreCourse` is ~65% of provisioning; the purge-bearing `runPhpCode` steps are 78–190ms each.**
Full analysis (confirmed + rejected hypotheses) in the issue.

## Testing

- [x] `npm test` — 748 unit tests pass (incl. new `timing.test.js` + executor timing tests)
- [x] `npm run build-worker`
- [x] `npm run test:e2e -- --project=chromium` — new `blueprint-perf.spec.mjs` passes (3.7s);
      opt-in external baseline (`RUN_EXTERNAL_PERF=1`) passes (~1min). Full suite runs in CI.
- [x] `npm run test:e2e -- --project=firefox` — new `blueprint-perf.spec.mjs` passes (18.9s)

## Notes

Closes the investigation for #249 (findings comment posted there). Bundles/manifests are
gitignored and not part of this diff.

Recommendations to send to **HenarLG** (the blueprint author) — non-blaming, evidence-based:

- Keep the `.mbz` course backup lean (it is ~65% of provisioning).
- Prefer pinned release ZIPs over moving `main` archives (`mod_exelearning`, the `.mbz`, and
  the 7 `refs/heads/main/...` resources).
- Drop the explicit `installLanguagePack es` step (locale `es` is already installed at boot;
  the step measured ~190ms, so it is redundant rather than costly).
- Move `debug=32767` / `debugdisplay=1` to the last step (or use `?debug=true`) — cheap good
  practice; not the current bottleneck.

Safe follow-up micro-fixes (kept out of this PR to stay focused) are listed in the issue:
a langpack idempotency guard, dropping a redundant `theme_reset_all_caches()` before a purge,
collapsing a dead `if/else` in `installPluginFiles`, and plugin-install sub-timings.
