### PR TITLE
fix(build): use MOODLE_502_STABLE instead of v5.2.0 tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ bundle-MOODLE_501_STABLE:
 	BRANCH=MOODLE_501_STABLE npm run bundle
 
 bundle-MOODLE_502_STABLE:
-	BRANCH=MOODLE_502_STABLE GIT_REF=v5.2.0 npm run bundle
+	BRANCH=MOODLE_502_STABLE npm run bundle
 
 bundle-main:
 	BRANCH=main npm run bundle

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "serve": "http-server . -p ${PORT:-8080} -c-1",
     "bundle:default": "sh -c 'BRANCH=\"${BRANCH:-MOODLE_500_STABLE}\" ./scripts/build-moodle-bundle.sh'",
     "prepare:dev:pretty": "concurrently --names worker,bundle --prefix name --prefix-colors cyan,yellow \"npm:build-worker\" \"npm:bundle:default\"",
-    "bundle:all:pretty": "concurrently --names 404,405,500,501,502,main --prefix name --prefix-colors blue,magenta,green,yellow,red,cyan \"sh -c 'BRANCH=MOODLE_404_STABLE ./scripts/build-moodle-bundle.sh'\" \"sh -c 'BRANCH=MOODLE_405_STABLE ./scripts/build-moodle-bundle.sh'\" \"sh -c 'BRANCH=MOODLE_500_STABLE ./scripts/build-moodle-bundle.sh'\" \"sh -c 'BRANCH=MOODLE_501_STABLE ./scripts/build-moodle-bundle.sh'\" \"sh -c 'BRANCH=MOODLE_502_STABLE GIT_REF=v5.2.0 ./scripts/build-moodle-bundle.sh'\" \"sh -c 'BRANCH=main ./scripts/build-moodle-bundle.sh'\"",
+    "bundle:all:pretty": "concurrently --names 404,405,500,501,502,main --prefix name --prefix-colors blue,magenta,green,yellow,red,cyan \"sh -c 'BRANCH=MOODLE_404_STABLE ./scripts/build-moodle-bundle.sh'\" \"sh -c 'BRANCH=MOODLE_405_STABLE ./scripts/build-moodle-bundle.sh'\" \"sh -c 'BRANCH=MOODLE_500_STABLE ./scripts/build-moodle-bundle.sh'\" \"sh -c 'BRANCH=MOODLE_501_STABLE ./scripts/build-moodle-bundle.sh'\" \"sh -c 'BRANCH=MOODLE_502_STABLE ./scripts/build-moodle-bundle.sh'\" \"sh -c 'BRANCH=main ./scripts/build-moodle-bundle.sh'\"",
     "bundle": "./scripts/build-moodle-bundle.sh",
     "test": "node --test tests/**/*.test.js",
     "test:blueprint": "node --test tests/blueprint/*.test.js",

--- a/src/shared/version-resolver.js
+++ b/src/shared/version-resolver.js
@@ -56,7 +56,7 @@ export const MOODLE_BRANCHES = [
     branch: "MOODLE_502_STABLE",
     version: "5.2",
     label: "Moodle 5.2.x",
-    gitRef: "v5.2.0",
+    gitRef: "MOODLE_502_STABLE",
     webRoot: "/www/moodle/public",
     manifestFile: "MOODLE_502_STABLE.json",
     bundleDir: "MOODLE_502_STABLE",

--- a/tests/shared/version-resolver.test.js
+++ b/tests/shared/version-resolver.test.js
@@ -46,6 +46,7 @@ describe("getBranchMetadata", () => {
     assert.ok(meta);
     assert.strictEqual(meta.version, "5.2");
     assert.strictEqual(meta.label, "Moodle 5.2.x");
+    assert.strictEqual(meta.gitRef, "MOODLE_502_STABLE");
     assert.strictEqual(meta.webRoot, "/www/moodle/public");
   });
 });


### PR DESCRIPTION
## Summary

- Moodle 5.2 now has a real `MOODLE_502_STABLE` branch (tip at the same commit as `v5.2.2`), so the temporary pin to the `v5.2.0` tag is no longer needed.
- Align 5.2 with every other stable branch: `gitRef` / `GIT_REF` default to the branch name.
- Drop the special-case overrides in `version-resolver.js`, `Makefile`, and `package.json`.

This undoes the workaround from `9685db1` ("use v5.2.0 tag as git ref since MOODLE_502_STABLE branch doesn't exist yet").

## Test plan

- [x] `node --test tests/shared/version-resolver.test.js` (52 pass)
- [ ] Optional: `make bundle-MOODLE_502_STABLE` clones/builds from `MOODLE_502_STABLE` without `GIT_REF`