### PR TITLE
fix: harden runtime against Sentry-reported crashes

### DIFF
--- a/lib/moodle-loader.js
+++ b/lib/moodle-loader.js
@@ -1,7 +1,23 @@
 import { BUNDLE_CACHE_NAME, DEFAULT_BOOT_OPTIONS } from "./constants.js";
 
+// WebKit and Firefox surface network-level fetch failures as a bare
+// "Load failed" / "NetworkError when attempting to fetch resource", which
+// reaches monitoring with no stack, no URL and no boot phase. Name the asset
+// and the phase so the report is actionable.
+async function fetchBootAsset(url, init, phase) {
+  try {
+    return await fetch(url, init);
+  } catch (error) {
+    const target = String(url).split("?")[0];
+    throw new Error(
+      `Network error while fetching ${phase} (${target}): ${error?.message || error}`,
+      { cause: error },
+    );
+  }
+}
+
 export async function fetchWithProgress(url, onProgress = () => {}) {
-  const response = await fetch(url);
+  const response = await fetchBootAsset(url, undefined, "bundle");
 
   if (!response.ok) {
     throw new Error(`Unable to download Moodle archive: ${response.status} ${response.statusText}`);
@@ -68,12 +84,16 @@ async function fetchJsonWithCache(url, cacheName) {
     return cached.json();
   }
 
-  const response = await fetch(url, {
-    cache: "no-cache",
-    headers: {
-      accept: "application/json",
+  const response = await fetchBootAsset(
+    url,
+    {
+      cache: "no-cache",
+      headers: {
+        accept: "application/json",
+      },
     },
-  });
+    "JSON asset",
+  );
 
   if (!response.ok) {
     throw new Error(`Unable to load JSON asset: ${response.status} ${response.statusText}`);
@@ -144,12 +164,16 @@ function normalizeManifest(manifestUrl, manifest) {
 }
 
 export async function fetchManifest(manifestUrl = DEFAULT_BOOT_OPTIONS.manifestUrl) {
-  const response = await fetch(manifestUrl, {
-    cache: "no-store",
-    headers: {
-      accept: "application/json",
+  const response = await fetchBootAsset(
+    manifestUrl,
+    {
+      cache: "no-store",
+      headers: {
+        accept: "application/json",
+      },
     },
-  });
+    "manifest",
+  );
 
   if (!response.ok) {
     throw new Error(`Unable to load manifest: ${response.status} ${response.statusText}`);
@@ -163,7 +187,7 @@ async function openBundleCache() {
 }
 
 async function fetchPartInto(url, target, baseOffset, onLoaded = () => {}) {
-  const response = await fetch(url);
+  const response = await fetchBootAsset(url, undefined, "bundle part");
 
   if (!response.ok) {
     throw new Error(`Unable to download bundle part: ${response.status} ${response.statusText} (${url})`);
@@ -370,7 +394,7 @@ export async function fetchAssetWithCache(url, { sha256: expectedSha256 } = {}, 
     }
   }
 
-  const response = await fetch(url);
+  const response = await fetchBootAsset(url, undefined, "asset");
   if (!response?.ok) {
     throw new Error(`Unable to download asset: ${response?.status} ${response?.statusText || ""} (${url})`);
   }

--- a/lib/moodle-loader.js
+++ b/lib/moodle-loader.js
@@ -4,7 +4,7 @@ import { BUNDLE_CACHE_NAME, DEFAULT_BOOT_OPTIONS } from "./constants.js";
 // "Load failed" / "NetworkError when attempting to fetch resource", which
 // reaches monitoring with no stack, no URL and no boot phase. Name the asset
 // and the phase so the report is actionable.
-async function fetchBootAsset(url, init, phase) {
+export async function fetchBootAsset(url, init, phase) {
   try {
     return await fetch(url, init);
   } catch (error) {

--- a/scripts/github-proxy-worker.js
+++ b/scripts/github-proxy-worker.js
@@ -225,14 +225,7 @@ async function handleAtomFeed(repo, type) {
     );
 
     if (!upstream.ok) {
-      return jsonResponse(
-        {
-          error: "Upstream server returned an error.",
-          status: upstream.status,
-          statusText: upstream.statusText,
-        },
-        502,
-      );
+      return upstreamErrorResponse(upstream);
     }
 
     const headers = new Headers();
@@ -276,14 +269,7 @@ async function proxyRawFile(repo, ref, rawPath) {
     );
 
     if (!upstream.ok) {
-      return jsonResponse(
-        {
-          error: "Upstream server returned an error.",
-          status: upstream.status,
-          statusText: upstream.statusText,
-        },
-        upstream.status === 404 ? 404 : 502,
-      );
+      return upstreamErrorResponse(upstream);
     }
 
     const headers = new Headers();
@@ -632,15 +618,7 @@ async function proxyGitHubZip(
     );
 
     if (!upstream.ok) {
-      return jsonResponse(
-        {
-          error: "Upstream server returned an error.",
-          status: upstream.status,
-          statusText: upstream.statusText,
-          upstream_url: url,
-        },
-        502,
-      );
+      return upstreamErrorResponse(upstream, { upstream_url: url });
     }
 
     const responseHeaders = new Headers(upstream.headers);
@@ -742,14 +720,7 @@ async function handleGenericProxy(targetUrl, request) {
     );
 
     if (!upstream.ok) {
-      return jsonResponse(
-        {
-          error: "Upstream server returned an error.",
-          status: upstream.status,
-          statusText: upstream.statusText,
-        },
-        502,
-      );
+      return upstreamErrorResponse(upstream);
     }
 
     const headers = new Headers(upstream.headers);
@@ -813,6 +784,25 @@ function jsonResponse(data, status) {
       ...corsHeaders(),
     },
   });
+}
+
+// Maps an upstream failure onto a client-visible status. A 404 (deleted branch,
+// renamed repo, stale blueprint URL), a 403/429 (rate limit) and a 401 are the
+// upstream's own verdict, not a proxy outage, so they are passed through instead
+// of being flattened into 502 — reporting them as "bad gateway" made ordinary
+// "not found" errors look like the proxy itself was down.
+const PASSTHROUGH_UPSTREAM_STATUSES = new Set([401, 403, 404, 410, 429]);
+
+function upstreamErrorResponse(upstream, extra = {}) {
+  return jsonResponse(
+    {
+      error: "Upstream server returned an error.",
+      status: upstream.status,
+      statusText: upstream.statusText,
+      ...extra,
+    },
+    PASSTHROUGH_UPSTREAM_STATUSES.has(upstream.status) ? upstream.status : 502,
+  );
 }
 
 // Maps a blocked redirect into a 400 response. A redirect into an

--- a/src/remote/main.js
+++ b/src/remote/main.js
@@ -2,7 +2,10 @@ import { loadBlueprint } from "../blueprint/index.js";
 import { loadPlaygroundConfig } from "../shared/config.js";
 import { buildScopedSitePath } from "../shared/paths.js";
 import { createShellChannel } from "../shared/protocol.js";
-import { registerVersionedServiceWorker } from "../shared/service-worker-version.js";
+import {
+  isServiceWorkerUnsupportedError,
+  registerVersionedServiceWorker,
+} from "../shared/service-worker-version.js";
 import { saveSessionState } from "../shared/storage.js";
 import {
   resolveRuntimeConfig,
@@ -118,8 +121,31 @@ async function registerRuntimeServiceWorker() {
       scope: "./",
     },
   );
-  await navigator.serviceWorker.ready;
+  await navigator.serviceWorker?.ready;
   return registration;
+}
+
+/**
+ * Show a Service Worker failure in the boot overlay and forward it to the
+ * shell, which owns the monitoring client. A missing API (iOS Safari private
+ * browsing, an insecure origin) is an environment limitation, so it travels as
+ * a warning under its own group instead of as a runtime error.
+ */
+function reportServiceWorkerFailure(scopeId, error) {
+  const unsupported = isServiceWorkerUnsupportedError(error);
+  const detail = unsupported
+    ? error.message
+    : `Service Worker registration failed: ${error?.message || error}`;
+
+  setOverlayVisible(true);
+  emit(scopeId, {
+    kind: "error",
+    detail,
+    level: unsupported ? "warning" : "error",
+    source: unsupported
+      ? "service-worker-unsupported"
+      : "service-worker-registration",
+  });
 }
 
 async function deleteIndexedDbDatabase(name) {
@@ -217,13 +243,13 @@ async function resetRuntimeStorage({
 }
 
 async function waitForServiceWorkerControl() {
-  if (!navigator.serviceWorker.controller) {
+  if (!navigator.serviceWorker?.controller) {
     await new Promise((resolve, reject) => {
       const timeoutId = window.setTimeout(() => {
         reject(new Error("Timed out waiting for service worker control."));
       }, 10000);
 
-      navigator.serviceWorker.addEventListener(
+      navigator.serviceWorker?.addEventListener(
         "controllerchange",
         () => {
           window.clearTimeout(timeoutId);
@@ -236,7 +262,7 @@ async function waitForServiceWorkerControl() {
 }
 
 function configureRuntimeServiceWorker({ addonProxyUrl }) {
-  if (!navigator.serviceWorker.controller) {
+  if (!navigator.serviceWorker?.controller) {
     return;
   }
 
@@ -247,7 +273,7 @@ function configureRuntimeServiceWorker({ addonProxyUrl }) {
 }
 
 function ensureRemoteServiceWorkerControl(scopeId, runtimeId) {
-  if (navigator.serviceWorker.controller) {
+  if (navigator.serviceWorker?.controller) {
     window.sessionStorage.removeItem(
       `${CONTROL_RELOAD_KEY_PREFIX}:${scopeId}:${runtimeId}`,
     );
@@ -566,7 +592,15 @@ async function bootstrapRemote() {
     progress: 0.08,
   });
 
-  await registerRuntimeServiceWorker();
+  try {
+    await registerRuntimeServiceWorker();
+  } catch (error) {
+    // Without a Service Worker nothing downstream can run; surface the reason
+    // instead of failing later with an opaque timeout or a blank frame.
+    reportServiceWorkerFailure(scopeId, error);
+    return;
+  }
+
   if (ensureRemoteServiceWorkerControl(scopeId, selection.runtimeId)) {
     return;
   }

--- a/src/runtime/manifest.js
+++ b/src/runtime/manifest.js
@@ -1,4 +1,7 @@
-import { resolveBootstrapArchive } from "../../lib/moodle-loader.js";
+import {
+  fetchBootAsset,
+  resolveBootstrapArchive,
+} from "../../lib/moodle-loader.js";
 import { buildManifestUrl as buildManifestUrlFromVersions } from "../shared/version-resolver.js";
 
 export async function fetchManifest(manifestUrl) {
@@ -9,7 +12,13 @@ export async function fetchManifest(manifestUrl) {
         : new URL("../../", import.meta.url).href;
     manifestUrl = new URL("assets/manifests/latest.json", base).toString();
   }
-  const response = await fetch(manifestUrl, { cache: "no-store" });
+  // Routed through fetchBootAsset so a network-level rejection names the
+  // phase and the URL instead of reaching monitoring as a bare "Load failed".
+  const response = await fetchBootAsset(
+    manifestUrl,
+    { cache: "no-store" },
+    "manifest",
+  );
 
   if (!response.ok) {
     throw new Error(
@@ -98,7 +107,11 @@ export async function resolveManifestUrl(moodleBranch, appBaseUrl) {
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     let response;
     try {
-      response = await fetch(branchUrl, { method: "HEAD", cache: "no-store" });
+      response = await fetchBootAsset(
+        branchUrl,
+        { method: "HEAD", cache: "no-store" },
+        "manifest probe",
+      );
     } catch (error) {
       // Network error — transient. Retry, then propagate if it never recovers.
       lastError = error;

--- a/src/runtime/php-compat.js
+++ b/src/runtime/php-compat.js
@@ -126,6 +126,11 @@ function getMimeType(path) {
   return MIME_TYPES[ext] || "application/octet-stream";
 }
 
+// The Fetch spec forbids a body on these statuses; PHP legitimately emits 204
+// and 304 (conditional GETs, no-content replies) and constructing a Response
+// with bytes for them throws and blanks the whole page.
+const NULL_BODY_STATUSES = new Set([101, 103, 204, 205, 304]);
+
 /**
  * Convert a PHPResponse to a native Response object.
  *
@@ -139,7 +144,18 @@ function phpResponseToResponse(phpResponse, extraHeaders) {
   if (phpResponse.headers) {
     for (const [key, values] of Object.entries(phpResponse.headers)) {
       for (const value of values) {
-        headers.append(key, value);
+        // Skip headers with an invalid name/value rather than letting a single
+        // malformed header (Headers.append() throws "Invalid name") abort the
+        // entire response — which would blank the whole page.
+        try {
+          headers.append(key, value);
+        } catch (error) {
+          try {
+            console.warn(
+              `[php-compat] skipping invalid response header "${key}": ${error?.message || error}`,
+            );
+          } catch {}
+        }
       }
     }
   }
@@ -151,10 +167,14 @@ function phpResponseToResponse(phpResponse, extraHeaders) {
     }
   }
 
-  return new Response(phpResponse.bytes, {
-    status: phpResponse.httpStatusCode,
-    headers,
-  });
+  const status = phpResponse.httpStatusCode;
+  return new Response(
+    NULL_BODY_STATUSES.has(status) ? null : phpResponse.bytes,
+    {
+      status,
+      headers,
+    },
+  );
 }
 
 /**

--- a/src/shared/service-worker-version.js
+++ b/src/shared/service-worker-version.js
@@ -12,10 +12,51 @@ export function buildVersionedServiceWorkerUrl(
   return url;
 }
 
+/**
+ * True when this browsing context exposes a usable Service Worker API.
+ *
+ * iOS Safari private browsing, insecure (non-HTTPS) origins and browsers with
+ * Service Workers disabled leave `navigator.serviceWorker` undefined, so any
+ * unguarded access throws a TypeError and blanks the page.
+ */
+export function isServiceWorkerSupported() {
+  return (
+    typeof navigator !== "undefined" &&
+    "serviceWorker" in navigator &&
+    typeof navigator.serviceWorker?.register === "function"
+  );
+}
+
+export const SERVICE_WORKER_UNSUPPORTED_ERROR_NAME =
+  "ServiceWorkerUnsupportedError";
+
+export const SERVICE_WORKER_UNSUPPORTED_MESSAGE =
+  "Service Workers are unavailable in this browser context. Private browsing " +
+  "on iOS Safari disables them, and the playground cannot run without one.";
+
+/**
+ * Build the error thrown when the Service Worker API is missing. Callers
+ * distinguish it from a genuine registration rejection by `error.name`, so an
+ * environment limitation is reported as a warning instead of a crash.
+ */
+export function createServiceWorkerUnsupportedError() {
+  const error = new Error(SERVICE_WORKER_UNSUPPORTED_MESSAGE);
+  error.name = SERVICE_WORKER_UNSUPPORTED_ERROR_NAME;
+  return error;
+}
+
+export function isServiceWorkerUnsupportedError(error) {
+  return error?.name === SERVICE_WORKER_UNSUPPORTED_ERROR_NAME;
+}
+
 export async function registerVersionedServiceWorker(
   serviceWorkerUrl,
   { scope = "./", type = "classic", updateViaCache = "none" } = {},
 ) {
+  if (!isServiceWorkerSupported()) {
+    throw createServiceWorkerUnsupportedError();
+  }
+
   const registration = await navigator.serviceWorker.register(
     buildVersionedServiceWorkerUrl(serviceWorkerUrl),
     {

--- a/src/shell/main.js
+++ b/src/shell/main.js
@@ -19,7 +19,10 @@ import {
 } from "../shared/monitoring.js";
 import { blueprintSourceKey, resolveRemoteUrl } from "../shared/paths.js";
 import { createShellChannel, SNAPSHOT_VERSION } from "../shared/protocol.js";
-import { registerVersionedServiceWorker } from "../shared/service-worker-version.js";
+import {
+  isServiceWorkerUnsupportedError,
+  registerVersionedServiceWorker,
+} from "../shared/service-worker-version.js";
 import {
   clearScopeSession,
   getOrCreateScopeId,
@@ -35,6 +38,7 @@ import {
   shouldTraceRuntimeSelection,
 } from "../shared/version-resolver.js";
 import { initBlueprintEditor } from "./blueprint-editor.js";
+import { escapeHtml } from "./blueprint-editor-core.js";
 
 const els = {
   addressForm: document.querySelector("#address-form"),
@@ -183,20 +187,84 @@ function recordBackEntry(previousPath, nextPath) {
   updateBackButton();
 }
 
-async function ensureRuntimeServiceWorker() {
-  if (!config) {
+/**
+ * Replace the site frame with a blocking, human-readable message. The runtime
+ * cannot boot without a Service Worker, so the alternative is a blank iframe
+ * with the failure buried in an uncaught TypeError.
+ */
+function showBlockingBootError(title, detail) {
+  setActivePanel("logs");
+  if (els.sidePanel?.classList.contains("is-collapsed")) {
+    toggleSidePanel();
+  }
+
+  if (!els.frame) {
     return;
   }
 
-  await registerVersionedServiceWorker(
-    new URL("../../sw.bundle.js", import.meta.url),
-    {
-      scope: "./",
-    },
-  );
-  await navigator.serviceWorker.ready;
+  els.frame.removeAttribute("src");
+  els.frame.srcdoc = `<!doctype html><meta charset="utf-8"><style>
+      html,body{height:100%}
+      body{margin:0;display:flex;align-items:center;justify-content:center;padding:24px;box-sizing:border-box;background:#fff;color:#1f2937;font:15px/1.6 ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}
+      div{max-width:44rem}
+      h1{margin:0 0 12px;font-size:1.15rem}
+      p{margin:0}
+    </style><div role="alert"><h1>${escapeHtml(title)}</h1><p>${escapeHtml(detail)}</p></div>`;
+}
 
-  if (!navigator.serviceWorker.controller) {
+/**
+ * Report a Service Worker failure to the user and to monitoring.
+ *
+ * A missing API is an environment limitation (iOS Safari private browsing,
+ * insecure origin), so it is reported as a warning under its own Sentry group;
+ * a rejected registration is a genuine failure and is captured as an exception.
+ */
+function reportServiceWorkerFailure(error) {
+  const unsupported = isServiceWorkerUnsupportedError(error);
+  const detail = unsupported
+    ? error.message
+    : `Service Worker registration failed: ${error?.message || error}`;
+
+  appendLog(detail, true);
+  showBlockingBootError(
+    unsupported
+      ? "Service Workers are unavailable"
+      : "Service Worker registration failed",
+    detail,
+  );
+  setUiLocked(false);
+
+  if (unsupported) {
+    captureMessage(detail, "warning", { source: "service-worker-unsupported" });
+    return;
+  }
+
+  captureException(error, { source: "service-worker-registration" });
+}
+
+/**
+ * Returns true when the runtime Service Worker is registered and usable.
+ * A false return means the failure has already been surfaced to the user.
+ */
+async function ensureRuntimeServiceWorker() {
+  if (!config) {
+    return true;
+  }
+
+  try {
+    await registerVersionedServiceWorker(
+      new URL("../../sw.bundle.js", import.meta.url),
+      {
+        scope: "./",
+      },
+    );
+    await navigator.serviceWorker?.ready;
+  } catch (error) {
+    reportServiceWorkerFailure(error);
+    return false;
+  }
+
+  if (!navigator.serviceWorker?.controller) {
     const alreadyReloaded =
       window.sessionStorage.getItem(CONTROL_RELOAD_KEY) === "1";
     if (!alreadyReloaded) {
@@ -207,6 +275,7 @@ async function ensureRuntimeServiceWorker() {
   }
 
   window.sessionStorage.removeItem(CONTROL_RELOAD_KEY);
+  return true;
 }
 
 async function updateFrame() {
@@ -214,7 +283,12 @@ async function updateFrame() {
     serviceWorkerReady = ensureRuntimeServiceWorker();
   }
 
-  await serviceWorkerReady;
+  if (!(await serviceWorkerReady)) {
+    // The blocking message is already on screen; loading the remote frame
+    // without a Service Worker would only render a blank iframe.
+    return;
+  }
+
   const url = resolveRemoteUrl(scopeId, currentRuntimeId, currentPath, {
     phpVersion: currentPhpVersion,
     moodleBranch: currentMoodleBranch,
@@ -230,6 +304,9 @@ async function updateFrame() {
     url.searchParams.set("reload", String(remoteReloadToken));
   }
   remoteFrameBooted = false;
+  // srcdoc wins over src, so drop any blocking message left by a previous
+  // failed boot before pointing the frame at the runtime again.
+  els.frame.removeAttribute("srcdoc");
   els.frame.src = url.toString();
   pendingCleanBoot = false;
 }
@@ -490,7 +567,12 @@ function bindShellChannel() {
         remoteFrameBooted = false;
         setUiLocked(false);
         appendLog(message.detail, true);
-        captureMessage(message.detail, "error", { source: "runtime" });
+        // The remote frame can classify its own failures (an unsupported
+        // Service Worker is an environment limitation, not a runtime error),
+        // so honor the level and source it sends.
+        captureMessage(message.detail, message.level || "error", {
+          source: message.source || "runtime",
+        });
         if (!latestPhpInfoHtml) {
           setActivePanel("phpinfo");
           capturePhpInfoViaWorker("bootstrap-error");
@@ -516,7 +598,7 @@ function bindShellChannel() {
 }
 
 function bindServiceWorkerMessages() {
-  navigator.serviceWorker.addEventListener("message", (event) => {
+  navigator.serviceWorker?.addEventListener("message", (event) => {
     const message = event.data;
     if (message?.kind === "sw-debug") {
       appendLog(`[sw] ${message.detail}`);

--- a/tests/runtime/manifest.test.js
+++ b/tests/runtime/manifest.test.js
@@ -129,6 +129,36 @@ describe("fetchManifest", () => {
 
     assert.strictEqual(seenInit?.cache, "no-store");
   });
+
+  // Regression: this is the manifest fetch the boot path actually performs.
+  // A WebKit/Firefox network-level rejection used to reach monitoring as a
+  // bare "Load failed" with no URL and no phase.
+  it("names the phase and the query-less URL when the fetch rejects", async () => {
+    await assert.rejects(
+      () =>
+        withFetch(
+          () => {
+            throw new TypeError("Load failed");
+          },
+          () =>
+            fetchManifest(
+              "https://example.com/assets/manifests/latest.json?build=abc123",
+            ),
+        ),
+      (error) => {
+        assert.match(error.message, /Network error while fetching manifest/);
+        assert.match(
+          error.message,
+          /https:\/\/example\.com\/assets\/manifests\/latest\.json/,
+        );
+        // The cache-busting query is stripped so Sentry groups the reports.
+        assert.ok(!error.message.includes("build=abc123"));
+        assert.match(error.message, /Load failed/);
+        assert.ok(error.cause instanceof TypeError);
+        return true;
+      },
+    );
+  });
 });
 
 describe("resolveManifestUrl", () => {
@@ -201,6 +231,35 @@ describe("resolveManifestUrl", () => {
     );
     // Transient errors are retried before propagating.
     assert.ok(headAttempts >= 2, `expected retries, got ${headAttempts}`);
+  });
+
+  it("gives the propagated probe error the phase and URL, keeping the retries", async () => {
+    let headAttempts = 0;
+    await assert.rejects(
+      () =>
+        withFetch(
+          (_url, init) => {
+            if (init.method === "HEAD") {
+              headAttempts++;
+              throw new TypeError("Load failed");
+            }
+            throw new Error("fallback should not be fetched");
+          },
+          () => resolveManifestUrl("main", APP_BASE),
+        ),
+      (error) => {
+        assert.match(
+          error.message,
+          /Network error while fetching manifest probe/,
+        );
+        assert.ok(error.message.includes(MAIN_BRANCH_URL));
+        assert.match(error.message, /Load failed/);
+        assert.ok(error.cause instanceof TypeError);
+        return true;
+      },
+    );
+    // Wrapping the rejection must not disturb the retry budget.
+    assert.strictEqual(headAttempts, 3);
   });
 
   it("retries a transient failure then succeeds on the branch URL", async () => {

--- a/tests/runtime/php-compat.test.js
+++ b/tests/runtime/php-compat.test.js
@@ -6,9 +6,15 @@
  * The critical functions are: resolveScriptPath, isPhpScript, getMimeType.
  * Since these are not exported, we replicate them here to test the logic
  * that the module depends on.
+ *
+ * phpResponseToResponse IS reachable (via the `__testing` export) and is
+ * exercised against the real implementation at the bottom of this file.
  */
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { __testing } from "../../src/runtime/php-compat.js";
+
+const { phpResponseToResponse } = __testing;
 
 // Replicate the pure functions from php-compat.js for testing
 function resolveScriptPath(pathname, webRoot) {
@@ -213,5 +219,78 @@ describe("decodePathInfo", () => {
 
   it("returns empty string for empty input", () => {
     assert.strictEqual(decodePathInfo(""), "");
+  });
+});
+
+describe("phpResponseToResponse", () => {
+  const makePhpResponse = (status, body, headers = {}) => ({
+    httpStatusCode: status,
+    headers,
+    bytes: new TextEncoder().encode(body),
+  });
+
+  // Regression: `new Response(bytes, { status: 204 })` throws
+  // "Response with null body status cannot have body", which aborted the
+  // request and blanked the page.
+  it("drops the body on a 204 while keeping the status", async () => {
+    const response = phpResponseToResponse(
+      makePhpResponse(204, "should not be sent", {
+        "content-type": ["text/html"],
+      }),
+    );
+
+    assert.strictEqual(response.status, 204);
+    assert.strictEqual(response.body, null);
+    assert.strictEqual(await response.text(), "");
+  });
+
+  it("drops the body on a 304 (conditional GET) while keeping the status", async () => {
+    const response = phpResponseToResponse(
+      makePhpResponse(304, "stale body", { etag: ['"abc"'] }),
+    );
+
+    assert.strictEqual(response.status, 304);
+    assert.strictEqual(response.body, null);
+    assert.strictEqual(response.headers.get("etag"), '"abc"');
+  });
+
+  it("keeps the body on a 200", async () => {
+    const response = phpResponseToResponse(
+      makePhpResponse(200, "<html>ok</html>", {
+        "content-type": ["text/html; charset=utf-8"],
+      }),
+    );
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(await response.text(), "<html>ok</html>");
+    assert.strictEqual(
+      response.headers.get("content-type"),
+      "text/html; charset=utf-8",
+    );
+  });
+
+  // Regression: Headers.append() throws "Invalid name" on a malformed header,
+  // which aborted the entire response instead of dropping one header.
+  it("skips an invalid header name instead of aborting the response", async () => {
+    const response = phpResponseToResponse(
+      makePhpResponse(200, "body", {
+        "content-type": ["text/plain"],
+        "x bad header": ["nope"],
+      }),
+    );
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(await response.text(), "body");
+    assert.strictEqual(response.headers.get("content-type"), "text/plain");
+  });
+
+  it("still applies extraHeaders", async () => {
+    const response = phpResponseToResponse(makePhpResponse(200, "body", {}), {
+      "x-playground": "1",
+      "x-empty": "",
+    });
+
+    assert.strictEqual(response.headers.get("x-playground"), "1");
+    assert.strictEqual(response.headers.get("x-empty"), null);
   });
 });

--- a/tests/shared/github-proxy-worker.test.js
+++ b/tests/shared/github-proxy-worker.test.js
@@ -1601,3 +1601,103 @@ describe("github-proxy-worker ?path= raw file mode", () => {
     assert.equal(body.error, "Upstream server returned an error.");
   });
 });
+
+describe("github-proxy-worker upstream status mapping", () => {
+  // Regression: a stale blueprint URL pointing at a deleted branch made the
+  // proxy answer 502 ("Failed to fetch ...: 502" in Sentry) even though GitHub
+  // itself answered 404, so an ordinary "not found" looked like a proxy outage.
+  const zipUrl =
+    "https://github.com/erseco/facturascripts-plugin-AiScan/archive/refs/heads/deleted-branch.zip";
+
+  const proxyZip = async () =>
+    worker.fetch(
+      new Request(`https://proxy.example/?url=${encodeURIComponent(zipUrl)}`),
+      {},
+    );
+
+  it("passes an upstream 404 through instead of flattening it into 502", async () => {
+    global.fetch = async () =>
+      new Response("Not Found", { status: 404, statusText: "Not Found" });
+
+    const response = await proxyZip();
+
+    assert.equal(response.status, 404);
+    const body = await response.json();
+    assert.equal(body.error, "Upstream server returned an error.");
+    assert.equal(body.status, 404);
+    assert.equal(body.statusText, "Not Found");
+  });
+
+  it("keeps upstream_url on the archive route while passing 404 through", async () => {
+    global.fetch = async () =>
+      new Response("Not Found", { status: 404, statusText: "Not Found" });
+
+    const response = await worker.fetch(
+      new Request("https://proxy.example/?repo=owner/repo&branch=gone"),
+      {},
+    );
+
+    assert.equal(response.status, 404);
+    const body = await response.json();
+    assert.equal(body.status, 404);
+    assert.equal(
+      body.upstream_url,
+      "https://github.com/owner/repo/archive/refs/heads/gone.zip",
+    );
+  });
+
+  it("passes an upstream 403 (rate limit) through unchanged", async () => {
+    global.fetch = async () =>
+      new Response("rate limited", { status: 403, statusText: "Forbidden" });
+
+    const response = await proxyZip();
+
+    assert.equal(response.status, 403);
+    const body = await response.json();
+    assert.equal(body.status, 403);
+    assert.equal(body.statusText, "Forbidden");
+  });
+
+  it("passes an upstream 429 through unchanged", async () => {
+    global.fetch = async () =>
+      new Response("slow down", {
+        status: 429,
+        statusText: "Too Many Requests",
+      });
+
+    const response = await proxyZip();
+
+    assert.equal(response.status, 429);
+    assert.equal((await response.json()).status, 429);
+  });
+
+  it("still reports a genuine upstream 500 as 502 while naming the real status", async () => {
+    global.fetch = async () =>
+      new Response("boom", {
+        status: 500,
+        statusText: "Internal Server Error",
+      });
+
+    const response = await proxyZip();
+
+    assert.equal(response.status, 502);
+    const body = await response.json();
+    assert.equal(body.status, 500);
+    assert.equal(body.statusText, "Internal Server Error");
+  });
+
+  it("passes an upstream 404 through on the Atom feed route", async () => {
+    global.fetch = async () =>
+      new Response("Not Found", { status: 404, statusText: "Not Found" });
+
+    const response = await worker.fetch(
+      new Request(
+        "https://proxy.example/?url=https://github.com/owner/repo/releases.atom",
+      ),
+      {},
+    );
+
+    assert.equal(response.status, 404);
+    assert.equal((await response.json()).status, 404);
+  });
+});

--- a/tests/shared/moodle-loader-asset-cache.test.js
+++ b/tests/shared/moodle-loader-asset-cache.test.js
@@ -177,3 +177,55 @@ describe("normalizeManifest snapshot/localcache URL resolution", () => {
     assert.equal(manifest.snapshot, undefined);
   });
 });
+
+// Regression: WebKit reports a network-level fetch rejection as a bare
+// "Load failed" and Firefox as "NetworkError when attempting to fetch
+// resource". Those reached Sentry with no URL and no boot phase, so they were
+// unactionable. The boot fetches now name both.
+describe("boot fetch network errors", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    teardownMocks();
+    globalThis.fetch = originalFetch;
+  });
+
+  it("names the phase and the query-less URL when the manifest fetch rejects", async () => {
+    installMocks();
+    globalThis.fetch = async () => {
+      throw new TypeError("Load failed");
+    };
+
+    await assert.rejects(
+      () =>
+        fetchManifest(
+          "https://example.test/assets/manifests/MOODLE_502_STABLE.json?build=abc123",
+        ),
+      (error) => {
+        assert.match(error.message, /Network error while fetching manifest/);
+        assert.match(
+          error.message,
+          /https:\/\/example\.test\/assets\/manifests\/MOODLE_502_STABLE\.json/,
+        );
+        // The cache-busting query string is stripped so Sentry groups the
+        // reports together instead of one group per build.
+        assert.ok(!error.message.includes("build=abc123"));
+        assert.match(error.message, /Load failed/);
+        assert.ok(error.cause instanceof TypeError);
+        return true;
+      },
+    );
+  });
+
+  it("names the asset phase when an auxiliary boot asset fetch rejects", async () => {
+    installMocks();
+    globalThis.fetch = async () => {
+      throw new TypeError("NetworkError when attempting to fetch resource.");
+    };
+
+    await assert.rejects(
+      () => fetchAssetWithCache("https://example.test/install.sq3"),
+      /Network error while fetching asset \(https:\/\/example\.test\/install\.sq3\): NetworkError/,
+    );
+  });
+});

--- a/tests/shared/service-worker-version.test.js
+++ b/tests/shared/service-worker-version.test.js
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { afterEach, describe, it } from "node:test";
 import { BUILD_VERSION } from "../../src/generated/build-version.js";
-import { buildVersionedServiceWorkerUrl } from "../../src/shared/service-worker-version.js";
+import {
+  buildVersionedServiceWorkerUrl,
+  isServiceWorkerSupported,
+  isServiceWorkerUnsupportedError,
+  registerVersionedServiceWorker,
+  SERVICE_WORKER_UNSUPPORTED_ERROR_NAME,
+} from "../../src/shared/service-worker-version.js";
 
 describe("buildVersionedServiceWorkerUrl", () => {
   it("adds the build version to a relative service worker URL", () => {
@@ -24,5 +30,83 @@ describe("buildVersionedServiceWorkerUrl", () => {
 
     assert.strictEqual(url.searchParams.get("foo"), "1");
     assert.strictEqual(url.searchParams.get("build"), BUILD_VERSION);
+  });
+});
+
+// Regression: iOS Safari private browsing leaves navigator.serviceWorker
+// undefined, so the unguarded register() call died with
+// "TypeError: undefined is not an object" and blanked the whole shell.
+describe("isServiceWorkerSupported", () => {
+  const originalNavigator = globalThis.navigator;
+
+  const setNavigator = (value) => {
+    Object.defineProperty(globalThis, "navigator", {
+      value,
+      configurable: true,
+      writable: true,
+    });
+  };
+
+  afterEach(() => {
+    setNavigator(originalNavigator);
+  });
+
+  it("is true when the API exposes register()", () => {
+    setNavigator({ serviceWorker: { register() {} } });
+    assert.strictEqual(isServiceWorkerSupported(), true);
+  });
+
+  it("is false when navigator has no serviceWorker (iOS private browsing)", () => {
+    setNavigator({});
+    assert.strictEqual(isServiceWorkerSupported(), false);
+  });
+
+  it("is false when serviceWorker exists but register() does not", () => {
+    setNavigator({ serviceWorker: {} });
+    assert.strictEqual(isServiceWorkerSupported(), false);
+  });
+
+  it("is false when navigator is undefined", () => {
+    setNavigator(undefined);
+    assert.strictEqual(isServiceWorkerSupported(), false);
+  });
+});
+
+describe("registerVersionedServiceWorker", () => {
+  const originalNavigator = globalThis.navigator;
+
+  const setNavigator = (value) => {
+    Object.defineProperty(globalThis, "navigator", {
+      value,
+      configurable: true,
+      writable: true,
+    });
+  };
+
+  afterEach(() => {
+    setNavigator(originalNavigator);
+  });
+
+  it("throws a distinguishable error without touching navigator.serviceWorker", async () => {
+    setNavigator({});
+
+    const error = await registerVersionedServiceWorker("./sw.js").then(
+      () => null,
+      (thrown) => thrown,
+    );
+
+    assert.ok(error instanceof Error);
+    assert.strictEqual(error.name, SERVICE_WORKER_UNSUPPORTED_ERROR_NAME);
+    assert.strictEqual(isServiceWorkerUnsupportedError(error), true);
+    assert.match(error.message, /Service Workers are unavailable/);
+    assert.match(error.message, /private browsing on ios safari/i);
+  });
+
+  it("does not classify an ordinary registration rejection as unsupported", () => {
+    assert.strictEqual(
+      isServiceWorkerUnsupportedError(new Error("Rejected")),
+      false,
+    );
+    assert.strictEqual(isServiceWorkerUnsupportedError(undefined), false);
   });
 });


### PR DESCRIPTION
Five production failures reported in Sentry (org `erseco`). Every one of them ended in a blank page or an unactionable report; none of them changes an existing architecture decision, so no new ADR — but see the note on the proxy status codes below, since `AGENTS.md` flags outbound networking as a sensitive area.

## A — Service Worker API missing / registration rejected

**Sentry**
- `TypeError: undefined is not an object (evaluating 'navigator.serviceWorker.register')` — Mobile Safari 26.6 / iOS 18.7, via `src/shell/main.js` `ensureRuntimeServiceWorker` → `src/shared/service-worker-version.js` `registerVersionedServiceWorker`
- `TypeError: undefined is not an object (evaluating 'navigator.serviceWorker.addEventListener')` — same session, `bindServiceWorkerMessages`
- `Error: Rejected` — Chrome 151 / Windows, same registration path

**Root cause** The shell and the remote host touched `navigator.serviceWorker` unconditionally. On iOS Safari private browsing — and in any non-secure or SW-disabled context — the property is `undefined`, so the app died with an uncaught TypeError and a blank page. A *rejected* `register()` produced the same blank page.

**Fix**
- `isServiceWorkerSupported()` in `src/shared/service-worker-version.js`; `registerVersionedServiceWorker` throws a dedicated `ServiceWorkerUnsupportedError` (stable, human-readable message) without touching `navigator.serviceWorker`.
- `src/shell/main.js` catches it and renders a blocking message in place of the site frame, opens the Logs panel, logs the detail and unlocks the UI. `src/remote/main.js` catches it, keeps the boot overlay up and forwards a classified error to the shell.
- Monitoring: unsupported browser → `captureMessage(detail, "warning", { source: "service-worker-unsupported" })` (an environment limitation, so it groups separately and not at error level); a genuine rejection → `captureException(error, { source: "service-worker-registration" })`.
- Every remaining `navigator.serviceWorker.*` access on the boot path in both files is now optional-chained, so nothing else throws before the message renders.

**Tests** `tests/shared/service-worker-version.test.js` — the helper across four navigator shapes, the unsupported-throw path (name, message, no property access), and that an ordinary rejection is *not* classified as unsupported.

## B — `TypeError: Response with null body status cannot have body`

**Sentry** Fired in production on the nextcloud sibling; the identical code path was latent here.

**Root cause** `phpResponseToResponse()` built `new Response(phpResponse.bytes, { status })` unconditionally. The Fetch spec forbids a body on null-body statuses, and PHP legitimately emits 204/304 (conditional GETs, no-content replies), so the constructor threw and blanked the page.

**Fix** `NULL_BODY_STATUSES = new Set([101, 103, 204, 205, 304])` in `src/runtime/php-compat.js`; the body is passed as `null` for those statuses. `extraHeaders` behavior is unchanged.

**Tests** `tests/runtime/php-compat.test.js` — a 204 and a 304 with non-empty `bytes` yield a valid Response with the right status and no body, a 200 still carries its body, and `extraHeaders` still applies.

## C — An invalid response header aborted the whole response

**Root cause** `headers.append(key, value)` throws `Invalid name` on a malformed header emitted by PHP, which aborted the entire response — a blank page for one bad header. `nextcloud-playground` already had this guard; this repo did not.

**Fix** The append is wrapped exactly as in the sibling: an invalid header is skipped with a `console.warn`, the rest of the response survives.

**Tests** `tests/runtime/php-compat.test.js` — a malformed header name is skipped and the status, body and remaining headers survive.

## D — Proxy worker reported an upstream 404 as 502

**Sentry** `Error: Failed to fetch https://zip-proxy.erseco.workers.dev/?url=...facturascripts-plugin-AiScan/archive/refs/heads/fix/gemini-3-and-latest-model-params.zip: 502`

**Root cause** Reproduced by hand: the worker answered **502** with body `{"error":"Upstream server returned an error.","status":404,...}` while GitHub itself answered **404** (that branch was deleted); a control URL (`main.zip`) returned 200. The proxy was healthy — it just masked "not found" as "bad gateway", making a stale blueprint URL look like an outage.

**Fix** `scripts/github-proxy-worker.js` (the canonical copy, mirrored into the three siblings) gains `PASSTHROUGH_UPSTREAM_STATUSES = new Set([401, 403, 404, 410, 429])` and an `upstreamErrorResponse()` helper placed immediately after `jsonResponse()`. All four `if (!upstream.ok)` blocks now call it; the ZIP one keeps its `upstream_url` extra, and the raw-file block's ad-hoc `404 ? 404 : 502` special case is subsumed. Nothing else in the file was renamed or reformatted, so the body stays mirror-identical. **This is a client-visible status-code change on the outbound-networking path:** a 404/403/429 from upstream now reaches the caller as itself rather than as 502.

**Tests** `tests/shared/github-proxy-worker.test.js` — upstream 404 → 404 (generic `?url=` ZIP route, the exact Sentry path), 403 → 403, 429 → 429, 500 → 502, `upstream_url` preserved on the archive route, 404 passthrough on the Atom route, and the JSON body still reporting the real upstream status in each case.

## E — Boot fetch failures reached Sentry with no context

**Sentry** `Load failed` (Safari 26.5.2 macOS + Chrome Mobile iOS 152, 2 users, both WebKit, branches `MOODLE_502_STABLE` and `main`) and `NetworkError when attempting to fetch resource.` (Firefox 153, dev). Both are the browser's generic message for a `fetch()` that rejects at the network layer; they arrived as bare strings with no stack, no URL and no boot phase.

**Root cause** `lib/moodle-loader.js` throws good messages for HTTP-status failures, but a network-level rejection propagated the raw `TypeError` unchanged. The same was true of `src/runtime/manifest.js`, which is the module that performs the manifest fetch the PHP worker actually runs at boot (`lib/moodle-loader.js`'s own `fetchManifest` is the fallback path).

**Fix** A `fetchBootAsset(url, init, phase)` wrapper rethrows with the phase and the query-less URL (cache-busting params stripped so Sentry grouping does not fragment), preserving the original as `cause`. It is exported from `lib/moodle-loader.js`, and every boot fetch in both files routes through it:

- `lib/moodle-loader.js` — `"manifest"`, `"bundle"`, `"bundle part"`, `"asset"`, `"JSON asset"`
- `src/runtime/manifest.js` — the manifest GET as `"manifest"`, and the branch HEAD probe in `resolveManifestUrl()` as `"manifest probe"`

The HEAD probe swap is behavior-preserving by construction: `fetchBootAsset` only wraps *rejections* and returns non-OK responses untouched, so the 3-attempt retry budget, the definitive-404 fallback branch and the non-OK propagation all keep working exactly as before — only the error finally propagated as `lastError` gains the phase, the URL and the original rejection as `cause`.

**Tests** `tests/shared/moodle-loader-asset-cache.test.js` — a rejecting `fetch` through `fetchManifest` yields a message naming the phase and the query-less URL (and not the `build=` param), with the original `TypeError` as `cause`; same for the auxiliary-asset path. `tests/runtime/manifest.test.js` — the same assertions for the runtime `fetchManifest`, plus a probe test asserting the propagated error carries the phase and URL **and** that the retry count is still exactly 3. The pre-existing "does NOT fall back on a transient network error" and "retries a transient failure then succeeds" tests still pass unchanged.

## Verification

```
make test   → 837 tests, 176 suites, 0 fail
make lint   → 0 errors (3 warnings + 2 infos, all pre-existing: biome.json schema/deprecation notices and useOptionalChain in src/blueprint/steps/moodle-{cohorts,roles,scales}.js)
node --check → clean on sw.js, php-worker.js, lib/moodle-loader.js, src/runtime/{php-loader,php-compat,bootstrap,crash-recovery,manifest}.js, src/shell/main.js, src/remote/main.js, src/blueprint/index.js, src/shared/service-worker-version.js, scripts/github-proxy-worker.js
npm run build-worker → sw.bundle.js + dist/php-worker.bundle.js build clean
```

## Not included

`src/shared/config.js:13` also fetches `playground.config.json` with a bare `fetch()` on the boot path. It is left alone here: it is a shell/remote-side module, and importing `lib/moodle-loader.js` into it to reach `fetchBootAsset` would pull the bundle loader into the shell's dependency graph. Worth a small shared helper later if that failure ever shows up in Sentry.

**The Cloudflare worker is not deployed.** `scripts/github-proxy-worker.js` is the canonical source in this repo, but the running `zip-proxy` / `github-proxy` workers still serve the old code — an upstream 404 keeps arriving as 502 until the worker is deployed separately, with your approval. Mirroring the same change into the three sibling repos is likewise out of scope here.
