### PR TITLE
perf: combine all optimizations (memory, bundle, overlap, diagnostics, SW fast-path, config, opcache) — exclude crash recovery

### DIFF
--- a/lib/config-template.js
+++ b/lib/config-template.js
@@ -172,6 +172,7 @@ max_input_vars=5000
 memory_limit=256M
 post_max_size=64M
 upload_max_filesize=64M
+opcache.jit=0
 sys_temp_dir=${TEMP_ROOT}
 upload_tmp_dir=${TEMP_ROOT}
 session.save_handler=files

--- a/php-worker.js
+++ b/php-worker.js
@@ -59,11 +59,16 @@ let automaticPhpInfoAttempted = false;
 //      MIN_REQUESTS_BEFORE_RESTART requests, it is likely a fundamental bug
 //      — do not restart (avoids infinite boot-crash-boot loops).
 //
-// No preventive rotation is performed. WordPress Playground does not rotate
-// preventively either; the correct fix for memory leaks is root-cause, not
-// periodic restarts that cost 3-8s each.
+// Preventive (scheduled) rotation is intentionally off by default because
+// a full Moodle boot is expensive. WP Playground rotates after N requests
+// in some hosting scenarios; here we only log at a very high watermark so
+// operators can decide to reload the tab. A future opt-in may be added.
 const MAX_REACTIVE_RESTARTS = 20;
 const MIN_REQUESTS_BEFORE_RESTART = 10;
+
+// Very high watermark — crossing this suggests a long-lived tab may be
+// accumulating leaks. We log a diagnostic but do not auto-reboot.
+const RUNTIME_HIGH_WATERMARK_REQUESTS = 1500;
 let requestCount = 0;
 let reactiveRestartCount = 0;
 
@@ -733,6 +738,18 @@ function installBridgeListener() {
 
       try {
         requestCount += 1;
+
+        // High-watermark diagnostic (no auto action — full reboot is expensive).
+        if (requestCount === RUNTIME_HIGH_WATERMARK_REQUESTS) {
+          postShell({
+            kind: "log",
+            level: "warn",
+            message:
+              `[perf] Request count reached ${RUNTIME_HIGH_WATERMARK_REQUESTS}. ` +
+              `Long-lived tab may benefit from a manual Reset Playground to release accumulated memory.`,
+          });
+        }
+
         const state = await getRuntimeState();
         const response = await executePhpRequest(state, data.request);
         // Detect plugin installations from Moodle's native admin UI

--- a/php-worker.js
+++ b/php-worker.js
@@ -536,15 +536,41 @@ async function getRuntimeState() {
 
     // Kick off the manifest resolution + bundle download NOW so it overlaps the
     // WASM compile in php.refresh(). The no-op .catch prevents an
-    // unhandledrejection if refresh() throws first; the real error resurfaces
-    // at `await archivePromise` inside bootstrapMoodle and flows into the
-    // bootstrap-error catch below.
+    // unhandledrejection if refresh() throws first.
     const archivePromise = startArchiveResolution({
       moodleBranch,
       appBaseUrl: appRootUrl,
       publish,
     });
     archivePromise.catch(() => {});
+
+    // Eagerly start snapshot + localcache seed downloads as soon as the
+    // manifest is known. This overlaps them with both WASM compile and the
+    // big core tar.zst, reducing critical path on snapshot-origin boots.
+    const snapshotAssetsPromise = archivePromise
+      .then((arch) => {
+        const m = arch?.manifest;
+        const ps = [];
+        if (m?.snapshot?.url) {
+          ps.push(
+            import("./lib/moodle-loader.js").then(({ fetchAssetWithCache }) =>
+              fetchAssetWithCache(m.snapshot.url, m.snapshot).catch((e) => ({ error: e })),
+            ),
+          );
+        }
+        if (m?.snapshot?.localcache?.url) {
+          ps.push(
+            import("./lib/moodle-loader.js").then(({ fetchAssetWithCache }) =>
+              fetchAssetWithCache(
+                m.snapshot.localcache.url,
+                m.snapshot.localcache,
+              ).catch((e) => ({ error: e })),
+            ),
+          );
+        }
+        return Promise.all(ps);
+      })
+      .catch(() => {});
 
     const t1 = performance.now();
     await php.refresh();

--- a/scripts/build-moodle-bundle.sh
+++ b/scripts/build-moodle-bundle.sh
@@ -200,6 +200,13 @@ set -- "$@" \
   -x "*/AUTHORS*" -x "*/CONTRIBUTING*" \
   -x "*/upgrade.txt" -x "*/UPGRADING*"
 
+# Additional low-risk non-runtime files and metadata. These are never
+# included by Moodle's PHP loader or asset pipelines in normal operation.
+set -- "$@" \
+  -x "*/.editorconfig" -x "*/*.editorconfig" \
+  -x "*/psalm.xml*" -x "*/phpstan*" -x "*/.phpcs.xml*" -x "*/phpcs.xml*" \
+  -x "*/.github/workflows/*"
+
 (cd "$MOODLE_DIR" && zip -qr "$BUNDLE_PATH" . "$@")
 
 # Keep the manifest fileCount consistent with what the zip actually contains:
@@ -252,6 +259,13 @@ TAR_BUNDLE_PATH="$DIST_DIR/$TAR_BUNDLE_NAME"
 echo "Converting $BUNDLE_NAME -> $TAR_BUNDLE_NAME" >&2
 node "$SCRIPT_DIR/build-tar-zst-from-zip.mjs" "$BUNDLE_PATH" "$TAR_BUNDLE_PATH"
 rm -f "$BUNDLE_PATH"
+
+# Enforce tar.zst as the only shipped bundle format (ADR 0019).
+if [ ! -f "$TAR_BUNDLE_PATH" ]; then
+  echo "ERROR: expected tar.zst bundle was not produced: $TAR_BUNDLE_PATH" >&2
+  exit 1
+fi
+echo "Final bundle: $TAR_BUNDLE_PATH (tar.zst, $(stat -c%s "$TAR_BUNDLE_PATH" 2>/dev/null || wc -c < "$TAR_BUNDLE_PATH") bytes)" >&2
 
 SNAPSHOT_ARGS=""
 if [ -f "$SNAPSHOT_DIR/install.sq3" ]; then

--- a/src/runtime/bootstrap.js
+++ b/src/runtime/bootstrap.js
@@ -724,6 +724,16 @@ try {
         'gradepointmax' => '100',
         'downloadcoursecontentallowed' => '0',
         'enablesharingtomoodlenet' => '0',
+        // Additional playground-specific disables for lower memory/CPU and
+        // simpler UX (these are safe in ephemeral single-user environment).
+        'enableanalytics' => '0',
+        'enablestats' => '0',
+        'enableportfolios' => '0',
+        'messaging' => '0',
+        'allowemojipicker' => '0',
+        'showuseridentity' => '',
+        'enablebadges' => '0',
+        'enableglobalsearch' => '0',
     ];
 
     foreach ($defaults as $name => $value) {

--- a/src/runtime/config-template.js
+++ b/src/runtime/config-template.js
@@ -363,6 +363,7 @@ export function createPhpIniEntries({
     // See docs/architecture/adr/ADR-0011-bundle-trim-and-runtime-tuning.md (amends
     // ADR 0004).
     "opcache.enable": "1",
+    "opcache.jit": "0",
     "opcache.file_cache": "/internal/shared/opcache",
     "opcache.file_cache_only": "1",
     "opcache.max_accelerated_files": "20000",

--- a/src/runtime/config-template.js
+++ b/src/runtime/config-template.js
@@ -327,12 +327,12 @@ export function createPhpIniEntries({
     log_errors: "1",
     // max_execution_time stays at 0 (WP Playground default) — no timeout in WASM
     max_input_vars: "5000",
-    // memory_limit: 256M is a good balance for Moodle Playground.
+    // memory_limit: 256M + modest opcache is a good balance for Moodle Playground.
     // Official Moodle recommendation (docs.moodle.org) is at least 96-128M.
     // 256M gives headroom for normal operation while greatly reducing WASM
-    // heap usage vs the previous 512M. Heavy operations (course restore,
-    // large plugin installs) call raise_memory_limit(MEMORY_EXTRA) which
-    // temporarily increases it further.
+    // heap usage vs the previous 512M. opcache values reduced similarly.
+    // Heavy operations (course restore, large plugin installs) call
+    // raise_memory_limit(MEMORY_EXTRA) which temporarily increases it further.
     memory_limit: "256M",
     post_max_size: "64M",
     upload_max_filesize: "64M",
@@ -366,8 +366,8 @@ export function createPhpIniEntries({
     "opcache.file_cache": "/internal/shared/opcache",
     "opcache.file_cache_only": "1",
     "opcache.max_accelerated_files": "20000",
-    "opcache.memory_consumption": "128",
-    "opcache.interned_strings_buffer": "32",
+    "opcache.memory_consumption": "96",
+    "opcache.interned_strings_buffer": "16",
     "opcache.validate_timestamps": "0",
     "opcache.file_cache_consistency_checks": "0",
   };

--- a/src/runtime/php-loader.js
+++ b/src/runtime/php-loader.js
@@ -114,6 +114,14 @@ export function createPhpRuntime(
       const runtimeId = await loadWebRuntime(resolvedPhpVersion, {
         ...(tcpOverFetch ? { tcpOverFetch } : {}),
         withIntl: true,
+        // Lower initial WASM memory allocation + explicit growth.
+        // Reduces peak memory at boot and allows the heap to grow only as
+        // needed (inspired by WP Playground lower-initial-memory work).
+        // 128 MiB starting point is a compromise for Moodle's size.
+        emscriptenOptions: {
+          INITIAL_MEMORY: 128 * 1024 * 1024,
+          ALLOW_MEMORY_GROWTH: 1,
+        },
       });
       const php = new PHP(runtimeId);
       const FS = php[__private__dont__use].FS;
@@ -252,6 +260,14 @@ export function createProvisioningRuntime(_runtime, { phpVersion } = {}) {
       const runtimeId = await loadWebRuntime(resolvedPhpVersion, {
         ...(tcpOverFetch ? { tcpOverFetch } : {}),
         withIntl: true,
+        // Lower initial WASM memory allocation + explicit growth.
+        // Reduces peak memory at boot and allows the heap to grow only as
+        // needed (inspired by WP Playground lower-initial-memory work).
+        // 128 MiB starting point is a compromise for Moodle's size.
+        emscriptenOptions: {
+          INITIAL_MEMORY: 128 * 1024 * 1024,
+          ALLOW_MEMORY_GROWTH: 1,
+        },
       });
       const php = new PHP(runtimeId);
       const FS2 = php[__private__dont__use].FS;

--- a/sw.js
+++ b/sw.js
@@ -21,12 +21,10 @@ const SCOPED_STATIC_RE = /\.(css|js|mjs|woff2?|ttf|otf|eot|png|jpe?g|gif|svg|ico
 // PHP scripts that serve cacheable assets with revision numbers in the URL.
 // The revision acts as a natural cache key — when content changes, the URL changes.
 // Excludes pluginfile.php and draftfile.php (user content, not cacheable).
-// lib/requirejs.php is included for symmetry with lib/javascript.php: its
-// module URLs (/lib/requirejs.php/<rev>/core/first.js) already match
-// SCOPED_STATIC_RE via their .js suffix, so this is belt-and-braces (the
-// scope+runtime cache key and BUILD_VERSION-scoped cache name prevent stale
-// cross-build content), not a functional change.
-const CACHEABLE_PHP_ASSET_RE = /\/(theme\/styles\.php|lib\/javascript\.php|lib\/requirejs\.php|theme\/image\.php|theme\/font\.php)\//u;
+// Additional patterns (theme/fonts.php, lib/yui.php etc.) added to increase
+// the number of Moodle-generated assets that bypass the serial PHP worker
+// and use the fast SW-scoped static cache (perf improvement #6).
+const CACHEABLE_PHP_ASSET_RE = /\/(theme\/styles\.php|lib\/javascript\.php|lib\/requirejs\.php|theme\/image\.php|theme\/font\.php|theme\/fonts\.php|lib\/yui\.php)\//u;
 const INTERNAL_PROXY_PATH = "/__playground_proxy__";
 let playgroundConfigPromise;
 let addonProxyUrlOverride = null;


### PR DESCRIPTION
## Summary

This PR combines **all** the performance optimization work into one branch (excluding the crash recovery change in #264).

**Supersedes the following PRs:**
- #255 (perf/1-memory-ini)
- #256 (perf/2-emscripten-memory)
- #257 (perf/3-bundle-trim-zstd)
- #258 (perf/4-download-overlap-cache)
- #259 (perf/5-leak-rotation)
- #260 (perf/6-sw-fastpath-cache)
- #262 (perf/8-more-config-disables)
- #263 (perf/9-opcache-jit-tuning)

(The 256M `memory_limit` change was already merged to main earlier.)

## Included changes

- Lower `INITIAL_MEMORY` + `ALLOW_MEMORY_GROWTH` (WASM)
- Additional safe bundle trimming + stronger `tar.zst` enforcement
- Early prefetch of snapshot + localcache seed (better overlap with WASM compile)
- High-watermark diagnostic for long-lived runtimes
- Expand SW fast-path for more generated Moodle assets
- More aggressive low-overhead config defaults in the normalizer (disable analytics, messaging, badges, etc.)
- Explicit `opcache.jit = 0` + aligned lower opcache values

## Excluded
- #264 (lighter crash snapshots) — benefit was less clear.

## Related ADRs
- ADR-0024 (memory + Emscripten config)
- ADR-0025 (boot delivery + runtime lifecycle)
- ADR-0026 (playground config minimization)

## Verification
- Biome clean
- Relevant tests pass
- `npm run build-worker` succeeds

This gives one clean, reviewable set of improvements instead of 8 separate PRs.