### PR TITLE
[SUPERSEDED by #265] perf: explicitly disable opcache.jit and align lower opcache memory values

### DIFF
--- a/lib/config-template.js
+++ b/lib/config-template.js
@@ -172,6 +172,7 @@ max_input_vars=5000
 memory_limit=256M
 post_max_size=64M
 upload_max_filesize=64M
+opcache.jit=0
 sys_temp_dir=${TEMP_ROOT}
 upload_tmp_dir=${TEMP_ROOT}
 session.save_handler=files

--- a/src/runtime/config-template.js
+++ b/src/runtime/config-template.js
@@ -363,6 +363,7 @@ export function createPhpIniEntries({
     // See docs/architecture/adr/ADR-0011-bundle-trim-and-runtime-tuning.md (amends
     // ADR 0004).
     "opcache.enable": "1",
+    "opcache.jit": "0",
     "opcache.file_cache": "/internal/shared/opcache",
     "opcache.file_cache_only": "1",
     "opcache.max_accelerated_files": "20000",

--- a/src/runtime/config-template.js
+++ b/src/runtime/config-template.js
@@ -327,12 +327,12 @@ export function createPhpIniEntries({
     log_errors: "1",
     // max_execution_time stays at 0 (WP Playground default) — no timeout in WASM
     max_input_vars: "5000",
-    // memory_limit: 256M is a good balance for Moodle Playground.
+    // memory_limit: 256M + modest opcache is a good balance for Moodle Playground.
     // Official Moodle recommendation (docs.moodle.org) is at least 96-128M.
     // 256M gives headroom for normal operation while greatly reducing WASM
-    // heap usage vs the previous 512M. Heavy operations (course restore,
-    // large plugin installs) call raise_memory_limit(MEMORY_EXTRA) which
-    // temporarily increases it further.
+    // heap usage vs the previous 512M. opcache values reduced similarly.
+    // Heavy operations (course restore, large plugin installs) call
+    // raise_memory_limit(MEMORY_EXTRA) which temporarily increases it further.
     memory_limit: "256M",
     post_max_size: "64M",
     upload_max_filesize: "64M",
@@ -366,8 +366,8 @@ export function createPhpIniEntries({
     "opcache.file_cache": "/internal/shared/opcache",
     "opcache.file_cache_only": "1",
     "opcache.max_accelerated_files": "20000",
-    "opcache.memory_consumption": "128",
-    "opcache.interned_strings_buffer": "32",
+    "opcache.memory_consumption": "96",
+    "opcache.interned_strings_buffer": "16",
     "opcache.validate_timestamps": "0",
     "opcache.file_cache_consistency_checks": "0",
   };


### PR DESCRIPTION
## Summary

This PR continues the performance/memory optimizations.

- Adds explicit `"opcache.jit": "0"` in the PHP runtime ini.
- Lowers `opcache.memory_consumption` (128 → 96) and `opcache.interned_strings_buffer` (32 → 16) for consistency with the 256M memory_limit work.
- Also applies `opcache.jit=0` to the local dev php.ini template used for snapshot generation and `make up-local`.

These values are mostly inert under `file_cache_only=1` (as documented in ADR-0011), but the explicit jit=0 and reduced numbers help with overall memory/CPU profile in the WASM environment.

## Context

Part of the follow-up tuning after the initial memory_limit reduction to 256M.

## Related

- Follow-up to #255 and #261
- References ADR-0024

## Verification

- `npm run build-worker` succeeds.
- No behavior change expected for normal operation (file cache only mode).