### PR TITLE
perf: more playground config disables + lighter crash recovery + opcache.jit=0

### DIFF
--- a/lib/config-template.js
+++ b/lib/config-template.js
@@ -172,6 +172,7 @@ max_input_vars=5000
 memory_limit=256M
 post_max_size=64M
 upload_max_filesize=64M
+opcache.jit=0
 sys_temp_dir=${TEMP_ROOT}
 upload_tmp_dir=${TEMP_ROOT}
 session.save_handler=files

--- a/src/runtime/bootstrap.js
+++ b/src/runtime/bootstrap.js
@@ -724,6 +724,16 @@ try {
         'gradepointmax' => '100',
         'downloadcoursecontentallowed' => '0',
         'enablesharingtomoodlenet' => '0',
+        // Additional playground-specific disables for lower memory/CPU and
+        // simpler UX (these are safe in ephemeral single-user environment).
+        'enableanalytics' => '0',
+        'enablestats' => '0',
+        'enableportfolios' => '0',
+        'messaging' => '0',
+        'allowemojipicker' => '0',
+        'showuseridentity' => '',
+        'enablebadges' => '0',
+        'enableglobalsearch' => '0',
     ];
 
     foreach ($defaults as $name => $value) {

--- a/src/runtime/config-template.js
+++ b/src/runtime/config-template.js
@@ -363,6 +363,7 @@ export function createPhpIniEntries({
     // See docs/architecture/adr/ADR-0011-bundle-trim-and-runtime-tuning.md (amends
     // ADR 0004).
     "opcache.enable": "1",
+    "opcache.jit": "0",
     "opcache.file_cache": "/internal/shared/opcache",
     "opcache.file_cache_only": "1",
     "opcache.max_accelerated_files": "20000",

--- a/src/runtime/config-template.js
+++ b/src/runtime/config-template.js
@@ -327,12 +327,12 @@ export function createPhpIniEntries({
     log_errors: "1",
     // max_execution_time stays at 0 (WP Playground default) — no timeout in WASM
     max_input_vars: "5000",
-    // memory_limit: 256M is a good balance for Moodle Playground.
+    // memory_limit: 256M + modest opcache is a good balance for Moodle Playground.
     // Official Moodle recommendation (docs.moodle.org) is at least 96-128M.
     // 256M gives headroom for normal operation while greatly reducing WASM
-    // heap usage vs the previous 512M. Heavy operations (course restore,
-    // large plugin installs) call raise_memory_limit(MEMORY_EXTRA) which
-    // temporarily increases it further.
+    // heap usage vs the previous 512M. opcache values reduced similarly.
+    // Heavy operations (course restore, large plugin installs) call
+    // raise_memory_limit(MEMORY_EXTRA) which temporarily increases it further.
     memory_limit: "256M",
     post_max_size: "64M",
     upload_max_filesize: "64M",
@@ -366,8 +366,8 @@ export function createPhpIniEntries({
     "opcache.file_cache": "/internal/shared/opcache",
     "opcache.file_cache_only": "1",
     "opcache.max_accelerated_files": "20000",
-    "opcache.memory_consumption": "128",
-    "opcache.interned_strings_buffer": "32",
+    "opcache.memory_consumption": "96",
+    "opcache.interned_strings_buffer": "16",
     "opcache.validate_timestamps": "0",
     "opcache.file_cache_consistency_checks": "0",
   };

--- a/src/runtime/crash-recovery.js
+++ b/src/runtime/crash-recovery.js
@@ -126,6 +126,8 @@ export function formatErrorDetail(error) {
  * 2. After bootstrapping a fresh runtime, overwrite the DB file and
  *    restore plugin directories. This preserves courses, users, config,
  *    and installed plugins.
+ *    (filedir/user uploads are intentionally not snapshotted to keep
+ *    the recovery path lighter on memory.)
  * 3. Re-create the admin session (auto-login) on the restored DB.
  *
  * @param {{ postShell: (msg: object) => void }} options

--- a/src/runtime/crash-recovery.js
+++ b/src/runtime/crash-recovery.js
@@ -133,11 +133,11 @@ export function formatErrorDetail(error) {
  * @param {{ postShell: (msg: object) => void }} options
  * @returns {object} Snapshot manager with hydrate/restore methods.
  */
-const FILEDIR_PATH = "/persist/moodledata/filedir";
-
 export function createSnapshotManager({ postShell }) {
   let savedDbSnapshot = null;
   let savedPluginFiles = null;
+  // filedir snapshot intentionally disabled to reduce memory on crash path
+  // (see ADR-0027). We keep the variable for minimal diff but never populate it.
   let savedFiledirFiles = null;
   /** Paths of plugin directories installed during this session. */
   const installedPluginDirs = new Set();
@@ -348,11 +348,8 @@ export function createSnapshotManager({ postShell }) {
 
     /** Whether there is a saved snapshot waiting to be restored. */
     get hasPendingRestore() {
-      return (
-        savedDbSnapshot !== null ||
-        savedPluginFiles !== null
-        // filedir intentionally not snapshotted to reduce memory on crash path
-      );
+      // filedir intentionally not snapshotted (see ADR-0027)
+      return savedDbSnapshot !== null || savedPluginFiles !== null;
     },
 
     /**

--- a/src/runtime/crash-recovery.js
+++ b/src/runtime/crash-recovery.js
@@ -278,28 +278,13 @@ export function createSnapshotManager({ postShell }) {
         });
       }
 
-      // 3. Save user-uploaded files (stored files in filedir)
-      try {
-        if (rawPhp.fileExists(FILEDIR_PATH) && rawPhp.isDir(FILEDIR_PATH)) {
-          const files = collectFiles(rawPhp, FILEDIR_PATH);
-          if (files.length > 0) {
-            savedFiledirFiles = files;
-            const totalBytes = files.reduce(
-              (sum, f) => sum + f.data.byteLength,
-              0,
-            );
-            postShell({
-              kind: "trace",
-              detail: `[snapshot] saved ${files.length} filedir entries (${Math.round(totalBytes / 1024)}KB)`,
-            });
-          }
-        }
-      } catch (err) {
-        postShell({
-          kind: "error",
-          detail: `[snapshot] failed to read filedir: ${err.message}`,
-        });
-      }
+      // 3. (intentionally skipped for memory optimization)
+      // Saving the entire filedir on crash can require copying a large amount
+      // of data into JS memory right when the runtime is unstable. In the
+      // ephemeral Playground, user uploads are not critical state — the DB
+      // + installed plugins are the valuable part that we preserve.
+      // If needed in the future, this can be re-enabled behind a size guard.
+      savedFiledirFiles = null;
     },
 
     /**
@@ -353,18 +338,8 @@ export function createSnapshotManager({ postShell }) {
         savedPluginFiles = null;
       }
 
-      // 3. Restore filedir (user-uploaded content)
-      if (savedFiledirFiles) {
-        const { ok, failed } = restoreFiles(rawPhp, savedFiledirFiles);
-        postShell({
-          kind: "trace",
-          detail: `[snapshot] restored ${ok} filedir entries${failed > 0 ? ` (${failed} failed)` : ""}`,
-        });
-        if (ok > 0) {
-          restored = true;
-        }
-        savedFiledirFiles = null;
-      }
+      // 3. filedir restore skipped (see save logic above — saves memory on crash)
+      savedFiledirFiles = null;
 
       return { restored, pluginsRestored, restoredPluginDirs };
     },
@@ -373,8 +348,8 @@ export function createSnapshotManager({ postShell }) {
     get hasPendingRestore() {
       return (
         savedDbSnapshot !== null ||
-        savedPluginFiles !== null ||
-        savedFiledirFiles !== null
+        savedPluginFiles !== null
+        // filedir intentionally not snapshotted to reduce memory on crash path
       );
     },
 


### PR DESCRIPTION
## Summary
Continuation of the performance/memory work (beyond the first 6 PRs).

- Expand `createConfigNormalizerPhp` with additional low-overhead settings:
  enableanalytics, enablestats, enableportfolios, messaging, enablebadges,
  enableglobalsearch, allowemojipicker, etc. These reduce background tasks,
  caches, and memory in the playground environment.
- In crash-recovery: skip full filedir snapshot on crash (was copying large
  amounts of user files into JS memory at the worst time). DB + plugins are
  preserved; user uploads are secondary for ephemeral sessions.
- Explicit "opcache.jit": "0" and aligned lower opcache memory/interned values.
- Minor opcache tuning for consistency with 256M memory_limit.

## Related
- Builds on ADR-0024 (memory/Emscripten) and ADR-0025 (boot/runtime lifecycle).
- New optimizations for reduced peak memory and faster/leaner runtime.

## Verification
- Unit tests pass
- `npm run build-worker` ok
- Changes are low-risk and reversible.

Continuing the series of optimizations inspired by WP Playground patterns while respecting the ephemeral design of this project.