### PR TITLE
[SUPERSEDED by #265] perf: overlap snapshot and localcache seed downloads with WASM + core bundle

### DIFF
--- a/php-worker.js
+++ b/php-worker.js
@@ -536,15 +536,41 @@ async function getRuntimeState() {
 
     // Kick off the manifest resolution + bundle download NOW so it overlaps the
     // WASM compile in php.refresh(). The no-op .catch prevents an
-    // unhandledrejection if refresh() throws first; the real error resurfaces
-    // at `await archivePromise` inside bootstrapMoodle and flows into the
-    // bootstrap-error catch below.
+    // unhandledrejection if refresh() throws first.
     const archivePromise = startArchiveResolution({
       moodleBranch,
       appBaseUrl: appRootUrl,
       publish,
     });
     archivePromise.catch(() => {});
+
+    // Eagerly start snapshot + localcache seed downloads as soon as the
+    // manifest is known. This overlaps them with both WASM compile and the
+    // big core tar.zst, reducing critical path on snapshot-origin boots.
+    const snapshotAssetsPromise = archivePromise
+      .then((arch) => {
+        const m = arch?.manifest;
+        const ps = [];
+        if (m?.snapshot?.url) {
+          ps.push(
+            import("./lib/moodle-loader.js").then(({ fetchAssetWithCache }) =>
+              fetchAssetWithCache(m.snapshot.url, m.snapshot).catch((e) => ({ error: e })),
+            ),
+          );
+        }
+        if (m?.snapshot?.localcache?.url) {
+          ps.push(
+            import("./lib/moodle-loader.js").then(({ fetchAssetWithCache }) =>
+              fetchAssetWithCache(
+                m.snapshot.localcache.url,
+                m.snapshot.localcache,
+              ).catch((e) => ({ error: e })),
+            ),
+          );
+        }
+        return Promise.all(ps);
+      })
+      .catch(() => {});
 
     const t1 = performance.now();
     await php.refresh();


### PR DESCRIPTION
## Summary
Implements performance improvement #4.

In `php-worker.js` `getRuntimeState()`:

- When the archive manifest resolves, immediately start prefetching the install snapshot (`install.sq3`) and localcache seed in parallel.
- These fetches run concurrently with WASM compilation (`php.refresh()`) and the main tar.zst streaming.

The existing prefetch logic inside `bootstrapMoodle` will hit the Cache API for anything that finished early.

## Related ADR
- **ADR-0025**: Boot-time asset delivery overlap, static fast-paths, and long-lived runtime diagnostics

## Benefits
- Reduces critical-path time on snapshot-origin cold boots.
- Snapshot + seed are small relative to the core bundle, so the overlap is cheap.

Part of the series of boot-time optimizations.