### PR TITLE
Prevent fork pull requests from running playground workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   # ── Fast feedback: syntax + unit tests + lint (no PHP, no bundle) ──
   lint-and-test:
-    if: github.event.action != 'closed'
+    if: github.event.action != 'closed' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -70,7 +70,7 @@ jobs:
 
   # ── Build: all 6 Moodle branches + docs ──
   build:
-    if: github.event.action != 'closed'
+    if: github.event.action != 'closed' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -203,6 +203,7 @@ jobs:
 
   # ── E2E: Chromium + Firefox ──
   e2e:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     needs: build
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/cloudflare-pages-cleanup.yml
+++ b/.github/workflows/cloudflare-pages-cleanup.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   cleanup:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     env:
       HAS_CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}


### PR DESCRIPTION
## Summary

- skip lint and unit tests for pull requests originating from forks
- skip the full six-branch Moodle build and documentation assembly for fork pull requests
- skip the Chromium and Firefox E2E matrix for fork pull requests
- skip Cloudflare cleanup for fork pull requests
- preserve pushes, manual rebuilds, production deployments, and same-repository pull request previews

## Security rationale

These workflows install Node.js, Python, PHP, Composer, browser, and documentation dependencies; build all supported Moodle branches; upload artifacts; and include Pages, OIDC, pull-request write, and optional Cloudflare credentials. Restricting fork-originated jobs prevents untrusted code from consuming substantial runner and network resources or reaching write-capable deployment and cleanup paths.