### PR TITLE
Redesign shell toolbar and side panel (Shell UI v2)

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,7 @@
       <header class="browser-toolbar" aria-label="Playground toolbar">
         <div class="toolbar-brand" aria-label="Moodle Playground">
           <img src="logo.png" alt="Moodle Playground" class="toolbar-brand__logo">
+          <img src="favicon-32x32.png" alt="Moodle Playground" class="toolbar-brand__icon">
         </div>
         <div class="browser-toolbar__center">
           <form id="address-form" class="address-form">
@@ -115,7 +116,7 @@
           </a>
           <a
             href="https://github.com/ateeducacion/moodle-playground"
-            class="icon-button"
+            class="icon-button toolbar-github"
             aria-label="GitHub repository"
             title="GitHub repository"
             target="_blank"

--- a/index.html
+++ b/index.html
@@ -79,19 +79,24 @@
   <body data-app="shell">
     <div class="shell">
       <header class="browser-toolbar" aria-label="Playground toolbar">
-        <div class="browser-toolbar__address">
+        <div class="toolbar-brand" aria-label="Moodle Playground">
+          <img src="logo.png" alt="Moodle Playground" class="toolbar-brand__logo">
+        </div>
+        <div class="browser-toolbar__center">
           <form id="address-form" class="address-form">
-            <div class="toolbar-brand" aria-label="Moodle Playground">
-              <img src="logo.png" alt="Moodle Playground" class="toolbar-brand__logo">
-            </div>
             <div class="nav-buttons">
-              <button type="button" id="home-button" class="icon-button" aria-label="Go to homepage" title="Go to homepage">
-                <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
-                  <path d="M2.5 6.5V14h4v-4h3v4h4V6.5L8 2 2.5 6.5Z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round" fill="none"/>
+              <button type="button" id="back-button" class="icon-button" aria-label="Go back" title="Back" disabled>
+                <svg width="15" height="15" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+                  <path d="M10 3 5 8l5 5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>
               </button>
               <button type="button" id="refresh-button" class="icon-button" aria-label="Refresh page" title="Refresh page">
                 <span aria-hidden="true">↻</span>
+              </button>
+              <button type="button" id="home-button" class="icon-button" aria-label="Go to homepage" title="Go to homepage">
+                <svg width="15" height="15" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+                  <path d="M2.5 6.5V14h4v-4h3v4h4V6.5L8 2 2.5 6.5Z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round" fill="none"/>
+                </svg>
               </button>
             </div>
             <div class="address-form__input">
@@ -102,17 +107,29 @@
         </div>
         <div class="browser-toolbar__actions">
           <a href="docs/" class="icon-button icon-button--labeled" aria-label="Documentation" title="Documentation" target="_blank" rel="noreferrer">
-            <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true" focusable="false">
+            <svg width="16" height="16" viewBox="0 0 18 18" fill="none" aria-hidden="true" focusable="false">
               <path d="M3 2.5A1.5 1.5 0 0 1 4.5 1h6.586a1 1 0 0 1 .707.293l3.414 3.414a1 1 0 0 1 .293.707V15.5A1.5 1.5 0 0 1 14 17H4.5A1.5 1.5 0 0 1 3 15.5v-13Z" stroke="currentColor" stroke-width="1.4" fill="none"/>
               <path d="M6 9h6M6 12h4" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
-              <path d="M11 1v3.5a1 1 0 0 0 1 1h3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" fill="none"/>
             </svg>
-            <span class="icon-button__label">Documentation</span>
+            <span class="icon-button__label">Docs</span>
           </a>
+          <a
+            href="https://github.com/ateeducacion/moodle-playground"
+            class="icon-button"
+            aria-label="GitHub repository"
+            title="GitHub repository"
+            target="_blank"
+            rel="noreferrer"
+          >
+            <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+              <path fill="currentColor" d="M8 0C3.58 0 0 3.67 0 8.2c0 3.63 2.29 6.71 5.47 7.8.4.08.55-.18.55-.4 0-.2-.01-.87-.01-1.58-2.01.38-2.53-.5-2.69-.96-.09-.24-.48-.97-.82-1.17-.28-.15-.68-.53-.01-.54.63-.01 1.08.59 1.23.84.72 1.24 1.87.89 2.33.68.07-.54.28-.89.51-1.09-1.78-.21-3.64-.92-3.64-4.08 0-.9.31-1.64.82-2.22-.08-.21-.36-1.06.08-2.2 0 0 .67-.22 2.2.85a7.38 7.38 0 0 1 4 0c1.53-1.07 2.2-.85 2.2-.85.44 1.14.16 1.99.08 2.2.51.58.82 1.31.82 2.22 0 3.17-1.87 3.87-3.65 4.08.29.26.54.75.54 1.52 0 1.1-.01 1.99-.01 2.26 0 .22.15.49.55.4A8.18 8.18 0 0 0 16 8.2C16 3.67 12.42 0 8 0Z"/>
+            </svg>
+          </a>
+          <span class="toolbar-separator" aria-hidden="true"></span>
           <button type="button" id="panel-toggle-button" class="icon-button" aria-label="Toggle sidebar panel" aria-expanded="false" title="Toggle sidebar">
-            <svg width="18" height="16" viewBox="0 0 18 16" fill="none" aria-hidden="true" focusable="false">
-              <rect x="0.5" y="0.5" width="10" height="15" rx="2" stroke="currentColor" stroke-width="1.5" fill="none"/>
-              <rect x="13" y="0.5" width="4.5" height="15" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/>
+            <svg width="17" height="15" viewBox="0 0 18 16" fill="none" aria-hidden="true" focusable="false">
+              <rect x="0.75" y="0.75" width="16.5" height="14.5" rx="2.25" stroke="currentColor" stroke-width="1.5" fill="none"/>
+              <path d="M11.5 1v14" stroke="currentColor" stroke-width="1.5"/>
             </svg>
           </button>
         </div>
@@ -125,16 +142,17 @@
 
         <aside id="side-panel" class="side-panel is-collapsed" aria-label="Playground panel">
           <div class="side-panel__header">
-            <div>
-              <strong>Moodle Playground</strong>
-              <span>Browser runtime controls</span>
+            <div class="side-panel__title">
+              <strong>Runtime</strong>
+              <span id="config-status" class="status-pill"><span class="dot"></span>Running</span>
             </div>
+            <button type="button" id="panel-close-button" class="side-panel__close" aria-label="Close panel" title="Close panel">✕</button>
           </div>
 
           <div class="panel-tabs" role="tablist" aria-label="Playground panel tabs">
             <button type="button" id="info-tab" class="panel-tab is-active" role="tab" aria-selected="true" data-panel-tab="info">Info</button>
             <button type="button" id="logs-tab" class="panel-tab" role="tab" aria-selected="false" data-panel-tab="logs">Logs</button>
-            <button type="button" id="phpinfo-tab" class="panel-tab" role="tab" aria-selected="false" data-panel-tab="phpinfo">PHP Info</button>
+            <button type="button" id="phpinfo-tab" class="panel-tab" role="tab" aria-selected="false" data-panel-tab="phpinfo">PHP</button>
             <button type="button" id="blueprint-tab" class="panel-tab" role="tab" aria-selected="false" data-panel-tab="blueprint">Blueprint</button>
           </div>
 
@@ -143,15 +161,16 @@
               <div class="info-section">
                 <div class="section-label">
                   <span>Configuration</span>
-                  <span id="config-status" class="status-pill"><span class="dot"></span>Running</span>
                 </div>
-                <div class="field">
-                  <label for="info-moodle-version">Moodle version</label>
-                  <select id="info-moodle-version"></select>
-                </div>
-                <div class="field">
-                  <label for="info-php-version">PHP version</label>
-                  <select id="info-php-version"></select>
+                <div class="config-grid">
+                  <div class="field">
+                    <label for="info-moodle-version">Moodle</label>
+                    <select id="info-moodle-version"></select>
+                  </div>
+                  <div class="field">
+                    <label for="info-php-version">PHP</label>
+                    <select id="info-php-version"></select>
+                  </div>
                 </div>
                 <div id="config-warning" class="warn-banner is-hidden" role="alert">
                   <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
@@ -165,8 +184,6 @@
                   <button type="button" id="config-apply" class="danger grow is-hidden">Apply &amp; Reset</button>
                 </div>
               </div>
-
-              <hr class="divider">
 
               <div class="info-section">
                 <div class="section-label"><span>Runtime</span></div>
@@ -184,6 +201,9 @@
                   <span class="vr-key">Moodle release</span>
                   <span id="moodle-release-value" title="">-</span>
                 </div>
+              </div>
+
+              <div class="info-section info-section--bottom">
                 <div class="action-row">
                   <button type="button" id="reset-button" class="danger grow">Reset Playground</button>
                 </div>
@@ -196,8 +216,19 @@
             <div class="panel__row">
               <span>Runtime log</span>
               <span class="panel__row-actions">
-                <button type="button" id="copy-logs-button">Copy</button>
-                <button type="button" id="clear-logs-button">Clear</button>
+                <button type="button" id="copy-logs-button" class="icon-button icon-button--icon-only" title="Copy logs" aria-label="Copy logs">
+                  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+                    <rect x="5" y="5" width="8" height="9" rx="1.5" stroke="currentColor" stroke-width="1.3"/>
+                    <path d="M11 5V3.5A1.5 1.5 0 0 0 9.5 2h-5A1.5 1.5 0 0 0 3 3.5v7A1.5 1.5 0 0 0 4.5 12H5" stroke="currentColor" stroke-width="1.3" fill="none"/>
+                  </svg>
+                </button>
+                <button type="button" id="clear-logs-button" class="icon-button icon-button--icon-only" title="Clear logs" aria-label="Clear logs">
+                  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+                    <path d="M2.5 4h11" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
+                    <path d="M5.5 4V2.75A.75.75 0 0 1 6.25 2h3.5a.75.75 0 0 1 .75.75V4" stroke="currentColor" stroke-width="1.3"/>
+                    <path d="M4.5 4l.55 9.3a.7.7 0 0 0 .7.66h4.5a.7.7 0 0 0 .7-.66L11.5 4" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/>
+                  </svg>
+                </button>
               </span>
             </div>
             <pre id="log-panel" class="log-panel"></pre>
@@ -206,21 +237,27 @@
           <section id="phpinfo-panel" class="side-panel__content side-panel__content--stack is-hidden" role="tabpanel" aria-labelledby="phpinfo-tab" data-panel-view="phpinfo">
             <div class="panel__row">
               <span>Runtime PHP Info</span>
-              <button type="button" id="refresh-phpinfo-button">Refresh</button>
+              <span class="panel__row-actions">
+                <button type="button" id="refresh-phpinfo-button" class="icon-button icon-button--icon-only" title="Refresh PHP info" aria-label="Refresh PHP info">
+                  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+                    <path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+                    <path d="M13.5 1.5v3h-3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                </button>
+              </span>
             </div>
             <iframe id="phpinfo-frame" class="panel-frame" title="PHP Info diagnostics"></iframe>
           </section>
 
           <section id="blueprint-panel" class="side-panel__content side-panel__content--stack is-hidden" role="tabpanel" aria-labelledby="blueprint-tab" data-panel-view="blueprint">
             <div class="panel__row">
-              <span>Blueprint JSON</span>
+              <button type="button" id="run-button" class="icon-button icon-button--primary icon-button--wide" title="Run blueprint" disabled>
+                <svg width="11" height="11" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" focusable="false">
+                  <path d="M4 2.5v11l10-5.5-10-5.5Z"/>
+                </svg>
+                <span>Run</span>
+              </button>
               <span class="panel__row-actions">
-                <button type="button" id="run-button" class="icon-button icon-button--primary icon-button--wide" title="Run blueprint" disabled>
-                  <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" focusable="false">
-                    <path d="M4 2.5v11l10-5.5-10-5.5Z"/>
-                  </svg>
-                  <span>Run</span>
-                </button>
                 <button type="button" id="export-button" class="icon-button icon-button--icon-only" title="Export blueprint JSON" aria-label="Export blueprint JSON">
                   <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
                     <path d="M8 2v7m0 0L5 6m3 3 3-3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
@@ -265,12 +302,14 @@
           </section>
 
           <footer class="side-panel__footer">
-            <p>Made with &#10084;&#65039; by <a href="https://www3.gobiernodecanarias.org/medusa/ecoescuela/ate/" target="_blank" rel="noreferrer">Área de Tecnología Educativa</a></p>
-            <p class="side-panel__footer-disclaimer">
-              Moodle&#8482; is a registered trademark of
-              <a href="https://moodle.com/trademarks/" target="_blank" rel="noreferrer">Moodle Pty Ltd</a>.
-              This project is not affiliated with Moodle Pty Ltd.
-            </p>
+            <div class="side-panel__footer-text">
+              <p>Made with &#10084;&#65039; by <a href="https://www3.gobiernodecanarias.org/medusa/ecoescuela/ate/" target="_blank" rel="noreferrer">Área de Tecnología Educativa</a></p>
+              <p class="side-panel__footer-disclaimer">
+                Moodle&#8482; is a registered trademark of
+                <a href="https://moodle.com/trademarks/" target="_blank" rel="noreferrer">Moodle Pty Ltd</a>.
+                This project is not affiliated with Moodle Pty Ltd.
+              </p>
+            </div>
             <a
               class="side-panel__footer-link"
               href="https://github.com/ateeducacion/moodle-playground"
@@ -285,7 +324,6 @@
                   d="M8 0C3.58 0 0 3.67 0 8.2c0 3.63 2.29 6.71 5.47 7.8.4.08.55-.18.55-.4 0-.2-.01-.87-.01-1.58-2.01.38-2.53-.5-2.69-.96-.09-.24-.48-.97-.82-1.17-.28-.15-.68-.53-.01-.54.63-.01 1.08.59 1.23.84.72 1.24 1.87.89 2.33.68.07-.54.28-.89.51-1.09-1.78-.21-3.64-.92-3.64-4.08 0-.9.31-1.64.82-2.22-.08-.21-.36-1.06.08-2.2 0 0 .67-.22 2.2.85a7.38 7.38 0 0 1 4 0c1.53-1.07 2.2-.85 2.2-.85.44 1.14.16 1.99.08 2.2.51.58.82 1.31.82 2.22 0 3.17-1.87 3.87-3.65 4.08.29.26.54.75.54 1.52 0 1.1-.01 1.99-.01 2.26 0 .22.15.49.55.4A8.18 8.18 0 0 0 16 8.2C16 3.67 12.42 0 8 0Z"
                 />
               </svg>
-              <span>GitHub</span>
             </a>
           </footer>
         </aside>

--- a/src/shell/blueprint-editor-core.js
+++ b/src/shell/blueprint-editor-core.js
@@ -174,10 +174,13 @@ export function createBlueprintValidationResult(rawText, deps) {
     };
   }
 
+  const stepCount = Array.isArray(blueprint?.steps)
+    ? blueprint.steps.length
+    : 0;
   return {
     valid: true,
     stage: "valid",
-    message: "Blueprint is valid.",
+    message: `✓ Valid blueprint · ${stepCount} ${stepCount === 1 ? "step" : "steps"}`,
     errors: [],
     blueprint,
   };

--- a/src/shell/main.js
+++ b/src/shell/main.js
@@ -447,16 +447,27 @@ function bindShellChannel() {
         els.address.value = currentPath;
         saveState({ lastReadyAt: new Date().toISOString() });
         break;
-      case "frame-ready":
+      case "frame-ready": {
+        // In-site navigations announce "frame-ready" before "navigate", so
+        // the back-stack transition must be recorded here — by the time the
+        // "navigate" message arrives, currentPath has already moved on. The
+        // very first frame load (and the first one after a restore) is the
+        // landing redirect, not a user navigation, so it is not recorded.
+        const wasBooted = remoteFrameBooted;
         remoteFrameBooted = true;
         if (!uiLocked) {
-          currentPath = isInternalRuntimePath(message.path)
+          const nextPath = isInternalRuntimePath(message.path)
             ? currentPath
             : message.path || currentPath;
+          if (wasBooted) {
+            recordBackEntry(currentPath, nextPath);
+          }
+          currentPath = nextPath;
           els.address.value = currentPath;
           saveState();
         }
         break;
+      }
       case "navigate": {
         const nextPath = isInternalRuntimePath(message.path)
           ? currentPath

--- a/src/shell/main.js
+++ b/src/shell/main.js
@@ -54,6 +54,8 @@ const els = {
   phpInfoTab: document.querySelector("#phpinfo-tab"),
   refreshPhpInfoButton: document.querySelector("#refresh-phpinfo-button"),
   home: document.querySelector("#home-button"),
+  back: document.querySelector("#back-button"),
+  panelClose: document.querySelector("#panel-close-button"),
   refresh: document.querySelector("#refresh-button"),
   reset: document.querySelector("#reset-button"),
   infoMoodleVersion: document.querySelector("#info-moodle-version"),
@@ -87,6 +89,11 @@ let currentPhpCorsProxyUrl = null;
 let currentDebugParam = null;
 let currentProfileParam = null;
 let currentPath = "/";
+// In-shell navigation history for the toolbar Back button. The iframe's own
+// session history is not usable here (navigations happen across nested frames
+// and service-worker scopes), so the shell tracks visited paths itself.
+const backStack = [];
+let suppressBackPush = false;
 let channel;
 let serviceWorkerReady = null;
 let activeBlueprint;
@@ -148,6 +155,24 @@ function setUiLocked(locked) {
   els.importInput.disabled = locked;
   els.addressForm.classList.toggle("is-disabled", locked);
   blueprintEditor.setLocked(locked);
+  updateBackButton();
+}
+
+function updateBackButton() {
+  if (els.back) {
+    els.back.disabled = uiLocked || backStack.length === 0;
+  }
+}
+
+function recordBackEntry(previousPath, nextPath) {
+  const suppressed = suppressBackPush;
+  suppressBackPush = false;
+  if (!suppressed && previousPath && previousPath !== nextPath) {
+    if (backStack[backStack.length - 1] !== previousPath) {
+      backStack.push(previousPath);
+    }
+  }
+  updateBackButton();
 }
 
 async function ensureRuntimeServiceWorker() {
@@ -215,7 +240,9 @@ function navigateWithinRuntime(path) {
     return;
   }
 
+  const previousPath = currentPath;
   currentPath = path || "/";
+  recordBackEntry(previousPath, currentPath);
   els.address.value = currentPath;
   saveState();
 
@@ -430,13 +457,16 @@ function bindShellChannel() {
           saveState();
         }
         break;
-      case "navigate":
-        currentPath = isInternalRuntimePath(message.path)
+      case "navigate": {
+        const nextPath = isInternalRuntimePath(message.path)
           ? currentPath
           : message.path || "/";
+        recordBackEntry(currentPath, nextPath);
+        currentPath = nextPath;
         els.address.value = currentPath;
         saveState();
         break;
+      }
       case "error":
         remoteFrameBooted = false;
         setUiLocked(false);
@@ -689,11 +719,26 @@ els.home.addEventListener("click", () => {
   navigateWithinRuntime("/");
 });
 
+els.back.addEventListener("click", () => {
+  if (uiLocked || backStack.length === 0) {
+    return;
+  }
+  const previousPath = backStack.pop();
+  updateBackButton();
+  suppressBackPush = true;
+  navigateWithinRuntime(previousPath);
+});
+
 els.refresh.addEventListener("click", () => {
   navigateWithinRuntime(currentPath);
 });
 
 els.panelToggle.addEventListener("click", toggleSidePanel);
+els.panelClose.addEventListener("click", () => {
+  if (!els.sidePanel.classList.contains("is-collapsed")) {
+    toggleSidePanel();
+  }
+});
 els.infoTab.addEventListener("click", () => setActivePanel("info"));
 els.logsTab.addEventListener("click", () => setActivePanel("logs"));
 els.phpInfoTab.addEventListener("click", () => {
@@ -707,10 +752,11 @@ els.clearLogs.addEventListener("click", () => {
 els.copyLogs.addEventListener("click", () => {
   const text = els.logPanel.textContent || "";
   navigator.clipboard.writeText(text).then(() => {
-    const original = els.copyLogs.textContent;
-    els.copyLogs.textContent = "Copied!";
+    // Icon-only button: swap the SVG for a checkmark, then restore it.
+    const original = els.copyLogs.innerHTML;
+    els.copyLogs.textContent = "✓";
     setTimeout(() => {
-      els.copyLogs.textContent = original;
+      els.copyLogs.innerHTML = original;
     }, 1200);
   });
 });
@@ -761,6 +807,8 @@ els.reset.addEventListener("click", async () => {
     updateBlueprintTextarea();
   }
   currentPath = activeBlueprint?.landingPage || config.landingPath || "/";
+  backStack.length = 0;
+  updateBackButton();
   els.address.value = currentPath;
   pendingCleanBoot = true;
   remoteFrameBooted = false;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -825,7 +825,8 @@ button.danger:hover {
     gap: var(--space-sm);
   }
 
-  /* Minimal mobile toolbar: app icon, Home, and the panel toggle. */
+  /* Minimal mobile toolbar: app icon, Home, a narrow URL bar, and the
+     panel toggle. */
   .toolbar-brand__logo {
     display: none;
   }
@@ -834,7 +835,6 @@ button.danger:hover {
     display: block;
   }
 
-  .address-form__input,
   .toolbar-separator,
   .browser-toolbar .icon-button--labeled,
   .browser-toolbar .toolbar-github,

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -21,17 +21,19 @@
   --color-orange-light: rgba(249, 128, 18, 0.08);
   --color-orange-border: rgba(249, 128, 18, 0.25);
 
-  /* Chrome (navbar + sidebar) on-orange palette */
-  --chrome-bg: var(--color-orange-soft);
+  /* Chrome (navbar) on-orange palette */
+  --chrome-bg: #f78d2d;
+  --chrome-bg2: var(--color-orange);
   --chrome-text: #ffffff;
-  --chrome-text-muted: rgba(255, 255, 255, 0.8);
-  --chrome-border: rgba(255, 255, 255, 0.2);
-  --chrome-hover: rgba(255, 255, 255, 0.15);
-  --chrome-active: rgba(255, 255, 255, 0.25);
+  --chrome-text-muted: rgba(255, 255, 255, 0.82);
+  --chrome-border: rgba(255, 255, 255, 0.22);
+  --chrome-hover: rgba(255, 255, 255, 0.16);
+  --chrome-input: rgba(255, 255, 255, 0.18);
+  --chrome-cluster: rgba(0, 0, 0, 0.08);
   --color-danger: #dc3545;
   --color-danger-hover: #c82333;
   --color-danger-light: rgba(220, 53, 69, 0.08);
-  --color-danger-border: rgba(220, 53, 69, 0.25);
+  --color-danger-border: rgba(220, 53, 69, 0.35);
   --color-success: #2f9e44;
 
   /* Semantic */
@@ -66,7 +68,7 @@
   --shadow-popover: 0 10px 32px rgba(0, 0, 0, 0.14);
 
   /* Layout */
-  --navbar-height: 56px;
+  --navbar-height: 54px;
   --sidebar-width: 340px;
 }
 
@@ -132,13 +134,16 @@ a:focus-visible {
 }
 
 button.danger {
-  color: var(--color-white);
-  background: var(--color-danger);
-  border-color: transparent;
+  color: var(--color-danger);
+  background: var(--bg-surface);
+  border-color: var(--color-danger-border);
+  font-weight: 600;
 }
 
 button.danger:hover {
-  background: var(--color-danger-hover);
+  color: var(--color-white);
+  background: var(--color-danger);
+  border-color: var(--color-danger);
 }
 
 /* ── Shell layout ─────────────────────────────────── */
@@ -158,20 +163,21 @@ button.danger:hover {
   right: 0;
   z-index: 20;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: var(--space-md);
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: var(--space-lg);
   align-items: center;
-  padding: 0 var(--space-lg);
+  padding: 0 14px;
   height: var(--navbar-height);
-  background: var(--chrome-bg);
+  background: linear-gradient(
+    180deg,
+    var(--chrome-bg) 0%,
+    var(--chrome-bg2) 100%
+  );
   border-bottom: 1px solid var(--chrome-border);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.12);
 }
 
-.browser-toolbar__address,
 .address-form,
-.browser-toolbar__actions,
-.panel-tabs,
 .panel__row,
 .settings-actions {
   display: flex;
@@ -179,8 +185,22 @@ button.danger:hover {
   gap: var(--space-sm);
 }
 
+.browser-toolbar__center {
+  display: flex;
+  justify-content: center;
+  min-width: 0;
+}
+
+.browser-toolbar__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
 .address-form {
-  width: 100%;
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 760px;
 }
 
 .address-form.is-disabled {
@@ -192,37 +212,55 @@ button.danger:hover {
   align-items: center;
   justify-content: center;
   flex: 0 0 auto;
+  min-width: 0;
 }
 
 .toolbar-brand__logo {
   display: block;
-  height: 24px;
+  height: 26px;
   width: auto;
 }
 
 .address-form__input {
-  flex: 1;
+  display: flex;
+  align-items: center;
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 34px;
+  padding: 0 12px;
+  border: 1px solid var(--chrome-border);
+  border-radius: 10px;
+  background: var(--chrome-input);
+  transition: background 0.15s;
+}
+
+.address-form__input:focus-within {
+  background: rgba(255, 255, 255, 0.3);
 }
 
 .address-form__input input {
-  width: 100%;
-  padding: 7px 12px;
-  border: 1px solid var(--chrome-border);
-  border-radius: var(--radius-md);
-  background: rgba(255, 255, 255, 0.2);
+  flex: 1;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
   color: var(--chrome-text);
-  font-size: 13px;
+  font:
+    13px ui-monospace,
+    "SFMono-Regular",
+    monospace;
+  outline: none;
 }
 
 .address-form__input input::placeholder {
   color: var(--chrome-text-muted);
 }
 
-.address-form__input input:focus {
-  background: rgba(255, 255, 255, 0.3);
-  border-color: rgba(255, 255, 255, 0.5);
-  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.15);
-  outline: none;
+.toolbar-separator {
+  width: 1px;
+  height: 20px;
+  background: var(--chrome-border);
+  margin: 0 6px;
 }
 
 .address-form__input input:disabled,
@@ -233,17 +271,21 @@ button.danger:hover {
   opacity: 0.45;
 }
 
-/* Toolbar icon buttons (on orange background) */
+/* Toolbar icon buttons (on chrome background) */
 .nav-buttons {
   display: inline-flex;
   align-items: center;
   gap: 2px;
+  flex: 0 0 auto;
+  padding: 2px;
+  background: var(--chrome-cluster);
+  border-radius: 10px;
 }
 
 .browser-toolbar .icon-button {
-  width: 36px;
-  min-width: 36px;
-  height: 36px;
+  width: 32px;
+  min-width: 32px;
+  height: 32px;
   padding: 0;
   display: inline-flex;
   align-items: center;
@@ -252,13 +294,13 @@ button.danger:hover {
   border-color: transparent;
   border-radius: var(--radius-md);
   color: var(--chrome-text-muted);
-  font-size: 16px;
+  font-size: 15px;
 }
 
 .browser-toolbar .icon-button--labeled {
   width: auto;
   padding: 0 12px;
-  gap: var(--space-xs);
+  gap: 6px;
   text-decoration: none;
 }
 
@@ -273,6 +315,18 @@ button.danger:hover {
   background: var(--chrome-hover);
   color: var(--chrome-text);
   border-color: transparent;
+}
+
+.browser-toolbar .icon-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  background: transparent;
+  color: var(--chrome-text-muted);
+}
+
+.browser-toolbar .icon-button[aria-expanded="true"] {
+  background: var(--chrome-hover);
+  color: var(--chrome-text);
 }
 
 /* Generic icon button (for non-toolbar contexts) */
@@ -349,8 +403,9 @@ button.danger:hover {
 .side-panel {
   display: grid;
   grid-template-rows: auto auto minmax(0, 1fr) auto;
-  border-left: 1px solid var(--chrome-border);
+  border-left: 1px solid var(--border);
   background: var(--bg-surface);
+  box-shadow: -4px 0 16px rgba(0, 0, 0, 0.04);
   min-height: 0;
   overflow: hidden;
 }
@@ -359,26 +414,45 @@ button.danger:hover {
   display: none;
 }
 
-.side-panel__header,
-.side-panel__content,
-.side-panel__footer {
-  padding: var(--space-lg);
-}
-
-.panel-tabs {
-  padding: var(--space-sm) var(--space-lg);
-}
-
 .side-panel__header {
-  background: var(--chrome-bg);
-  border-bottom: 1px solid var(--chrome-border);
-  padding: var(--space-md) var(--space-lg);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  padding: 12px var(--space-lg) 10px;
 }
 
-.side-panel__header strong {
-  display: block;
-  color: var(--chrome-text);
+.side-panel__title {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  min-width: 0;
+}
+
+.side-panel__title strong {
+  font-size: 13.5px;
+  color: var(--text-heading);
+}
+
+.side-panel__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
   font-size: 14px;
+  cursor: pointer;
+}
+
+.side-panel__close:hover {
+  background: var(--color-gray-100);
+  color: var(--text);
+  border-color: transparent;
 }
 
 .remote-boot__card strong {
@@ -387,44 +461,49 @@ button.danger:hover {
   font-size: 14px;
 }
 
-.side-panel__header span {
-  color: var(--chrome-text-muted);
-  font-size: 12px;
-}
-
-/* ── Panel tabs ───────────────────────────────────── */
+/* ── Panel tabs (segmented control) ───────────────── */
 .panel-tabs {
-  gap: 4px;
-  background: var(--chrome-bg);
-  border-bottom: 1px solid var(--chrome-border);
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin: 0 var(--space-lg) var(--space-md);
+  padding: 3px;
+  background: var(--color-gray-100);
+  border-radius: 9px;
 }
 
 .panel-tab {
+  flex: 1;
+  padding: 5px 0;
+  border: 0;
+  border-radius: 7px;
   background: transparent;
-  border-color: transparent;
-  color: var(--chrome-text-muted);
-  font-size: 13px;
-  padding: 6px 12px;
-  border-radius: var(--radius-md);
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 500;
+  transition:
+    background 0.15s,
+    color 0.15s;
 }
 
 .panel-tab:hover {
-  color: var(--chrome-text);
-  background: var(--chrome-hover);
+  color: var(--text);
+  background: transparent;
   border-color: transparent;
 }
 
 .panel-tab.is-active {
-  background: var(--chrome-active);
-  border-color: var(--chrome-border);
-  color: var(--chrome-text);
+  background: var(--color-white);
+  color: var(--text-heading);
   font-weight: 600;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
 }
 
 /* ── Panel content ────────────────────────────────── */
 .side-panel__content {
   overflow: auto;
   min-height: 0;
+  padding: var(--space-xs) var(--space-lg) var(--space-lg);
 }
 
 .side-panel__content.is-hidden {
@@ -440,13 +519,22 @@ button.danger:hover {
 
 /* ── Panel footer ─────────────────────────────────── */
 .side-panel__footer {
-  display: grid;
-  gap: var(--space-sm);
-  border-top: 1px solid var(--chrome-border);
-  background: var(--chrome-bg);
-  color: var(--chrome-text-muted);
-  font-size: 12px;
-  padding: var(--space-md) var(--space-lg);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  border-top: 1px solid var(--border-light);
+  background: var(--bg-surface-muted);
+  color: var(--text-muted);
+  font-size: 11px;
+  padding: 10px var(--space-lg);
+}
+
+.side-panel__footer-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
 }
 
 .side-panel__footer p {
@@ -459,26 +547,30 @@ button.danger:hover {
   opacity: 0.85;
 }
 
-.side-panel__footer a {
-  color: var(--chrome-text);
+.side-panel__footer-text a {
+  color: var(--accent-hover);
+  font-weight: 600;
   text-decoration: none;
 }
 
-.side-panel__footer a:hover {
-  color: var(--color-white);
+.side-panel__footer-text a:hover {
+  color: var(--accent);
 }
 
 .side-panel__footer-link {
   display: inline-flex;
   align-items: center;
-  gap: var(--space-sm);
-  width: fit-content;
-  font-weight: 600;
+  flex: 0 0 auto;
+  color: var(--text-muted);
+}
+
+.side-panel__footer-link:hover {
+  color: var(--text);
 }
 
 .side-panel__footer-link svg {
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
 }
 
 /* ── Settings fields (sidebar) ────────────────────── */
@@ -533,13 +625,18 @@ button.danger:hover {
   flex-wrap: wrap;
   row-gap: var(--space-xs);
   margin-bottom: var(--space-sm);
+  color: var(--text-muted);
+}
+
+/* Uppercase mono section label (the row's leading span only, so buttons
+   in the same row keep the regular UI font). */
+.panel__row > span:first-child:not(.panel__row-actions) {
   font:
     600 11px / 1.2 ui-monospace,
     "SFMono-Regular",
     monospace;
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: var(--text-muted);
 }
 
 .panel__row-actions {
@@ -710,12 +807,15 @@ button.danger:hover {
 
 @media (max-width: 720px) {
   .browser-toolbar {
-    grid-template-columns: minmax(0, 1fr) auto;
     padding: 0 var(--space-md);
     gap: var(--space-sm);
   }
 
   .address-form__input {
+    display: none;
+  }
+
+  .toolbar-separator {
     display: none;
   }
 
@@ -736,12 +836,24 @@ button.danger:hover {
 
 /* ── Config / Info building blocks (sidebar redesign) ── */
 .info-stack {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: var(--space-xl);
+  min-height: 100%;
 }
 .info-section {
   display: grid;
   gap: var(--space-md);
+}
+.info-section--bottom {
+  margin-top: auto;
+  gap: var(--space-sm);
+}
+
+.config-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
 }
 
 .section-label {
@@ -871,13 +983,6 @@ button.danger:hover {
 .copy-chip:hover {
   border-color: var(--color-gray-400);
   background: var(--color-gray-100);
-}
-
-.divider {
-  height: 1px;
-  background: var(--border-light);
-  border: 0;
-  margin: 0;
 }
 
 .muted-help {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -221,6 +221,15 @@ button.danger:hover {
   width: auto;
 }
 
+/* Compact app-icon variant of the brand, shown instead of the wordmark on
+   narrow screens. */
+.toolbar-brand__icon {
+  display: none;
+  height: 26px;
+  width: 26px;
+  border-radius: 6px;
+}
+
 .address-form__input {
   display: flex;
   align-items: center;
@@ -816,21 +825,21 @@ button.danger:hover {
     gap: var(--space-sm);
   }
 
-  .address-form__input {
+  /* Minimal mobile toolbar: app icon, Home, and the panel toggle. */
+  .toolbar-brand__logo {
     display: none;
   }
 
-  .toolbar-separator {
-    display: none;
+  .toolbar-brand__icon {
+    display: block;
   }
 
-  .browser-toolbar .icon-button--labeled {
-    width: 36px;
-    min-width: 36px;
-    padding: 0;
-  }
-
-  .browser-toolbar .icon-button__label {
+  .address-form__input,
+  .toolbar-separator,
+  .browser-toolbar .icon-button--labeled,
+  .browser-toolbar .toolbar-github,
+  #back-button,
+  #refresh-button {
     display: none;
   }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -795,13 +795,18 @@ button.danger:hover {
     grid-template-columns: 1fr;
   }
 
-  .workspace:not(.is-panel-collapsed) {
-    grid-template-rows: 1fr 1fr;
-  }
-
+  /* On narrow screens the open panel takes over the whole area below the
+     toolbar instead of splitting the screen with the site. */
   .side-panel {
+    position: fixed;
+    top: var(--navbar-height);
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 15;
     border-left: 0;
     border-top: 1px solid var(--border-light);
+    box-shadow: none;
   }
 }
 

--- a/src/styles/blueprint-editor.css
+++ b/src/styles/blueprint-editor.css
@@ -102,20 +102,48 @@
 
 .icon-button--icon-only {
   justify-content: center;
-  width: 30px;
-  height: 30px;
+  width: 28px;
+  height: 28px;
   padding: 0;
 }
 
+/* Quiet, borderless icon actions (design: Shell UI v2) — the higher
+   specificity also neutralises the base `label.import-button` border. */
+.panel__row-actions .icon-button--icon-only {
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+}
+
+.panel__row-actions .icon-button--icon-only:hover {
+  background: var(--color-gray-100);
+  color: var(--text);
+}
+
+.panel__row-actions .icon-button--icon-only:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  background: transparent;
+  color: var(--text-muted);
+}
+
 .icon-button--wide {
-  min-width: 76px;
   justify-content: center;
+  width: auto;
+  min-width: 0;
+  height: auto;
 }
 
 .icon-button--primary {
   color: var(--color-white);
   background: var(--accent);
   border-color: transparent;
+  border-radius: 7px;
+  padding: 5px 14px;
+  font-size: 12.5px;
+  font-weight: 600;
+  gap: 6px;
 }
 
 .icon-button--primary:hover {


### PR DESCRIPTION
## Summary

Implements the **Shell UI v2** design for the playground chrome (toolbar + side panel), from the Claude Design project `Shell UI v2.dc.html`.

### Toolbar
- Three-zone grid: brand logo / centered nav cluster + URL bar / actions, on an orange gradient (`--chrome-bg` → `--chrome-bg2`)
- Grouped **Back / Refresh / Home** nav cluster in a darker rounded pill
- **New Back button** backed by an in-shell navigation history stack (the nested-iframe + service-worker setup makes the browser's own session history unusable for this)
- URL bar as a translucent monospace pill
- Actions: **Docs** link, **GitHub** link (new), separator, panel toggle with an active state while the panel is open

### Side panel
- Header: **Runtime** title + live status pill (Running / Unsaved) + close (✕) button
- Segmented pill tabs: Info / Logs / **PHP** / Blueprint (active tab = white pill with shadow)
- Info: Moodle + PHP selects side by side; Reset section pinned to the panel bottom
- Logs / PHP Info / Blueprint rows now use quiet icon-only actions (copy, clear, refresh, import/export/copy) in a consistent style
- Blueprint: Run button left, icon actions right; valid status reads `✓ Valid blueprint · N steps`
- Footer: light surface, orange ATE link, icon-only GitHub link
- Danger buttons switch to an outline style that fills red on hover

All existing element ids, ARIA attributes and behaviors are preserved (`#address-input`, `#panel-toggle-button` + `aria-expanded`, `#side-panel.is-collapsed`, tab ids, …), so the e2e suite keeps working unchanged.

Note: the design project's `logo.png` export turned out to be an almost fully transparent image, so the existing repo logo (same 297×40 white wordmark) is kept.

## Testing
- `make test` — 773/773 unit tests pass
- `make lint` — clean (3 pre-existing warnings in untouched blueprint step files)
- Verified manually in Chromium: full boot to the Moodle dashboard, back-stack navigation, panel open/close, all four tabs, 1440px/680px/390px viewports

The same redesign is being applied to the sibling playgrounds (omeka-s, nextcloud, facturascripts) in parallel PRs.

## Screenshots

**Toolbar + Info panel (desktop)**

![shot-info-panel.png](https://github.com/user-attachments/assets/edfdeba1-716c-449a-977e-2d475f86cc68)

**Blueprint tab**

![shot-blueprint.png](https://github.com/user-attachments/assets/a581ae08-8157-43ba-8639-f7cf2b83d696)

**Mobile (390px) — minimal toolbar (app icon, Home, narrow URL bar, panel toggle); the open panel takes over the full screen below it**

![shot-mobile-minimal.png](https://github.com/user-attachments/assets/3e4b6d5f-e67b-4924-966b-fecebc45eb84)

![shot-mobile-panel-open.png](https://github.com/user-attachments/assets/5f24cabd-90e0-4252-aa78-b2730acd0805)
