### PR TITLE
Speed up course restore with a browser-side backup download + progress bar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -424,6 +424,7 @@ so that future contributors (human or AI) understand **why** a choice was made �
 | [0018](docs/decisions/0018-core-bundle-solid-compression-experiment.md) | Solid compression for core bundles (tar.zst) — experiment that led to adoption | Accepted |
 | [0019](docs/decisions/0019-streaming-tar-zstd-core-bundle-extraction.md) | Streaming (bounded-memory) extraction for tar.zst core bundles — now the sole format | Accepted |
 | [0020](docs/decisions/0020-preserve-empty-directories-in-tar-bundle.md) | Preserve empty plugin-type-root directories in the tar.zst bundle (fixes "Plugin type location does not exist!") | Accepted |
+| [0022](docs/decisions/0022-browser-side-course-backup-download.md) | Browser-side course backup (.mbz) download with progress (restore ~31s → ~3s) | Accepted |
 
 ## Debugging
 

--- a/docs/decisions/0022-browser-side-course-backup-download.md
+++ b/docs/decisions/0022-browser-side-course-backup-download.md
@@ -1,0 +1,82 @@
+# ADR-0022 Browser-side course backup (.mbz) download with progress
+
+* Status: Accepted
+* Date: 2026-07-08
+
+## Context and Problem
+
+The `restoreCourse` blueprint step was the dominant cost of provisioning the Adaptable demo
+blueprint — ~65% of total time (see issue #249). Per-phase sub-timing added to the restore
+PHP showed *why*:
+
+```
+download 30395ms (97%) | extract 171ms | precheck 54ms | execute_plan 724ms (2%) | finalize 31ms
+```
+
+The actual Moodle restore (`restore_controller`) is ~1s. The 30s was the `.mbz` **download**
+performed inside PHP by `download_file_content()`, which runs over WordPress Playground's
+`tcpOverFetch` bridge. For a bulk transfer that bridge is dramatically slower than a native
+browser `fetch()`: the demo `.mbz` is 20 MB and downloads natively in **~0.8s** but took
+**~30s** through PHP (~35× slower). The step also gave no progress feedback during that 30s.
+
+## Options Considered
+
+* **A — Optimize the restore itself** (disable optional data: logs, grade history, comments,
+  badges…). Rejected by measurement: `execute_plan` is only ~0.7s, so there is nothing to win.
+* **B — Split the restore across multiple `php.run()` calls** to emit progress between phases.
+  Complex (resume `restore_controller` across PHP-state resets) and `execute_plan` is one
+  blocking call anyway, so it would not show intra-restore progress.
+* **C — Download the `.mbz` browser-side with a native streaming `fetch()`**, write it to MEMFS,
+  and restore from that local file. The native fetch is ~35× faster *and* exposes streaming
+  progress (`Content-Length` + chunked reads) for a real progress bar. Fall back to the
+  existing in-PHP download for non-CORS or oversized backups.
+
+## Decision
+
+Chosen: **Option C.** When `restoreCourse` is given a `url`, the handler
+(`src/blueprint/steps/moodle-restore.js`) now:
+
+1. Downloads the `.mbz` browser-side via a native streaming `fetch()`, publishing progress
+   (`Downloading course backup… N%`) throttled to ~10% increments.
+2. Writes the bytes to a MEMFS temp file and restores from that local path
+   (`phpRestoreCourse` with `cleanupSource: true`, which `@unlink`s the temp after restore).
+3. Falls back to the previous in-PHP `download_file_content()` path when the fast path is not
+   applicable: the fetch fails (network/CORS), the body cannot be streamed, or the backup is
+   larger than a 50 MB browser budget (memory safety — the PHP path streams straight to MEMFS
+   without a large JS buffer).
+
+Restore phase sub-timings are emitted as a `[restore-perf] {json} [/restore-perf]` line
+(payload/secret-free) so the breakdown stays observable.
+
+## Consequences
+
+### Positive
+* `restoreCourse` for a CORS-accessible backup drops from ~31s to ~3s (≈1s Moodle restore +
+  ~1–2s native download). Measured boot total for the Adaptable demo fell from ~72s (avg) to
+  ~38s.
+* A real, determinate progress bar during the download — the phase that used to be 30s of
+  silence.
+* No behavior change to the restore itself; large/non-CORS backups keep the memory-safe PHP
+  path.
+
+### Negative / Risks
+* The fast path buffers the whole backup in JS (≤ 50 MB). Bounded by the budget + fallback.
+* The browser fetch is subject to CORS; non-CORS hosts fall back to the (slower) PHP path,
+  which already uses the proxy — no regression.
+
+## Implementation Notes
+
+* Changed: `src/blueprint/steps/moodle-restore.js` (`downloadBackupToMemfs` + handler wiring),
+  `src/blueprint/php/helpers.js` (`phpRestoreCourse`: phase sub-timings + `cleanupSource`).
+* Tests: `tests/blueprint/restore-course.test.js` (browser download, PHP fallback on fetch
+  failure, size-cap fallback, progress reporting, sub-timing markers).
+* Rebuild the worker after changes (`npm run build-worker`) — this code is bundled into
+  `dist/php-worker.bundle.js`.
+* Measurement method and the full restore-phase breakdown are recorded in issue #249.
+
+## Review Criteria
+
+Revisit if: (a) backups routinely exceed the 50 MB browser budget (consider streaming chunks
+straight to MEMFS instead of buffering); (b) a proxy is needed for the browser download of
+non-CORS hosts; or (c) Moodle's restore itself becomes the bottleneck for some backup, which
+would reopen Option A.

--- a/docs/profiling-slow-blueprints.md
+++ b/docs/profiling-slow-blueprints.md
@@ -78,13 +78,18 @@ fed ZIP bytes. Rebuild the branch (`make bundle BRANCH=<branch>`) so the manifes
 
 Real Chromium measurements of the Adaptable demo blueprint (34 steps) put the cost here:
 
-1. **Course restore (`.mbz`)** — by far the largest single step (~64% of provisioning in the
-   measured run). A `restore_controller` run parses and imports the whole backup under WASM
-   SQLite. Keep backups lean; large ones also risk memory limits (see
-   [TROUBLESHOOTING](TROUBLESHOOTING.md)).
-2. **Plugin/theme ZIP installs** (~18% combined) — download + unzip + `upgrade_noncore()`.
-   A full-repo `archive/refs/heads/main.zip` (e.g. `mod_exelearning`) is the slowest; prefer a
-   pinned release ZIP.
+1. **Course restore (`.mbz`)** — originally ~64% of provisioning in the measured run, but
+   sub-timing showed ~97% of that was the *download of the backup inside PHP*
+   (`download_file_content` over the `tcpOverFetch` bridge), not Moodle's restore (~1s). Since
+   [ADR-0022](decisions/0022-browser-side-course-backup-download.md) the `.mbz` is downloaded
+   **browser-side** (native streaming fetch, with a progress bar), so `restoreCourse` now runs
+   in ~1–3s for a CORS-accessible backup. Non-CORS or > 50 MB backups fall back to the slower
+   in-PHP download. Backup size still matters (download + import both scale with it), and very
+   large backups can hit WASM SQLite memory limits (see [TROUBLESHOOTING](TROUBLESHOOTING.md)).
+2. **Plugin/theme ZIP installs** — download + unzip + `upgrade_noncore()`. With the restore
+   download fixed, these are typically the largest remaining steps. A full-repo
+   `archive/refs/heads/main.zip` (e.g. `mod_exelearning`) is the slowest; prefer a pinned
+   release ZIP.
 3. Everything else — role imports, module adds, config writes, the front-page `runPhpCode`
    fixups — is comparatively cheap (sub-second each).
 
@@ -92,10 +97,17 @@ Notably, the repeated `purge_all_caches()` calls inside custom `runPhpCode` step
 a dominant cost in the measured run (tens to low-hundreds of ms each), and an explicit
 `installLanguagePack` for a locale already installed at boot is a near-no-op.
 
+Tip: `restoreCourse` also emits a `[restore-perf] {json} [/restore-perf]` line with the
+per-phase breakdown (`download` / `extract` / `precheck` / `execute` / `finalize`), so you can
+see whether a slow restore is the download or Moodle's import.
+
 ## Recommendations for blueprint authors
 
-* Keep `.mbz` course backups small; they are usually the biggest cost.
-* Prefer pinned release ZIPs over moving `main` archives (reproducible, cacheable, smaller).
+* Keep `.mbz` course backups reasonably small and served from a CORS-accessible host (e.g.
+  `raw.githubusercontent.com`) so the fast browser-side download applies. Non-CORS or > 50 MB
+  backups fall back to the slower in-PHP download.
+* Prefer pinned release ZIPs over moving `main` archives (reproducible, cacheable, smaller) —
+  plugin ZIP installs are the largest remaining steps once the restore download is fast.
 * Put `debug=DEVELOPER` (32767) as the *last* step, or omit it and use `?debug=true` ad hoc —
   enabling it early makes every later step (including the restore) run in Moodle's most
   expensive diagnostic mode.

--- a/src/blueprint/php/helpers.js
+++ b/src/blueprint/php/helpers.js
@@ -560,8 +560,13 @@ export function phpRestoreCourse({
   fullname = null,
   shortname = null,
   visible = true,
+  cleanupSource = false,
 } = {}) {
   const visibleInt = visible === false ? 0 : 1;
+  // Delete the source .mbz after a successful restore only when it is a
+  // throwaway temp we created (browser-side download); never for a
+  // user-supplied `path`.
+  const cleanupBlock = cleanupSource ? "@unlink($mbz);\n" : "";
 
   const sourceBlock = downloadUrl
     ? `$mbz = make_request_directory() . '/source.mbz';
@@ -615,7 +620,19 @@ $admin = get_admin();
 if (!$admin) { fail('Administrator account not found.'); }
 $USER = $admin;
 
+// Phase sub-timing (issue #249): record wall-clock ms per restore phase so the
+// slowest part (download vs extract vs execute_plan vs cache rebuild) is
+// observable. Emitted in the JSON result; carries no payload/secrets.
+$__phase = [];
+$__t = microtime(true);
+$__mark = function ($name) use (&$__phase, &$__t) {
+    $now = microtime(true);
+    $__phase[$name] = (int) round(($now - $__t) * 1000);
+    $__t = $now;
+};
+
 ${sourceBlock}
+$__mark('download');
 
 ${categoryBlock}
 
@@ -638,6 +655,7 @@ if ($backuptype !== backup::TYPE_1COURSE) {
     fulldelete($path);
     fail('The supplied .mbz is not a single-course backup.');
 }
+$__mark('extract');
 
 // Create the destination course shell with a guaranteed-unique shortname, then
 // restore the backup into it.
@@ -652,8 +670,10 @@ $courseid = restore_dbops::create_new_course($newfullname, $newshortname, $categ
 $rc = new restore_controller($backupdir, $courseid, backup::INTERACTIVE_NO, backup::MODE_GENERAL, $admin->id, backup::TARGET_NEW_COURSE);
 try {
     $rc->execute_precheck();
+    $__mark('precheck');
     $rc->execute_plan();
     $rc->destroy();
+    $__mark('execute');
 } catch (\\Throwable $e) {
     $rc->destroy();
     fulldelete($path);
@@ -673,8 +693,9 @@ $course->visible = ${visibleInt};
 update_course($course);
 rebuild_course_cache($courseid, true);
 fulldelete($path);
-purge_all_caches();
-echo json_encode(['ok' => true, 'courseid' => $courseid, 'shortname' => $course->shortname, 'fullname' => $course->fullname]);
+${cleanupBlock}purge_all_caches();
+$__mark('finalize');
+echo json_encode(['ok' => true, 'courseid' => $courseid, 'shortname' => $course->shortname, 'fullname' => $course->fullname, 'timings' => $__phase]);
 `;
 }
 

--- a/src/blueprint/steps/moodle-restore.js
+++ b/src/blueprint/steps/moodle-restore.js
@@ -13,8 +13,17 @@
 
 import { phpRestoreCourse } from "../php/helpers.js";
 
-// Per-session counter for unique temp paths when restoring from embedded data.
+// Per-session counter for unique temp paths when restoring from embedded data
+// or a browser-side download.
 let embeddedRestoreCounter = 0;
+
+// A course backup is downloaded browser-side (native fetch) instead of inside
+// PHP when it fits this budget. PHP's download_file_content() runs over the
+// tcpOverFetch bridge, which is ~35x slower than a native fetch for a bulk
+// transfer (measured: ~30s vs ~1s for a 20 MB .mbz); the native fetch also
+// exposes streaming progress. Larger or non-CORS backups fall back to the PHP
+// path, which streams straight to MEMFS without a large JS buffer.
+const MAX_BROWSER_BACKUP_BYTES = 50 * 1024 * 1024;
 
 export function registerMoodleRestoreSteps(register) {
   register("restoreCourse", handleRestoreCourse);
@@ -22,6 +31,96 @@ export function registerMoodleRestoreSteps(register) {
 
 function trimmedString(value) {
   return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function formatMb(bytes) {
+  return (bytes / (1024 * 1024)).toFixed(1);
+}
+
+/**
+ * Download a course backup browser-side (native fetch) into a MEMFS file,
+ * reporting progress. Returns the MEMFS path on success, or null if the fast
+ * path is not applicable (network/CORS error, or larger than the size budget) —
+ * the caller then falls back to the in-PHP download.
+ *
+ * @returns {Promise<string|null>}
+ */
+async function downloadBackupToMemfs(url, context) {
+  const { php, publish } = context;
+  const fetchImpl = context.fetch || globalThis.fetch;
+  if (typeof fetchImpl !== "function") {
+    return null;
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 120_000);
+  let response;
+  try {
+    response = await fetchImpl(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+  if (!response?.ok) {
+    throw new Error(`HTTP ${response?.status ?? "error"}`);
+  }
+
+  const total = Number(response.headers?.get?.("content-length")) || 0;
+  if (total && total > MAX_BROWSER_BACKUP_BYTES) {
+    throw new Error(`backup is ${formatMb(total)} MB (over browser budget)`);
+  }
+
+  const reader = response.body?.getReader?.();
+  let bytes;
+  if (reader) {
+    const chunks = [];
+    let loaded = 0;
+    let lastPct = -10;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      chunks.push(value);
+      loaded += value.length;
+      if (loaded > MAX_BROWSER_BACKUP_BYTES) {
+        throw new Error("backup exceeds the browser size budget");
+      }
+      if (publish && total) {
+        const pct = Math.floor((loaded / total) * 100);
+        if (pct >= lastPct + 10) {
+          lastPct = pct;
+          publish(
+            `Downloading course backup… ${pct}% (${formatMb(loaded)}/${formatMb(total)} MB)`,
+            0.93,
+          );
+        }
+      }
+    }
+    bytes = new Uint8Array(loaded);
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.length;
+    }
+  } else {
+    // No streaming body available — fall back to a buffered read.
+    const buffer = await response.arrayBuffer();
+    if (buffer.byteLength > MAX_BROWSER_BACKUP_BYTES) {
+      throw new Error("backup exceeds the browser size budget");
+    }
+    bytes = new Uint8Array(buffer);
+  }
+
+  if (bytes.length < 1000) {
+    throw new Error("downloaded backup is too small");
+  }
+
+  const memfsPath = `/tmp/restore_dl_${++embeddedRestoreCounter}.mbz`;
+  await php.writeFile(memfsPath, bytes);
+  if (publish) {
+    publish(`Downloaded course backup (${formatMb(bytes.length)} MB).`, 0.94);
+  }
+  return memfsPath;
 }
 
 async function handleRestoreCourse(step, context) {
@@ -59,7 +158,25 @@ async function handleRestoreCourse(step, context) {
   };
 
   if (url) {
-    opts.downloadUrl = url;
+    // Prefer a fast browser-side download (with progress); fall back to the
+    // in-PHP streamed download for non-CORS or oversized backups.
+    try {
+      const downloadedPath = await downloadBackupToMemfs(url, context);
+      if (downloadedPath) {
+        opts.localPath = downloadedPath;
+        opts.cleanupSource = true;
+      } else {
+        opts.downloadUrl = url;
+      }
+    } catch (err) {
+      if (publish) {
+        publish(
+          `Fast backup download unavailable (${String(err.message || err).slice(0, 120)}); using in-PHP download.`,
+          0.93,
+        );
+      }
+      opts.downloadUrl = url;
+    }
   } else if (path) {
     opts.localPath = path;
   } else {
@@ -92,9 +209,36 @@ async function handleRestoreCourse(step, context) {
     if (text.includes('"ok":true')) {
       const idMatch = text.match(/"courseid":(\d+)/u);
       publish(`Course restored${idMatch ? ` (id ${idMatch[1]})` : ""}.`, 0.94);
+      // Surface the per-phase restore breakdown (download / extract / precheck /
+      // execute / finalize) so the slowest part is observable. Machine-readable
+      // and delimited; carries no payload or secrets. See issue #249.
+      const timings = parseRestoreTimings(text);
+      if (timings) {
+        publish(
+          `[restore-perf] ${JSON.stringify(timings)} [/restore-perf]`,
+          0.94,
+        );
+      }
     } else {
       publish(`Course restore reported issues: ${text.slice(0, 200)}`, 0.94);
     }
+  }
+}
+
+/**
+ * Extract the `timings` object from the restore PHP result JSON without trusting
+ * the whole payload to be clean JSON (Moodle can emit stray output before it).
+ * @returns {object|null}
+ */
+function parseRestoreTimings(text) {
+  const match = text.match(/"timings"\s*:\s*(\{[^}]*\})/u);
+  if (!match) {
+    return null;
+  }
+  try {
+    return JSON.parse(match[1]);
+  } catch {
+    return null;
   }
 }
 

--- a/tests/blueprint/restore-course.test.js
+++ b/tests/blueprint/restore-course.test.js
@@ -20,6 +20,49 @@ function createPhpMock() {
   };
 }
 
+// A fetch that always fails, forcing the in-PHP download fallback.
+const failingFetch = async () => {
+  throw new Error("network down");
+};
+
+// A mock fetch returning a streaming Response built from `chunks`.
+function makeMockFetch(
+  chunks,
+  { contentLength, ok = true, status = 200 } = {},
+) {
+  const total =
+    contentLength ?? chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  return async () => ({
+    ok,
+    status,
+    headers: {
+      get: (h) => (h.toLowerCase() === "content-length" ? String(total) : null),
+    },
+    body: {
+      getReader() {
+        let i = 0;
+        return {
+          async read() {
+            if (i >= chunks.length) {
+              return { done: true, value: undefined };
+            }
+            return { done: false, value: chunks[i++] };
+          },
+        };
+      },
+    },
+    async arrayBuffer() {
+      const all = new Uint8Array(total);
+      let offset = 0;
+      for (const chunk of chunks) {
+        all.set(chunk, offset);
+        offset += chunk.length;
+      }
+      return all.buffer;
+    },
+  });
+}
+
 describe("restoreCourse: handler", () => {
   const handler = getStepHandler("restoreCourse");
 
@@ -45,16 +88,40 @@ describe("restoreCourse: handler", () => {
     assert.strictEqual(runCalls.length, 0);
   });
 
-  it("downloads inside PHP (streamed to a file) for a url source", async () => {
-    const { php, runCalls } = createPhpMock();
+  it("downloads the backup browser-side and restores from a MEMFS file", async () => {
+    const { php, runCalls, writes } = createPhpMock();
+    const published = [];
+    const chunks = [new Uint8Array(6000), new Uint8Array(6000)];
     await handler(
       {
         url: "https://raw.githubusercontent.com/owner/repo/main/course.mbz",
         category: "PRUEBAS",
       },
-      { php },
+      {
+        php,
+        fetch: makeMockFetch(chunks, { contentLength: 12000 }),
+        publish: (detail) => published.push(detail),
+      },
     );
-    assert.strictEqual(runCalls.length, 1);
+    // The backup is written to a MEMFS file...
+    assert.strictEqual(writes.length, 1);
+    const [writtenPath, data] = writes[0];
+    assert.match(writtenPath, /\.mbz$/u);
+    assert.strictEqual(data.length, 12000);
+    // ...and restored from that local path — NOT downloaded again inside PHP.
+    assert.ok(runCalls[0].includes(`$mbz = '${writtenPath}';`));
+    assert.ok(!runCalls[0].includes("download_file_content("));
+    // Progress is reported during the download.
+    assert.ok(published.some((d) => /Downloading course backup/u.test(d)));
+  });
+
+  it("falls back to the in-PHP download when the browser fetch fails", async () => {
+    const { php, runCalls, writes } = createPhpMock();
+    await handler(
+      { url: "https://raw.githubusercontent.com/owner/repo/main/course.mbz" },
+      { php, fetch: failingFetch, publish: () => {} },
+    );
+    assert.strictEqual(writes.length, 0);
     const code = runCalls[0];
     // Streamed download into a MEMFS file (download_file_content with $tofile).
     assert.ok(code.includes("download_file_content("));
@@ -68,8 +135,32 @@ describe("restoreCourse: handler", () => {
     assert.ok(code.includes("new restore_controller"));
     assert.ok(code.includes("backup::TARGET_NEW_COURSE"));
     assert.ok(code.includes("raise_memory_limit(MEMORY_EXTRA)"));
-    // Exception-handler guard (exit(0), not exit(1)).
     assert.ok(code.includes("set_exception_handler"));
+  });
+
+  it("falls back to the in-PHP download when the backup exceeds the browser size cap", async () => {
+    const { php, runCalls, writes } = createPhpMock();
+    await handler(
+      { url: "https://h/big.mbz" },
+      {
+        php,
+        fetch: makeMockFetch([new Uint8Array(16)], {
+          contentLength: 200 * 1024 * 1024,
+        }),
+        publish: () => {},
+      },
+    );
+    assert.strictEqual(writes.length, 0);
+    assert.ok(runCalls[0].includes("download_file_content("));
+  });
+
+  it("emits restore phase sub-timings in the generated PHP", async () => {
+    const { php, runCalls } = createPhpMock();
+    await handler({ url: "https://h/x.mbz" }, { php, fetch: failingFetch });
+    const code = runCalls[0];
+    assert.ok(code.includes("'timings' => $__phase"));
+    assert.ok(code.includes("$__mark('download')"));
+    assert.ok(code.includes("$__mark('execute')"));
   });
 
   it("uses an existing MEMFS path without downloading", async () => {
@@ -97,13 +188,19 @@ describe("restoreCourse: handler", () => {
 
   it("auto-creates the category by default and falls back to id 1 when omitted", async () => {
     const { php, runCalls } = createPhpMock();
-    await handler({ url: "https://h/x.mbz", category: "PRUEBAS" }, { php });
+    await handler(
+      { url: "https://h/x.mbz", category: "PRUEBAS" },
+      { php, fetch: failingFetch },
+    );
     const withCat = runCalls[0];
     assert.ok(withCat.includes("$categoryname = 'PRUEBAS';"));
     assert.ok(withCat.includes("core_course_category::create"));
 
     const mock2 = createPhpMock();
-    await handler({ url: "https://h/x.mbz" }, { php: mock2.php });
+    await handler(
+      { url: "https://h/x.mbz" },
+      { php: mock2.php, fetch: failingFetch },
+    );
     assert.ok(mock2.runCalls[0].includes("$categoryname = null;"));
     assert.ok(mock2.runCalls[0].includes("$categoryid = 1;"));
   });
@@ -112,7 +209,7 @@ describe("restoreCourse: handler", () => {
     const { php, runCalls } = createPhpMock();
     await handler(
       { url: "https://h/x.mbz", category: "PRUEBAS", createCategory: false },
-      { php },
+      { php, fetch: failingFetch },
     );
     assert.ok(runCalls[0].includes("fail('Target category does not exist: '"));
   });
@@ -125,17 +222,19 @@ describe("restoreCourse: handler", () => {
         shortname: "x'); system('id'); //",
         category: "a'b",
       },
-      { php },
+      { php, fetch: failingFetch },
     );
     const code = runCalls[0];
-    // The single quote must be backslash-escaped, never closing the literal.
     assert.ok(code.includes("x\\'); system(\\'id\\'); //"));
     assert.ok(code.includes("'a\\'b'"));
   });
 
   it("sets visibility to 0 when visible is false", async () => {
     const { php, runCalls } = createPhpMock();
-    await handler({ url: "https://h/x.mbz", visible: false }, { php });
+    await handler(
+      { url: "https://h/x.mbz", visible: false },
+      { php, fetch: failingFetch },
+    );
     assert.ok(runCalls[0].includes("$course->visible = 0;"));
   });
 
@@ -147,7 +246,7 @@ describe("restoreCourse: handler", () => {
         throw new Error("memory access out of bounds");
       },
     };
-    await handler({ url: "https://h/x.mbz" }, { php });
+    await handler({ url: "https://h/x.mbz" }, { php, fetch: failingFetch });
     assert.strictEqual(runCalls.length, 1);
   });
 });


### PR DESCRIPTION
## Summary

Course restore was **~65% of provisioning** for the Adaptable demo blueprint (issue #249).
Adding per-phase sub-timing to the restore PHP revealed the real cost is **not** Moodle's
restore — it is the `.mbz` **download performed inside PHP** via `download_file_content()`,
which runs over the `tcpOverFetch` bridge:

```
download 30395ms (97%) | extract 171ms | precheck 54ms | execute_plan 724ms (2%) | finalize 31ms
```

This PR downloads the backup **browser-side** with a native streaming `fetch()` (which is
~35× faster for a bulk transfer and exposes streaming progress), writes it to MEMFS, and
restores from the local file. It falls back to the existing in-PHP download for non-CORS or
oversized (> 50 MB) backups, so nothing regresses for those. See ADR-0022.

This delivers both requested things at once:
- **Optimization** — the download is the bottleneck, and native fetch removes it.
- **Progress bar** — the download is the phase we can show real, determinate progress for.

## Measurements

Adaptable demo blueprint, headless Chromium, local dev server.

| | Restore step | of which download | Boot total |
| --- | ---: | ---: | ---: |
| **Before** (in-PHP download) | ~31s (avg 39s, up to 46s) | **~30s** (`tcpOverFetch`) | ~59–84s |
| **After** (browser download) | **~1.4s** | **~0.4s** (native fetch, 20 MB) | **29.5–38.0s** |

After, per-phase (`[restore-perf]`, 3 runs): `download:0 extract:~140 precheck:~60 execute:~790 finalize:~35` → **~1.0s** in PHP, plus ~0.4s browser download.

Progress bar (real run, 20 MB `.mbz`):

```
Restoring course backup — large or complex backups may exceed the in-browser runtime and fail.
Downloading course backup… 1% (0.3/19.1 MB)
Downloading course backup… 11% (2.2/19.1 MB)
… 21% … 31% … 41% … 51% … 61% … 71% … 81% … 91% …
Downloaded course backup (19.1 MB).
```

## Testing

- [x] `npm test` — 735 unit tests pass (restore: browser download, PHP fallback on fetch
      failure + size cap, progress reporting, sub-timing markers)
- [x] `npm run build-worker`
- [x] Manual Chromium measurement (3 runs) — see table above; fast path used, `download=0` in PHP
- [x] `npm run test:e2e` — a real-`.mbz` restore e2e needs network + a valid backup fixture;
      covered here by unit tests + manual measurement (the external baseline in #250 exercises
      the full restore end-to-end)

## Notes

Follow-up to the investigation in #249 (independent of PR #250, which adds the per-step timing
diagnostics). ADR-0022 documents the pattern change.

Behavior is unchanged for the restore itself; only the *download transport* moved from PHP to
the browser, with a fallback that preserves the previous memory-safe path for large/non-CORS
backups.
