### PR TITLE
fix(sqlite): pass an object to database_column_info so $column->name is populated

### DIFF
--- a/patches/shared/lib/dml/sqlite3_pdo_moodle_database.php
+++ b/patches/shared/lib/dml/sqlite3_pdo_moodle_database.php
@@ -389,7 +389,12 @@ class sqlite3_pdo_moodle_database extends pdo_moodle_database {
             if ($columninfo['has_default'] && ($columninfo['meta_type'] == 'X' || $columninfo['meta_type'] == 'C')) {
                 $columninfo['default_value'] = substr($columninfo['default_value'], 1, -1);
             }
-            $structure[$columninfo['name']] = new database_column_info($columninfo);
+            // database_column_info::__construct() reads its fields via object property
+            // access ($data->$element), so it must be given an object like the other
+            // Moodle DML drivers (pgsql/mysqli) do. Passing the raw array leaves every
+            // property (including ->name) null, which silently breaks callers that read
+            // $column->name (e.g. theme_snap's deadlines query).
+            $structure[$columninfo['name']] = new database_column_info((object) $columninfo);
         }
 
         return $structure;


### PR DESCRIPTION
## Summary

The SQLite PDO driver's `fetch_columns()` builds each column as an **array** and passes it straight to `database_column_info`:

```php
$structure[$columninfo['name']] = new database_column_info($columninfo); // $columninfo is an array
```

But `database_column_info::__construct()` reads its fields via **object property access**:

```php
foreach ($validelements as $element) {
    if (isset($data->$element)) {       // $data->name, $data->type, ...
        $this->data[$element] = $data->$element;
    } else {
        $this->data[$element] = null;
    }
}
```

Passing an array means `$data->$element` resolves to `null` for every field, so **every column's `->name` (and every other property) ends up `null`**. The *array keys* returned by `get_columns()` stay correct (they come from `$columninfo['name']`), which is why most of Moodle — which iterates columns by key — kept working. Any caller that reads `$column->name`, however, silently gets an empty value.

## Symptom

`theme_snap` builds its "deadlines" events query from `get_columns('event')`:

```php
$cols = $DB->get_columns('event');
foreach ($cols as $col) {
    ...
    $selectfields .= 'e.' . $col->name;   // $col->name is empty
}
```

This produced `SELECT e., e., e., ... FROM {event} e ...` and failed with:

```
SQLSTATE[HY000]: General error: 1 near ",": syntax error
```

i.e. an **"Error reading from database"** on every course page and dashboard for a logged-in user whenever the Snap theme is active. (Discovered while building a Moodle Playground preview for `theme_snap`.)

## Fix

Cast the column info to an object before constructing `database_column_info`, exactly as the core `pgsql` and `mysqli` drivers already do (`$structure[$info->name] = new database_column_info($info)` with `$info` a `stdClass`):

```php
$structure[$columninfo['name']] = new database_column_info((object) $columninfo);
```

Applied to the canonical patch `patches/shared/lib/dml/sqlite3_pdo_moodle_database.php`.

## Validation

Reproduced the constructor behaviour in isolation with Moodle 4.5's `database_column_info`:

```
current (array)  -> name = NULL
fixed   (object) -> name = 'timestart'
```

To verify end to end: rebuild the bundle with this patch, install and enable `theme_snap`, and open any course page as a logged-in user — the page now renders instead of throwing the DML read exception.

Low risk: the change only normalises the argument passed to `database_column_info` to the object form every other Moodle DML driver already uses.
