### PR TITLE
[SUPERSEDED by #265] perf(runtime): add high-watermark diagnostic for long-lived runtimes

### DIFF
--- a/php-worker.js
+++ b/php-worker.js
@@ -59,11 +59,16 @@ let automaticPhpInfoAttempted = false;
 //      MIN_REQUESTS_BEFORE_RESTART requests, it is likely a fundamental bug
 //      — do not restart (avoids infinite boot-crash-boot loops).
 //
-// No preventive rotation is performed. WordPress Playground does not rotate
-// preventively either; the correct fix for memory leaks is root-cause, not
-// periodic restarts that cost 3-8s each.
+// Preventive (scheduled) rotation is intentionally off by default because
+// a full Moodle boot is expensive. WP Playground rotates after N requests
+// in some hosting scenarios; here we only log at a very high watermark so
+// operators can decide to reload the tab. A future opt-in may be added.
 const MAX_REACTIVE_RESTARTS = 20;
 const MIN_REQUESTS_BEFORE_RESTART = 10;
+
+// Very high watermark — crossing this suggests a long-lived tab may be
+// accumulating leaks. We log a diagnostic but do not auto-reboot.
+const RUNTIME_HIGH_WATERMARK_REQUESTS = 1500;
 let requestCount = 0;
 let reactiveRestartCount = 0;
 
@@ -707,6 +712,18 @@ function installBridgeListener() {
 
       try {
         requestCount += 1;
+
+        // High-watermark diagnostic (no auto action — full reboot is expensive).
+        if (requestCount === RUNTIME_HIGH_WATERMARK_REQUESTS) {
+          postShell({
+            kind: "log",
+            level: "warn",
+            message:
+              `[perf] Request count reached ${RUNTIME_HIGH_WATERMARK_REQUESTS}. ` +
+              `Long-lived tab may benefit from a manual Reset Playground to release accumulated memory.`,
+          });
+        }
+
         const state = await getRuntimeState();
         const response = await executePhpRequest(state, data.request);
         // Detect plugin installations from Moodle's native admin UI


### PR DESCRIPTION
## Summary
Implements performance improvement #5.

- Adds `RUNTIME_HIGH_WATERMARK_REQUESTS = 1500`.
- When crossed, emits a single diagnostic warning to the shell Logs panel.
- No automatic rotation or reboot is performed (full reboots are expensive).
- Clarifies comments around the existing reactive-only restart policy.

## Related ADR
- **ADR-0025**: Boot-time asset delivery overlap, static fast-paths, and long-lived runtime diagnostics

## Rationale
WordPress Playground uses preventive rotation in some cases. For Moodle the cost of a full boot is high, so we provide observability instead and keep the "rotate only on fatal WASM error" strategy.

## Benefits
- Gives operators of very long-lived tabs a gentle hint that a "Reset Playground" may help release accumulated state.

Part of the runtime lifecycle improvements.