### PR TITLE
Make blueprint provisioning resilient to transient resource-fetch failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -426,6 +426,7 @@ so that future contributors (human or AI) understand **why** a choice was made â
 | [0020](docs/decisions/0020-preserve-empty-directories-in-tar-bundle.md) | Preserve empty plugin-type-root directories in the tar.zst bundle (fixes "Plugin type location does not exist!") | Accepted |
 | [0021](docs/decisions/0021-blueprint-per-step-timing-diagnostics.md) | Blueprint per-step timing instrumentation + `[blueprint-perf]` diagnostics channel | Accepted |
 | [0022](docs/decisions/0022-browser-side-course-backup-download.md) | Browser-side course backup (.mbz) download with progress (restore ~31s â†’ ~3s) | Accepted |
+| [0023](docs/decisions/0023-resilient-resource-fetch-and-non-fatal-steps.md) | Resilient resource fetching (retry) + non-fatal-by-default steps (`critical` opt-in) | Accepted |
 
 ## Debugging
 

--- a/docs/blueprints/reference.md
+++ b/docs/blueprints/reference.md
@@ -117,9 +117,11 @@ from a step with the string `"@name"`, or inline the descriptor directly.
 
 !!! note "Legend"
     **(HTTP)** runs over an HTTP request (for session cookies); all other PHP
-    steps run via CLI. **(marker)** does no work itself. **(non-fatal)** reports
-    a failure but does not abort the rest of the blueprint. Unmarked steps abort
-    the blueprint on error. Batch steps take an array under the named field.
+    steps run via CLI. **(marker)** does no work itself. Step failures are
+    **non-fatal by default**: a failing step is reported and the rest of the
+    blueprint still runs (the steps tagged **(non-fatal)** below also handle
+    PHP-level errors gracefully). Add `"critical": true` to a step to abort the
+    blueprint on its failure. Batch steps take an array under the named field.
 
 ### Install and auth
 
@@ -416,9 +418,16 @@ defaults to `main`. See [PR previews](../github/pr-previews.md).
 - Steps run **sequentially** in array order.
 - Most steps run PHP in `CLI_SCRIPT` mode. `login`, `request`, and
   `runPhpScript` run over HTTP; `installMoodle` and `setLandingPage` are markers.
-- By default a failing step **stops** the blueprint and reports the error.
-- **Non-fatal steps** report the failure and continue: `restoreCourse` and
-  `installLanguagePack`. For `applyPrOverlay`, an unreachable or oversized
+- Step failures are **non-fatal by default** (ADR-0005 / ADR-0023): a failing
+  step is reported (progress log + `[blueprint-perf]` `status: "failed"`) and
+  execution continues, so one transient error (e.g. a resource download) does
+  not discard the whole playground. Add `"critical": true` to a step to abort
+  the blueprint on its failure.
+- URL resources are fetched with **retry on transient failure** (network errors
+  and HTTP 5xx/429, with backoff); permanent errors (4xx, over the 50 MB cap)
+  fail fast.
+- **Non-fatal steps** also handle PHP-level failures gracefully: `restoreCourse`
+  and `installLanguagePack`. For `applyPrOverlay`, an unreachable or oversized
   individual file is skipped, and the cache-purge and upgrade phases are
   best-effort — but manifest resolution and the `maxFiles` cap still abort.
 - The `createRole` / `createScale` / `createCohort` / `importRoles` generators

--- a/docs/decisions/0023-resilient-resource-fetch-and-non-fatal-steps.md
+++ b/docs/decisions/0023-resilient-resource-fetch-and-non-fatal-steps.md
@@ -1,0 +1,79 @@
+# ADR-0023 Resilient resource fetching + non-fatal-by-default blueprint steps
+
+* Status: Accepted
+* Date: 2026-07-08
+
+## Context and Problem
+
+Re-measuring the Adaptable demo blueprint after the restore fix (#251, ADR-0022) showed the
+remaining provisioning time is dominated by **network fetches of remote assets**, not CPU:
+the blueprint pulls 16 resources (config JSON, logo, role XMLs, scales JSON, 3 plugin ZIPs,
+the `.mbz`, …) from `raw.githubusercontent.com` during provisioning, and the big per-step
+variance (`createScales` 0.65–5.4s, `importRoles` 1.0–3.5s) is network jitter.
+
+Worse, one of three measured runs **aborted the whole blueprint at step 8**: a transient
+failure fetching the theme-logo resource made `setConfigFile` throw, and the executor stopped —
+so no course restore, no courses, no users. Two problems combined:
+
+1. **No retry.** `resources.resolve()` did a single `fetch()` with a flat 30s timeout; any
+   network blip or transient 5xx threw immediately.
+2. **A thrown step aborted everything.** Although ADR-0005's intent is "install what we can",
+   the executor halted on any thrown step, so a resource-fetch failure discarded the rest of
+   an otherwise-working blueprint.
+
+## Options Considered
+
+* **A — Retry only.** Add retry/backoff to `resources.resolve()`. Fixes transient blips but a
+  *persistent* failure of even a cosmetic resource (the logo) would still abort the whole run.
+* **B — Make each resource-fetching handler catch-and-skip.** Localized, but touches many
+  handlers and only covers resource fetches, leaving the executor's abort-on-throw in place.
+* **C — Retry + make the executor non-fatal by default (with a `critical` opt-in).** Completes
+  ADR-0005's stated intent at the executor level and covers every step uniformly.
+
+## Decision
+
+Chosen: **Option C.**
+
+1. **Retry transient resource fetches.** `ResourceRegistry` fetches URL resources through a
+   retry loop (default 3 attempts, linear backoff). Retriable: network errors / aborts (no HTTP
+   status) and transient statuses (5xx, 429). Not retriable: permanent 4xx and the 50 MB cap.
+   `fetchImpl` / `retryAttempts` / `retryDelayMs` are injectable for tests.
+2. **Non-fatal step execution by default.** The executor now logs a failing step (progress +
+   `[blueprint-perf]` `status: "failed"`) and continues to the next step, reporting the first
+   failure in the result. A step with `"critical": true` still aborts the blueprint. This
+   fulfils ADR-0005 ("a failing plugin/module doesn't block subsequent steps") — previously
+   only achievable by handlers that avoided throwing — and implements the `critical` flag,
+   which was documented but had no effect.
+
+## Consequences
+
+### Positive
+* A transient (or persistent) failure of one resource — especially a cosmetic one like the
+  logo — no longer discards the rest of the playground. The run-2 abort cannot recur.
+* Retry absorbs the network jitter that dominated the post-restore step variance.
+* Better observability: the `[blueprint-perf]` report now lists *all* steps with per-step
+  `status`, instead of stopping at the first failure.
+
+### Negative / Risks
+* Steps after a failure run against possibly-incomplete state; dependent steps then fail too,
+  but gracefully (they are reported, not fatal). Net effect is "install what we can", the
+  intended behavior. Authors who need hard ordering guarantees use `"critical": true`.
+* This reverses the previously-documented "unmarked steps abort" default; `docs/blueprints/reference.md`
+  is updated accordingly.
+
+## Implementation Notes
+
+* `src/blueprint/resources.js` — retry loop (`#fetchResourceBytes` / `#fetchOnce`,
+  `isTransientFetchError`) + constructor options.
+* `src/blueprint/executor.js` — accumulate the first failure, continue by default, honor
+  `step.critical`.
+* Tests: `tests/blueprint/resources.test.js` (retry: transient network, transient 5xx, budget
+  exhaustion, no-retry-on-404) and `tests/blueprint/executor.test.js` (continue on non-critical
+  failure, halt on `critical`, continue past unknown step).
+* Rebuild the worker after changes (`npm run build-worker`).
+
+## Review Criteria
+
+Revisit if: (a) a step genuinely must halt the blueprint by default (reconsider per-step
+defaults); (b) retry masks a persistent misconfiguration that should surface louder; or
+(c) parallel/prefetch resource loading is added, which would change where retry lives.

--- a/src/blueprint/executor.js
+++ b/src/blueprint/executor.js
@@ -51,6 +51,10 @@ export async function executeBlueprint(blueprint, context) {
   const t0 = now();
   /** @type {import("./timing.js").StepTiming[]} */
   const timings = [];
+  // First failure encountered (reported back), while execution keeps going —
+  // step failures are non-fatal by default (ADR-0005). A step with
+  // `critical: true` aborts the remaining blueprint on failure.
+  let firstFailure = null;
   const recordTiming = (index, stepName, label, startMs, status) => {
     const endMs = Math.round(now() - t0);
     timings.push({
@@ -77,13 +81,15 @@ export async function executeBlueprint(blueprint, context) {
     const handler = getStepHandler(stepName);
     if (!handler) {
       recordTiming(i + 1, stepName, label, startMs, "failed");
-      return {
-        success: false,
-        landingPage,
-        failedStep: `${i + 1}:${stepName}`,
-        error: `Unknown step type: ${stepName}`,
-        timings,
-      };
+      const error = `Unknown step type: ${stepName}`;
+      publish(`Blueprint step ${stepName} skipped: ${error}`, progress);
+      if (!firstFailure) {
+        firstFailure = { failedStep: `${i + 1}:${stepName}`, error };
+      }
+      if (step.critical) {
+        return { success: false, landingPage, ...firstFailure, timings };
+      }
+      continue;
     }
 
     try {
@@ -107,19 +113,22 @@ export async function executeBlueprint(blueprint, context) {
       recordTiming(i + 1, stepName, label, startMs, "failed");
       const message = error?.message || String(error);
       publish(`Blueprint step ${stepName} failed: ${message}`, progress);
-      return {
-        success: false,
-        landingPage,
-        failedStep: `${i + 1}:${stepName}`,
-        error: message,
-        timings,
-      };
+      if (!firstFailure) {
+        firstFailure = { failedStep: `${i + 1}:${stepName}`, error: message };
+      }
+      // Non-fatal by default (ADR-0005): keep provisioning the remaining steps
+      // so one transient failure (e.g. a resource download) does not discard
+      // the whole playground. `critical: true` opts a step into aborting.
+      if (step.critical) {
+        return { success: false, landingPage, ...firstFailure, timings };
+      }
     }
   }
 
   return {
-    success: true,
+    success: !firstFailure,
     landingPage,
+    ...(firstFailure || {}),
     timings,
   };
 }

--- a/src/blueprint/resources.js
+++ b/src/blueprint/resources.js
@@ -10,16 +10,40 @@ export class ResourceRegistry {
   #php;
   /** @type {Map<string, Uint8Array>} */
   #cache;
+  /** @type {Function} */
+  #fetchImpl;
+  /** @type {number} */
+  #retryAttempts;
+  /** @type {number} */
+  #retryDelayMs;
 
   /**
    * @param {Record<string, object>} resourceDefs - Named resource descriptors from blueprint.resources
-   * @param {{ appBaseUrl?: string, php?: object }} options
+   * @param {{ appBaseUrl?: string, php?: object, fetchImpl?: Function, retryAttempts?: number, retryDelayMs?: number }} options
    */
-  constructor(resourceDefs = {}, { appBaseUrl = "", php = null } = {}) {
+  constructor(
+    resourceDefs = {},
+    {
+      appBaseUrl = "",
+      php = null,
+      fetchImpl = null,
+      retryAttempts = 3,
+      retryDelayMs = 500,
+    } = {},
+  ) {
     this.#defs = resourceDefs;
     this.#appBaseUrl = appBaseUrl;
     this.#php = php;
     this.#cache = new Map();
+    // Bind to the global fetch so native fetch isn't called with the registry
+    // as `this` (illegal invocation); tests inject a plain function.
+    this.#fetchImpl =
+      fetchImpl ||
+      (typeof globalThis.fetch === "function"
+        ? globalThis.fetch.bind(globalThis)
+        : null);
+    this.#retryAttempts = Math.max(1, retryAttempts);
+    this.#retryDelayMs = Math.max(0, retryDelayMs);
   }
 
   /**
@@ -73,6 +97,64 @@ export class ResourceRegistry {
     return null; // inline values are not cached
   }
 
+  /**
+   * Fetch a URL resource with retry-on-transient-failure (issue #249). Network
+   * errors, aborts/timeouts and transient HTTP statuses (5xx, 429) are retried
+   * with linear backoff; permanent errors (4xx, size cap) fail fast.
+   * @param {string} url
+   * @returns {Promise<Uint8Array>}
+   */
+  async #fetchResourceBytes(url) {
+    let lastError;
+    for (let attempt = 1; attempt <= this.#retryAttempts; attempt++) {
+      try {
+        return await this.#fetchOnce(url);
+      } catch (err) {
+        lastError = err;
+        if (attempt >= this.#retryAttempts || !isTransientFetchError(err)) {
+          throw err;
+        }
+        if (this.#retryDelayMs > 0) {
+          await new Promise((resolve) =>
+            setTimeout(resolve, this.#retryDelayMs * attempt),
+          );
+        }
+      }
+    }
+    throw lastError;
+  }
+
+  async #fetchOnce(url) {
+    if (typeof this.#fetchImpl !== "function") {
+      throw new Error("No fetch implementation available for URL resources.");
+    }
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 30000);
+    try {
+      const response = await this.#fetchImpl(url, {
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        const error = new Error(
+          `Failed to fetch resource from ${url}: ${response.status}`,
+        );
+        error.status = response.status;
+        throw error;
+      }
+      const buffer = await response.arrayBuffer();
+      if (buffer.byteLength > 50 * 1024 * 1024) {
+        const error = new Error(
+          `Resource from ${url} exceeds 50MB size limit.`,
+        );
+        error.permanent = true;
+        throw error;
+      }
+      return new Uint8Array(buffer);
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
   async #fetchDescriptor(descriptor) {
     const encoder = new TextEncoder();
 
@@ -88,24 +170,7 @@ export class ResourceRegistry {
       const resolved = this.#appBaseUrl
         ? new URL(descriptor.url, this.#appBaseUrl).toString()
         : descriptor.url;
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 30000);
-      let response;
-      try {
-        response = await fetch(resolved, { signal: controller.signal });
-      } finally {
-        clearTimeout(timeoutId);
-      }
-      if (!response.ok) {
-        throw new Error(
-          `Failed to fetch resource from ${resolved}: ${response.status}`,
-        );
-      }
-      const buffer = await response.arrayBuffer();
-      if (buffer.byteLength > 50 * 1024 * 1024) {
-        throw new Error(`Resource from ${resolved} exceeds 50MB size limit.`);
-      }
-      return new Uint8Array(buffer);
+      return this.#fetchResourceBytes(resolved);
     }
 
     if (descriptor.base64) {
@@ -140,6 +205,24 @@ export class ResourceRegistry {
       `Unsupported resource descriptor: ${JSON.stringify(descriptor)}`,
     );
   }
+}
+
+/**
+ * Whether a fetch error is worth retrying: network errors / aborts (no HTTP
+ * status) and transient server statuses (5xx, 429). Permanent errors — the
+ * 50MB size cap and other 4xx statuses — are not retried.
+ * @param {any} err
+ * @returns {boolean}
+ */
+function isTransientFetchError(err) {
+  if (err?.permanent) {
+    return false;
+  }
+  const status = err?.status;
+  if (typeof status === "number") {
+    return status >= 500 || status === 429;
+  }
+  return true;
 }
 
 function base64ToBytes(str) {

--- a/tests/blueprint/executor.test.js
+++ b/tests/blueprint/executor.test.js
@@ -213,4 +213,68 @@ describe("executeBlueprint", () => {
     assert.strictEqual(result.timings[0].label, "make a student");
     assert.strictEqual(result.timings[0].status, "success");
   });
+
+  // ---------------------------------------------------------------------------
+  // Resilient execution: non-fatal by default, `critical` opt-in (ADR-0005)
+  // ---------------------------------------------------------------------------
+
+  it("continues after a non-critical step failure and runs later steps", async () => {
+    const php = createMockPhp();
+    const result = await executeBlueprint(
+      {
+        steps: [
+          { step: "installMoodle" },
+          { step: "createUser" }, // missing username -> throws (non-critical)
+          { step: "setLandingPage", path: "/after/" },
+        ],
+      },
+      { php, publish: () => {} },
+    );
+
+    // The blueprint reports the failure but did NOT abort: the later step ran.
+    assert.strictEqual(result.success, false);
+    assert.ok(result.failedStep.includes("createUser"));
+    assert.strictEqual(result.landingPage, "/after/");
+    assert.strictEqual(result.timings.length, 3);
+    assert.strictEqual(result.timings[1].status, "failed");
+    assert.strictEqual(result.timings[2].status, "success");
+  });
+
+  it("halts on a step marked critical", async () => {
+    const php = createMockPhp();
+    const result = await executeBlueprint(
+      {
+        steps: [
+          { step: "installMoodle" },
+          { step: "createUser", critical: true }, // throws + critical -> halt
+          { step: "setLandingPage", path: "/after/" },
+        ],
+      },
+      { php, publish: () => {} },
+    );
+
+    assert.strictEqual(result.success, false);
+    assert.ok(result.failedStep.includes("createUser"));
+    // The later step did NOT run.
+    assert.strictEqual(result.landingPage, null);
+    assert.strictEqual(result.timings.length, 2);
+  });
+
+  it("continues past an unknown step type (non-fatal) and runs later steps", async () => {
+    const php = createMockPhp();
+    const result = await executeBlueprint(
+      {
+        steps: [
+          { step: "nonExistentStep" },
+          { step: "setLandingPage", path: "/after/" },
+        ],
+      },
+      { php, publish: () => {} },
+    );
+    assert.strictEqual(result.success, false);
+    assert.ok(result.error.includes("Unknown step type"));
+    assert.strictEqual(result.landingPage, "/after/");
+    assert.strictEqual(result.timings.length, 2);
+    assert.strictEqual(result.timings[0].status, "failed");
+  });
 });

--- a/tests/blueprint/resources.test.js
+++ b/tests/blueprint/resources.test.js
@@ -100,4 +100,84 @@ describe("ResourceRegistry", () => {
       /Malformed data: URL/,
     );
   });
+
+  // ---------------------------------------------------------------------------
+  // URL resources: retry transient failures (issue #249)
+  // ---------------------------------------------------------------------------
+
+  function okResponse(text) {
+    return {
+      ok: true,
+      status: 200,
+      async arrayBuffer() {
+        return new TextEncoder().encode(text).buffer;
+      },
+    };
+  }
+  function errResponse(status) {
+    return {
+      ok: false,
+      status,
+      async arrayBuffer() {
+        return new ArrayBuffer(0);
+      },
+    };
+  }
+
+  it("retries a transient network error and then succeeds", async () => {
+    let calls = 0;
+    const fetchImpl = async () => {
+      calls++;
+      if (calls === 1) throw new Error("connection reset");
+      return okResponse("recovered");
+    };
+    const registry = new ResourceRegistry(
+      { r: { url: "https://h/x" } },
+      { fetchImpl, retryDelayMs: 0 },
+    );
+    assert.strictEqual(await registry.resolveText("@r"), "recovered");
+    assert.strictEqual(calls, 2);
+  });
+
+  it("retries a transient 503 and then succeeds", async () => {
+    let calls = 0;
+    const fetchImpl = async () => {
+      calls++;
+      return calls < 3 ? errResponse(503) : okResponse("ok");
+    };
+    const registry = new ResourceRegistry(
+      { r: { url: "https://h/x" } },
+      { fetchImpl, retryDelayMs: 0 },
+    );
+    assert.strictEqual(await registry.resolveText("@r"), "ok");
+    assert.strictEqual(calls, 3);
+  });
+
+  it("gives up after the retry budget on a persistent failure", async () => {
+    let calls = 0;
+    const fetchImpl = async () => {
+      calls++;
+      throw new Error("down");
+    };
+    const registry = new ResourceRegistry(
+      { r: { url: "https://h/x" } },
+      { fetchImpl, retryAttempts: 3, retryDelayMs: 0 },
+    );
+    await assert.rejects(() => registry.resolve("@r"));
+    assert.strictEqual(calls, 3);
+  });
+
+  it("does not retry a permanent 404", async () => {
+    let calls = 0;
+    const fetchImpl = async () => {
+      calls++;
+      return errResponse(404);
+    };
+    const registry = new ResourceRegistry(
+      { r: { url: "https://h/x" } },
+      { fetchImpl, retryAttempts: 3, retryDelayMs: 0 },
+    );
+    await assert.rejects(() => registry.resolve("@r"), /404/);
+    assert.strictEqual(calls, 1);
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to the #249 investigation. Re-measuring after the restore fix (#251) showed the
remaining provisioning time is dominated by **network fetches of remote assets**, and — more
importantly — that a single transient fetch failure could **abort the whole blueprint**.

In one of three measured runs the blueprint aborted at step 8: a transient failure fetching the
theme-logo resource made `setConfigFile` throw, and the executor stopped — so the course
restore, courses, users and everything after never ran. This PR fixes that.

- **Retry transient resource fetches.** `ResourceRegistry` now fetches URL resources through a
  retry loop (3 attempts, linear backoff). Retriable: network errors / aborts and HTTP 5xx/429.
  Permanent errors (4xx, > 50 MB cap) fail fast. This absorbs the network jitter that dominated
  the post-restore step variance.
- **Non-fatal step execution by default.** The executor logs a failing step (progress +
  `[blueprint-perf]` `status: "failed"`) and continues, reporting the first failure. A step with
  `"critical": true` still aborts. This fulfils ADR-0005's stated intent ("a failing
  plugin/module doesn't block subsequent steps") — previously only achievable by handlers that
  avoided throwing — and implements the `critical` flag, which was documented but inert.

See ADR-0023.

## Why (evidence from #249)

Re-measured on `main` (post #250 + #251), 3 Chromium runs of the external Adaptable blueprint:

| Run | Provisioning | Steps completed |
| --- | ---: | ---: |
| 1 | 21.0s | 34/34 |
| 2 | 11.7s | **8/34 — aborted at `setConfigFile` (logo fetch failed)** |
| 3 | 27.9s | 34/34 |

`resources.resolve()` did a single `fetch()` with a flat 30s timeout and no retry; a blip threw,
and the executor halted on the throw. Full analysis in
[#249](https://github.com/ateeducacion/moodle-playground/issues/249).

## Testing

- [x] `npm test` — 758 unit tests pass. New: `resources.test.js` (retry: transient network,
      transient 5xx, budget exhaustion, no-retry-on-404); `executor.test.js` (continue on
      non-critical failure, halt on `critical`, continue past unknown step).
- [x] `npm run build-worker`
- [x] Manual Chromium verification — 2 runs completed **34/34, no failures**, provisioning
      ~21–25s (no regression from the executor change).

## Notes

This is a product-side robustness fix; it makes resource-heavy demo blueprints resilient to
transient network failures rather than requiring the author to change anything. The
complementary author-side suggestions for **@HenarLG** (pin `mod_exelearning` to a release ZIP,
keep the `.mbz` small, fewer/pinned remote resources) still stand in #249 as ways to make the
demo faster and more reproducible — but a network blip will no longer discard the playground.

Behavior change: step failures are now non-fatal by default (previously an unmarked failing step
aborted the blueprint). `docs/blueprints/reference.md` is updated, and `"critical": true` is
available for steps that must abort on failure.
