### PR TITLE
[SUPERSEDED by #265] perf: pass lower INITIAL_MEMORY + ALLOW_MEMORY_GROWTH to loadWebRuntime

### DIFF
--- a/src/runtime/php-loader.js
+++ b/src/runtime/php-loader.js
@@ -114,6 +114,14 @@ export function createPhpRuntime(
       const runtimeId = await loadWebRuntime(resolvedPhpVersion, {
         ...(tcpOverFetch ? { tcpOverFetch } : {}),
         withIntl: true,
+        // Lower initial WASM memory allocation + explicit growth.
+        // Reduces peak memory at boot and allows the heap to grow only as
+        // needed (inspired by WP Playground lower-initial-memory work).
+        // 128 MiB starting point is a compromise for Moodle's size.
+        emscriptenOptions: {
+          INITIAL_MEMORY: 128 * 1024 * 1024,
+          ALLOW_MEMORY_GROWTH: 1,
+        },
       });
       const php = new PHP(runtimeId);
       const FS = php[__private__dont__use].FS;
@@ -252,6 +260,14 @@ export function createProvisioningRuntime(_runtime, { phpVersion } = {}) {
       const runtimeId = await loadWebRuntime(resolvedPhpVersion, {
         ...(tcpOverFetch ? { tcpOverFetch } : {}),
         withIntl: true,
+        // Lower initial WASM memory allocation + explicit growth.
+        // Reduces peak memory at boot and allows the heap to grow only as
+        // needed (inspired by WP Playground lower-initial-memory work).
+        // 128 MiB starting point is a compromise for Moodle's size.
+        emscriptenOptions: {
+          INITIAL_MEMORY: 128 * 1024 * 1024,
+          ALLOW_MEMORY_GROWTH: 1,
+        },
       });
       const php = new PHP(runtimeId);
       const FS2 = php[__private__dont__use].FS;


### PR DESCRIPTION
## Summary
Implements performance improvement #2 (Emscripten memory configuration).

Adds explicit `emscriptenOptions` to `loadWebRuntime` calls:
```js
emscriptenOptions: {
  INITIAL_MEMORY: 128 * 1024 * 1024,
  ALLOW_MEMORY_GROWTH: 1,
}
```

This change was later consolidated with the memory_limit reduction (see companion PR for 256M php.ini values).

## Related ADR
- **ADR-0024**: Lower base PHP memory_limit and Emscripten INITIAL_MEMORY for browser WASM environments

## Benefits
- Reduces initial WASM memory reservation.
- Allows controlled growth only as needed by Moodle core + plugins.
- Faster startup and lower peak usage on memory-constrained browsers.

## Verification
- Builds cleanly
- Compatible with existing @php-wasm web builds (which already enable growth)

Part of the memory and boot performance series.