### PR TITLE
[SUPERSEDED by #265] perf: expand playground config normalizer with more memory/CPU saving defaults

### DIFF
--- a/src/runtime/bootstrap.js
+++ b/src/runtime/bootstrap.js
@@ -724,6 +724,16 @@ try {
         'gradepointmax' => '100',
         'downloadcoursecontentallowed' => '0',
         'enablesharingtomoodlenet' => '0',
+        // Additional playground-specific disables for lower memory/CPU and
+        // simpler UX (these are safe in ephemeral single-user environment).
+        'enableanalytics' => '0',
+        'enablestats' => '0',
+        'enableportfolios' => '0',
+        'messaging' => '0',
+        'allowemojipicker' => '0',
+        'showuseridentity' => '',
+        'enablebadges' => '0',
+        'enableglobalsearch' => '0',
     ];
 
     foreach ($defaults as $name => $value) {


### PR DESCRIPTION
## Summary

This PR continues the performance and memory optimizations (post the initial 1-6 series).

- Expands the set of Moodle config settings that are forced to low-overhead values in the playground normalizer (`createConfigNormalizerPhp`).
- New disables/minimizations include:
  - `enableanalytics`, `enablestats`, `enableportfolios`, `messaging`, `enablebadges`, `enableglobalsearch`
  - `allowemojipicker`, `showuseridentity`, etc.

These settings reduce background processing, MUC cache overhead, UI complexity, and memory usage in the ephemeral single-user WASM environment without impacting core playground functionality.

## Context

Builds on the runtime tuning work in ADR-0024 and the earlier config normalizer changes.

## Related

- Follow-up to PRs #255–#261
- **ADR-0026**: Playground-specific minimization of Moodle configuration and features for memory and simplicity
- References ADR-0024 (memory and runtime configuration)

## Verification

- Existing unit tests for config normalizer continue to pass.
- Changes are isolated to the post-install normalizer step.